### PR TITLE
use more mock data in model tests

### DIFF
--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -98,8 +98,8 @@ def test_trainable_model_interface_set_optimize() -> None:
 
 def _mock_data() -> Tuple[tf.Tensor, tf.Tensor]:
     return (
-        tf.constant([[1.2]], gpflow.default_float()),
-        tf.constant([[3.4]], gpflow.default_float()),
+        tf.constant([[1.2], [2.3]], gpflow.default_float()),
+        tf.constant([[3.4], [4.5]], gpflow.default_float()),
     )
 
 

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -98,8 +98,8 @@ def test_trainable_model_interface_set_optimize() -> None:
 
 def _mock_data() -> Tuple[tf.Tensor, tf.Tensor]:
     return (
-        tf.constant([[1.2], [2.3]], gpflow.default_float()),
-        tf.constant([[3.4], [4.5]], gpflow.default_float()),
+        tf.constant([[1.1], [2.2], [3.3], [4.4]], gpflow.default_float()),
+        tf.constant([[1.2], [3.4], [5.6], [7.8]], gpflow.default_float()),
     )
 
 


### PR DESCRIPTION
not having enough data meant there were no inducing points for `SGPR`, which lead my GPU to crash on tests. This fixes that