### PR TITLE
use result type in optimizer

### DIFF
--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -77,13 +77,13 @@ model = build_model(initial_data[OBJECTIVE])
 #
 # We'll run the optimizer for fifteen steps.
 #
-# The optimization loop catches errors so as not to lose progress, which means the optimization loop might not complete and the data from the last step may not exist. Here we'll handle this crudely by asking for the data regardless, using `.try_get_final_data()`, which will re-raise the error if one did occur. For a review of how to handle errors systematically, there is a [dedicated tutorial](recovering_from_errors.ipynb). Finally, like the observer, the optimizer outputs labelled datasets, so we'll get the (only) dataset here by indexing with tag `OBJECTIVE`.
+# The optimization loop catches errors so as not to lose progress, which means the optimization loop might not complete and the data from the last step may not exist. Here we'll handle this crudely by asking for the data regardless, using `.try_get_final_datasets()`, which will re-raise the error if one did occur. For a review of how to handle errors systematically, there is a [dedicated tutorial](recovering_from_errors.ipynb). Finally, like the observer, the optimizer outputs labelled datasets, so we'll get the (only) dataset here by indexing with tag `OBJECTIVE`.
 
 # %%
 bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
 
 result = bo.optimize(15, initial_data, model)
-dataset = result.try_get_final_data()[OBJECTIVE]
+dataset = result.try_get_final_datasets()[OBJECTIVE]
 
 # %% [markdown]
 # ## Explore the results
@@ -184,8 +184,8 @@ plt.plot(ls[:, 1])
 # If we need more iterations for better convergence, we can run the optimizer again using the data produced from the last run, as well as the model. We'll visualise the final data.
 
 # %%
-result = bo.optimize(5, result.try_get_final_data(), result.try_get_final_models())
-dataset = result.try_get_final_data()[OBJECTIVE]
+result = bo.optimize(5, result.try_get_final_datasets(), result.try_get_final_models())
+dataset = result.try_get_final_datasets()[OBJECTIVE]
 
 arg_min_idx = tf.squeeze(tf.argmin(dataset.observations, axis=0))
 fig, ax = plot_function_2d(branin, mins, maxs, grid_density=40, contour=True)

--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -128,7 +128,7 @@ bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
 
 data = bo.optimize(
     num_steps, initial_data, models, rule, track_state=False
-).try_get_final_data()
+).try_get_final_datasets()
 
 # %% [markdown]
 # To conclude, we visualise the resulting data. Orange dots show the new points queried during optimization. Notice the concentration of these points in regions near the local minima.

--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -126,15 +126,15 @@ rule = trieste.acquisition.rule.EfficientGlobalOptimization(eci)
 num_steps = 20
 bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
 
-result = bo.optimize(num_steps, initial_data, models, acquisition_rule=rule)
-
-if result.error is not None: raise result.error
+data = bo.optimize(
+    num_steps, initial_data, models, rule, track_state=False
+).try_get_final_data()
 
 # %% [markdown]
 # To conclude, we visualise the resulting data. Orange dots show the new points queried during optimization. Notice the concentration of these points in regions near the local minima.
 
 # %%
-constraint_data = result.datasets[CONSTRAINT]
+constraint_data = data[CONSTRAINT]
 new_query_points = constraint_data.query_points[-num_steps:]
 new_observations = constraint_data.observations[-num_steps:]
 new_data = (new_query_points, new_observations)

--- a/docs/notebooks/recovering_from_errors.pct.py
+++ b/docs/notebooks/recovering_from_errors.pct.py
@@ -67,7 +67,7 @@ acquisition_rule = trieste.acquisition.rule.TrustRegion()
 #
 # In this tutorial we'll try to complete fifteen optimization loops, which, with the broken observer, may take more than one attempt. The optimizer returns an `OptimizationResult`, which is simply a container for both:
 #
-#   * the final result, which uses a `Result` type (not to be confused with `OptimizationResult`), to safely encapsulates the final data, models and acquisition state if the process completed successfully, or an error if one occurred
+#   * the final result, which uses a `Result` type (not to be confused with `OptimizationResult`) to safely encapsulate the final data, models and acquisition state if the process completed successfully, or an error if one occurred
 #   * the history of the successful optimization steps.
 #
 # We can access these with the `astuple` method.

--- a/docs/notebooks/recovering_from_errors.pct.py
+++ b/docs/notebooks/recovering_from_errors.pct.py
@@ -1,0 +1,133 @@
+# %% [markdown]
+# # Recovering from errors during optimization
+
+# %%
+import numpy as np
+import tensorflow as tf
+import random
+
+np.random.seed(1793)
+tf.random.set_seed(1793)
+random.seed(3)
+
+# %% [markdown]
+# Sometimes the Bayesian optimization process encounters an error from which we can recover, without the need to restart the run from the beginning. In this tutorial, we'll simulate such an error and show how to recover from it.
+#
+# We'll use a similar setup to the [EI notebook](expected_improvement.ipynb), but use an observer that intermittently breaks when evaluated, and needs manual attention to get running again. We can simulate fixing the observer with its `manual_fix` method.
+
+# %%
+import trieste
+from trieste.acquisition.rule import OBJECTIVE
+from trieste.utils.objectives import branin
+
+
+class FaultyBranin:
+    def __init__(self):
+        self._is_broken = False
+
+    def manual_fix(self):
+        self._is_broken = False
+
+    def __call__(self, x):
+        if random.random() < 0.05:
+            self._is_broken = True
+
+        if self._is_broken:
+            raise Exception("Observer is broken")
+
+        return {OBJECTIVE: trieste.data.Dataset(x, branin(x))}
+
+
+observer = FaultyBranin()
+
+# %% [markdown]
+# ## Set up the problem
+# We'll use the same set up as before, except for the acquisition rule, where we'll use `TrustRegion`, which (with non-trivial state) will better illustrate how to recover.
+
+# %%
+import gpflow
+
+search_space = trieste.space.Box(
+    tf.cast([0.0, 0.0], tf.float64), tf.cast([1.0, 1.0], tf.float64)
+)
+initial_data = observer(search_space.sample(5))
+
+variance = tf.math.reduce_variance(initial_data[OBJECTIVE].observations)
+kernel = gpflow.kernels.Matern52(variance, [0.2, 0.2]) + gpflow.kernels.White(1e-12)
+gpr = gpflow.models.GPR(
+    initial_data[OBJECTIVE].astuple(), kernel, noise_variance=1e-5
+)
+gpflow.set_trainable(gpr.likelihood, False)
+models = {OBJECTIVE: trieste.models.GaussianProcessRegression(gpr)}
+
+acquisition_rule = trieste.acquisition.rule.TrustRegion()
+
+# %% [markdown]
+# ## Run the optimization loop
+#
+# In this tutorial we'll try to complete fifteen optimization loops, which, with the broken observer, may take more than one attempt. The optimizer returns an `OptimizationResult`, which is simply a container for both:
+#
+#   * the final result, which uses a `Result` type (not to be confused with `OptimizationResult`), to safely encapsulates the final data, models and acquisition state if the process completed successfully, or an error if one occurred
+#   * the history of the successful optimization steps.
+#
+# We can access these with the `astuple` method.
+
+# %%
+bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
+
+result, history = bo.optimize(15, initial_data, models, acquisition_rule).astuple()
+
+# %% [markdown]
+# We can see from the logs that the optimization loop failed, and this can be sufficient to know what to do next if we're working in a notebook. However, sometimes our setup means we don't have access to the logs. We'll pretend from here that's the case.
+
+# %% [markdown]
+# ## Handling success
+#
+# We don't know if the optimization completed successfully or not, so we'll only try to access and plot the data if it was successful. We can find out if this was the case with `result`'s `is_ok` attribute. If it was successful, we know there is data in the `result`, which we can `unwrap` and view.
+
+# %%
+if result.is_ok:
+    data = result.unwrap().datasets[OBJECTIVE]
+    print("best observation: ", tf.reduce_min(data.observations))
+
+# %% [markdown]
+# ## Handling failure
+#
+# If on the other hand, the optimization didn't complete successfully, we can fix our observer, and try again. We can try again by using the data, model and acquisition state from the last successful step, which is the last element of the `history`.
+#
+# Note we can view any `Result` by printing it. We'll do that here to see what exception was caught.
+
+# %%
+if result.is_err:
+    print("result: ", result)
+
+    observer.manual_fix()
+
+    result, new_history = bo.optimize(
+        15 - len(history),
+        history[-1].datasets,
+        history[-1].models,
+        acquisition_rule,
+        history[-1].acquisition_state
+    ).astuple()
+
+    history.extend(new_history)
+
+# %% [markdown]
+# We can repeat this until we've spent our optimization budget, using a loop if appropriate. But here, we'll just plot the data if it exists, safely by using `result`'s `is_ok` attribute.
+
+# %%
+from util.plotting import plot_bo_points, plot_function_2d
+
+if result.is_ok:
+    data = result.unwrap().datasets[OBJECTIVE]
+    arg_min_idx = tf.squeeze(tf.argmin(data.observations, axis=0))
+    _, ax = plot_function_2d(
+        branin, search_space.lower, search_space.upper, 30, contour=True
+    )
+    plot_bo_points(data.query_points.numpy(), ax[0, 0], 5, arg_min_idx)
+
+# %% [markdown]
+# ## LICENSE
+#
+# [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -68,7 +68,7 @@ acq_rule = trieste.acquisition.rule.ThompsonSampling(
 bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
 
 result = bo.optimize(5, initial_data, model_config, acq_rule, track_state=False)
-dataset = result.try_get_final_data()[OBJECTIVE]
+dataset = result.try_get_final_datasets()[OBJECTIVE]
 
 # %% [markdown]
 # ## Visualising the result

--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -66,12 +66,9 @@ acq_rule = trieste.acquisition.rule.ThompsonSampling(
 
 # %%
 bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
-result = bo.optimize(5, initial_data, model_config, acq_rule)
 
-if result.error is not None:
-    raise result.error
-
-dataset = result.datasets[OBJECTIVE]
+result = bo.optimize(5, initial_data, model_config, acq_rule, track_state=False)
+dataset = result.try_get_final_data()[OBJECTIVE]
 
 # %% [markdown]
 # ## Visualising the result
@@ -96,7 +93,12 @@ plot_bo_points(query_points, ax[0, 0], num_initial_data_points, arg_min_idx)
 # %%
 from util.plotting_plotly import plot_gp_plotly, add_bo_points_plotly
 
-fig = plot_gp_plotly(gpr, lower_bound.numpy(), upper_bound.numpy(), grid_density=30)
+fig = plot_gp_plotly(
+    result.try_get_final_models()[OBJECTIVE].model,
+    lower_bound.numpy(),
+    upper_bound.numpy(),
+    grid_density=30
+)
 fig = add_bo_points_plotly(
     x=query_points[:, 0],
     y=query_points[:, 1],

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -36,6 +36,7 @@ The following tutorials (or sections thereof) explain how to use and extend spec
 * :doc:`How do I set up a basic Bayesian optimization routine?<notebooks/expected_improvement>`
 * :ref:`How do I make a custom acquisition function?<notebooks/failure_ego:Create a custom acquisition function>`
 * :ref:`How do I customize the model optimization routine?<notebooks/failure_ego:Create a custom optimize method>`
+* :doc:`How do I recover a failed optimization loop?<notebooks/recovering_from_errors>`
 
 Run the tutorials interactively
 -------------------------------

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -64,14 +64,11 @@ def test_optimizer_finds_minima_of_the_branin_function(
     initial_data = observer(initial_query_points)
     model = build_model(initial_data[OBJECTIVE])
 
-    res = BayesianOptimizer(observer, search_space).optimize(
-        num_steps, initial_data, {OBJECTIVE: model}, acquisition_rule
+    dataset = (
+        BayesianOptimizer(observer, search_space)
+        .optimize(num_steps, initial_data, {OBJECTIVE: model}, acquisition_rule)
+        .try_get_final_data()[OBJECTIVE]
     )
-
-    if res.error is not None:
-        raise res.error
-
-    dataset = res.datasets[OBJECTIVE]
 
     arg_min_idx = tf.squeeze(tf.argmin(dataset.observations, axis=0))
 

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -67,7 +67,7 @@ def test_optimizer_finds_minima_of_the_branin_function(
     dataset = (
         BayesianOptimizer(observer, search_space)
         .optimize(num_steps, initial_data, {OBJECTIVE: model}, acquisition_rule)
-        .try_get_final_data()[OBJECTIVE]
+        .try_get_final_datasets()[OBJECTIVE]
     )
 
     arg_min_idx = tf.squeeze(tf.argmin(dataset.observations, axis=0))

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -11,25 +11,75 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, Tuple
+from typing import Dict, List, Mapping, NoReturn, Optional, Tuple
 
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
 
-from tests.util.misc import FixedAcquisitionRule, one_dimensional_range, zero_dataset
+from tests.util.misc import (
+    FixedAcquisitionRule,
+    assert_datasets_allclose,
+    one_dimensional_range,
+    quadratic,
+    zero_dataset,
+)
 from tests.util.model import GaussianMarginal, PseudoTrainableProbModel, QuadraticWithUnitVariance
 from trieste.acquisition.rule import OBJECTIVE, AcquisitionRule
-from trieste.bayesian_optimizer import BayesianOptimizer, OptimizationResult
+from trieste.bayesian_optimizer import BayesianOptimizer, OptimizationResult, Record
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel, TrainableProbabilisticModel
-from trieste.space import Box
+from trieste.observer import Observer
+from trieste.space import Box, SearchSpace
 from trieste.type import TensorType
+from trieste.utils import Err, Ok
 
 
 class _PseudoTrainableQuadratic(QuadraticWithUnitVariance, PseudoTrainableProbModel):
     pass
+
+
+class _Whoops(Exception):
+    pass
+
+
+def test_optimization_result_astuple() -> None:
+    opt_result: OptimizationResult[None] = OptimizationResult(
+        Err(_Whoops()), [Record({}, {}, None)]
+    )
+    final_result, history = opt_result.astuple()
+    assert final_result is opt_result.final_result
+    assert history is opt_result.history
+
+
+def test_optimization_result_try_get_final_data_for_successful_optimization() -> None:
+    data = {"foo": zero_dataset()}
+    result: OptimizationResult[None] = OptimizationResult(
+        Ok(Record(data, {"foo": _PseudoTrainableQuadratic()}, None)), []
+    )
+    assert result.try_get_final_data() is data
+
+
+def test_optimization_result_try_get_final_data_for_failed_optimization() -> None:
+    result: OptimizationResult[object] = OptimizationResult(Err(_Whoops()), [])
+    with pytest.raises(_Whoops):
+        result.try_get_final_data()
+
+
+def test_optimization_result_try_get_final_models_for_successful_optimization() -> None:
+    models = {"foo": _PseudoTrainableQuadratic()}
+    result: OptimizationResult[None] = OptimizationResult(
+        Ok(Record({"foo": zero_dataset()}, models, None)), []
+    )
+    assert result.try_get_final_models() is models
+
+
+def test_optimization_result_try_get_final_models_for_failed_optimization() -> None:
+    result: OptimizationResult[object] = OptimizationResult(Err(_Whoops()), [])
+    with pytest.raises(_Whoops):
+        result.try_get_final_models()
 
 
 @pytest.mark.parametrize("steps", [0, 1, 2, 5])
@@ -45,18 +95,15 @@ def test_bayesian_optimizer_calls_observer_once_per_iteration(steps: int) -> Non
     optimizer = BayesianOptimizer(observer, one_dimensional_range(-1, 1))
     data = Dataset(tf.constant([[0.5]]), tf.constant([[0.25]]))
 
-    res: OptimizationResult[None] = optimizer.optimize(
+    optimizer.optimize(
         steps, {OBJECTIVE: data}, {OBJECTIVE: _PseudoTrainableQuadratic()}
-    )
-
-    if res.error is not None:
-        raise res.error
+    ).final_result.unwrap()
 
     assert observer.call_count == steps
 
 
 @pytest.mark.parametrize(
-    "datasets, model_specs",
+    "datasets, models",
     [
         ({}, {}),
         ({"foo": zero_dataset()}, {}),
@@ -67,15 +114,14 @@ def test_bayesian_optimizer_calls_observer_once_per_iteration(steps: int) -> Non
         ),
     ],
 )
-def test_bayesian_optimizer_optimize_raises_for_invalid_rule_keys(
-    datasets: Dict[str, Dataset], model_specs: Dict[str, TrainableProbabilisticModel]
+def test_bayesian_optimizer_optimize_raises_for_invalid_keys(
+    datasets: Dict[str, Dataset], models: Dict[str, TrainableProbabilisticModel]
 ) -> None:
-    optimizer = BayesianOptimizer(
-        lambda x: {"foo": Dataset(x, x[:1])}, one_dimensional_range(-1, 1)
-    )
+    search_space = one_dimensional_range(-1, 1)
+    optimizer = BayesianOptimizer(lambda x: {"foo": Dataset(x, x[:1])}, search_space)
     rule = FixedAcquisitionRule(tf.constant([[0.0]]))
     with pytest.raises(ValueError):
-        optimizer.optimize(10, datasets, model_specs, rule)
+        optimizer.optimize(10, datasets, models, rule)
 
 
 def test_bayesian_optimizer_optimize_raises_for_invalid_rule_keys_and_default_acquisition() -> None:
@@ -84,9 +130,14 @@ def test_bayesian_optimizer_optimize_raises_for_invalid_rule_keys_and_default_ac
         optimizer.optimize(3, {"foo": zero_dataset()}, {"foo": _PseudoTrainableQuadratic()})
 
 
-@pytest.mark.parametrize("starting_state, expected_states", [(None, [None, 1, 2]), (3, [3, 4, 5])])
+@pytest.mark.parametrize(
+    "starting_state, expected_states_received, final_acquisition_state",
+    [(None, [None, 1, 2], 3), (3, [3, 4, 5], 6)],
+)
 def test_bayesian_optimizer_uses_specified_acquisition_state(
-    starting_state: Optional[int], expected_states: List[Optional[int]]
+    starting_state: Optional[int],
+    expected_states_received: List[Optional[int]],
+    final_acquisition_state: Optional[int],
 ) -> None:
     class Rule(AcquisitionRule[int, Box]):
         def __init__(self):
@@ -108,29 +159,128 @@ def test_bayesian_optimizer_uses_specified_acquisition_state(
 
     rule = Rule()
 
-    res = BayesianOptimizer(
-        lambda x: {"": Dataset(x, x ** 2)}, one_dimensional_range(-1, 1)
-    ).optimize(3, {"": zero_dataset()}, {"": _PseudoTrainableQuadratic()}, rule, starting_state)
-
-    if res.error is not None:
-        raise res.error
-
-    assert rule.states_received == expected_states
-    assert [state.acquisition_state for state in res.history] == expected_states
-
-
-def test_bayesian_optimizer_optimize_returns_default_acquisition_state_of_correct_type() -> None:
-    optimizer = BayesianOptimizer(
-        lambda x: {OBJECTIVE: Dataset(x, x[:1])}, one_dimensional_range(-1, 1)
-    )
-    res: OptimizationResult[None] = optimizer.optimize(
-        3, {OBJECTIVE: zero_dataset()}, {OBJECTIVE: _PseudoTrainableQuadratic()}
+    final_state, history = (
+        BayesianOptimizer(lambda x: {"": Dataset(x, x ** 2)}, one_dimensional_range(-1, 1))
+        .optimize(3, {"": zero_dataset()}, {"": _PseudoTrainableQuadratic()}, rule, starting_state)
+        .astuple()
     )
 
-    if res.error is not None:
-        raise res.error
+    assert rule.states_received == expected_states_received
+    assert final_state.unwrap().acquisition_state == final_acquisition_state
+    assert [record.acquisition_state for record in history] == expected_states_received
 
-    assert all(logging_state.acquisition_state is None for logging_state in res.history)
+
+def test_bayesian_optimizer_optimize_for_uncopyable_model() -> None:
+    class _UncopyableModel(_PseudoTrainableQuadratic):
+        _optimize_count = 0
+
+        def optimize(self, dataset: Dataset) -> None:
+            self._optimize_count += 1
+
+        def __deepcopy__(self, memo: Dict[int, object]) -> _UncopyableModel:
+            if self._optimize_count >= 3:
+                raise _Whoops
+
+            return self
+
+    rule = FixedAcquisitionRule(tf.constant([[0.0]]))
+    result, history = (
+        BayesianOptimizer(quadratic, one_dimensional_range(0, 1))
+        .optimize(10, {"": zero_dataset()}, {"": _UncopyableModel()}, rule)
+        .astuple()
+    )
+
+    with pytest.raises(_Whoops):
+        result.unwrap()
+
+    assert len(history) == 4
+
+
+def _broken_observer(x: tf.Tensor) -> NoReturn:
+    raise _Whoops
+
+
+class _BrokenModel(_PseudoTrainableQuadratic):
+    def optimize(self, dataset: Dataset) -> NoReturn:
+        raise _Whoops
+
+
+class _BrokenRule(AcquisitionRule[None, SearchSpace]):
+    def acquire(
+        self,
+        search_space: SearchSpace,
+        datasets: Mapping[str, Dataset],
+        models: Mapping[str, ProbabilisticModel],
+        state: None,
+    ) -> NoReturn:
+        raise _Whoops
+
+
+@pytest.mark.parametrize(
+    "observer, model, rule",
+    [
+        (_broken_observer, _PseudoTrainableQuadratic(), FixedAcquisitionRule(tf.constant([[0.0]]))),
+        (quadratic, _BrokenModel(), FixedAcquisitionRule(tf.constant([[0.0]]))),
+        (quadratic, _PseudoTrainableQuadratic(), _BrokenRule()),
+    ],
+)
+def test_bayesian_optimizer_optimize_for_failed_step(
+    observer: Observer, model: TrainableProbabilisticModel, rule: AcquisitionRule
+) -> None:
+    optimizer = BayesianOptimizer(observer, one_dimensional_range(0, 1))
+    result, history = optimizer.optimize(3, {"": zero_dataset()}, {"": model}, rule).astuple()
+
+    with pytest.raises(_Whoops):
+        result.unwrap()
+
+    assert len(history) == 1
+
+
+@pytest.mark.parametrize("num_steps", [-3, -1])
+def test_bayesian_optimizer_optimize_raises_for_negative_steps(num_steps: int) -> None:
+    optimizer = BayesianOptimizer(quadratic, one_dimensional_range(-1, 1))
+
+    with pytest.raises(ValueError, match="num_steps"):
+        optimizer.optimize(num_steps, {"": zero_dataset()}, {"": _PseudoTrainableQuadratic()})
+
+
+def test_bayesian_optimizer_optimize_is_noop_for_zero_steps() -> None:
+    class _UnusableModel(TrainableProbabilisticModel):
+        def predict(self, query_points: TensorType) -> NoReturn:
+            assert False
+
+        def sample(self, query_points: TensorType, num_samples: int) -> NoReturn:
+            assert False
+
+        def update(self, dataset: Dataset) -> NoReturn:
+            assert False
+
+        def optimize(self, dataset: Dataset) -> NoReturn:
+            assert False
+
+    class _UnusableRule(AcquisitionRule[None, Box]):
+        def acquire(
+            self,
+            search_space: Box,
+            datasets: Mapping[str, Dataset],
+            models: Mapping[str, ProbabilisticModel],
+            state: None,
+        ) -> NoReturn:
+            assert False
+
+    def _unusable_observer(x: tf.Tensor) -> NoReturn:
+        assert False
+
+    data = {"": zero_dataset()}
+    result, history = (
+        BayesianOptimizer(_unusable_observer, one_dimensional_range(-1, 1))
+        .optimize(0, data, {"": _UnusableModel()}, _UnusableRule())
+        .astuple()
+    )
+    assert history == []
+    final_data = result.unwrap().datasets
+    assert len(final_data) == 1
+    assert_datasets_allclose(final_data[""], data[""])
 
 
 def test_bayesian_optimizer_can_use_two_gprs_for_objective_defined_by_two_dimensions() -> None:
@@ -173,23 +323,89 @@ def test_bayesian_optimizer_can_use_two_gprs_for_objective_defined_by_two_dimens
             EXPONENTIAL: Dataset(query_points, tf.exp(-query_points)),
         }
 
-    data = {
+    data: Mapping[str, Dataset] = {
         LINEAR: Dataset(tf.constant([[0.0]]), tf.constant([[0.0]])),
         EXPONENTIAL: Dataset(tf.constant([[0.0]]), tf.constant([[1.0]])),
     }
 
-    models: Dict[str, TrainableProbabilisticModel] = {  # mypy can't infer this type
+    models: Mapping[str, TrainableProbabilisticModel] = {
         LINEAR: LinearWithUnitVariance(),
         EXPONENTIAL: ExponentialWithUnitVariance(),
     }
 
-    res = BayesianOptimizer(
-        linear_and_exponential, Box(tf.constant([-2.0]), tf.constant([2.0]))
-    ).optimize(20, data, models, AdditionRule())
+    data = (
+        BayesianOptimizer(linear_and_exponential, Box(tf.constant([-2.0]), tf.constant([2.0])))
+        .optimize(20, data, models, AdditionRule())
+        .try_get_final_data()
+    )
 
-    if res.error is not None:
-        raise res.error
-
-    objective_values = res.datasets[LINEAR].observations + res.datasets[EXPONENTIAL].observations
+    objective_values = data[LINEAR].observations + data[EXPONENTIAL].observations
     min_idx = tf.argmin(objective_values, axis=0)[0]
-    npt.assert_allclose(res.datasets[LINEAR].query_points[min_idx], -tf.math.log(2.0), rtol=0.01)
+    npt.assert_allclose(data[LINEAR].query_points[min_idx], -tf.math.log(2.0), rtol=0.01)
+
+
+def test_bayesian_optimizer_optimize_doesnt_track_state_if_told_not_to() -> None:
+    class _UncopyableModel(_PseudoTrainableQuadratic):
+        def __deepcopy__(self, memo: Dict[int, object]) -> NoReturn:
+            assert False
+
+    history = (
+        BayesianOptimizer(quadratic, one_dimensional_range(-1, 1))
+        .optimize(
+            5, {OBJECTIVE: zero_dataset()}, {OBJECTIVE: _UncopyableModel()}, track_state=False
+        )
+        .history
+    )
+    assert len(history) == 0
+
+
+def test_bayesian_optimizer_optimize_tracked_state() -> None:
+    class _CountingRule(AcquisitionRule[int, Box]):
+        def acquire(
+            self,
+            search_space: Box,
+            datasets: Mapping[str, Dataset],
+            models: Mapping[str, ProbabilisticModel],
+            state: Optional[int],
+        ) -> Tuple[TensorType, int]:
+            new_state = 0 if state is None else state + 1
+            return tf.constant([[10.0]]) + new_state, new_state
+
+    class _DecreasingVarianceModel(QuadraticWithUnitVariance, TrainableProbabilisticModel):
+        def __init__(self, data: Dataset):
+            super().__init__()
+            self._data = data
+
+        def predict(self, query_points: TensorType) -> Tuple[TensorType, TensorType]:
+            mean, var = super().predict(query_points)
+            return mean, var / len(self._data)
+
+        def update(self, dataset: Dataset) -> None:
+            self._data = dataset
+
+        def optimize(self, dataset: Dataset) -> None:
+            pass
+
+    _, history = (
+        BayesianOptimizer(quadratic, one_dimensional_range(0, 1))
+        .optimize(
+            3, {"": zero_dataset()}, {"": _DecreasingVarianceModel(zero_dataset())}, _CountingRule()
+        )
+        .astuple()
+    )
+
+    assert [record.acquisition_state for record in history] == [None, 0, 1]
+
+    assert_datasets_allclose(history[0].datasets[""], zero_dataset())
+    assert_datasets_allclose(
+        history[1].datasets[""],
+        Dataset(tf.constant([[0.0], [10.0]]), tf.constant([[0.0], [100.0]])),
+    )
+    assert_datasets_allclose(
+        history[2].datasets[""],
+        Dataset(tf.constant([[0.0], [10.0], [11.0]]), tf.constant([[0.0], [100.0], [121.0]])),
+    )
+
+    for step in range(3):
+        _, variance_from_saved_model = history[step].models[""].predict(tf.constant([[0.0]]))
+        npt.assert_allclose(variance_from_saved_model, 1.0 / (step + 1))

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -54,18 +54,18 @@ def test_optimization_result_astuple() -> None:
     assert history is opt_result.history
 
 
-def test_optimization_result_try_get_final_data_for_successful_optimization() -> None:
+def test_optimization_result_try_get_final_datasets_for_successful_optimization() -> None:
     data = {"foo": zero_dataset()}
     result: OptimizationResult[None] = OptimizationResult(
         Ok(Record(data, {"foo": _PseudoTrainableQuadratic()}, None)), []
     )
-    assert result.try_get_final_data() is data
+    assert result.try_get_final_datasets() is data
 
 
-def test_optimization_result_try_get_final_data_for_failed_optimization() -> None:
+def test_optimization_result_try_get_final_datasets_for_failed_optimization() -> None:
     result: OptimizationResult[object] = OptimizationResult(Err(_Whoops()), [])
     with pytest.raises(_Whoops):
-        result.try_get_final_data()
+        result.try_get_final_datasets()
 
 
 def test_optimization_result_try_get_final_models_for_successful_optimization() -> None:
@@ -336,7 +336,7 @@ def test_bayesian_optimizer_can_use_two_gprs_for_objective_defined_by_two_dimens
     data = (
         BayesianOptimizer(linear_and_exponential, Box(tf.constant([-2.0]), tf.constant([2.0])))
         .optimize(20, data, models, AdditionRule())
-        .try_get_final_data()
+        .try_get_final_datasets()
     )
 
     objective_values = data[LINEAR].observations + data[EXPONENTIAL].observations

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 
 from tests.util.misc import ShapeLike, various_shapes
 from trieste.type import TensorType
-from trieste.utils.misc import jit, shapes_equal, to_numpy
+from trieste.utils.misc import Err, Ok, jit, shapes_equal, to_numpy
 
 
 @pytest.mark.parametrize("apply", [True, False])
@@ -67,3 +67,17 @@ def test_shapes_equal(this_shape: ShapeLike, that_shape: ShapeLike) -> None:
 )
 def test_to_numpy(t: TensorType, expected: np.ndarray) -> None:
     npt.assert_array_equal(to_numpy(t), expected)
+
+
+def test_ok() -> None:
+    assert Ok(1).unwrap() == 1
+    assert Ok(1).is_ok is True
+    assert Ok(1).is_err is False
+
+
+def test_err() -> None:
+    with pytest.raises(ValueError):
+        Err(ValueError()).unwrap()
+
+    assert Err(ValueError()).is_ok is False
+    assert Err(ValueError()).is_err is True

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -82,6 +82,22 @@ def raise_(*_: object, **__: object) -> NoReturn:
     raise Exception
 
 
+def quadratic(x: tf.Tensor) -> Mapping[str, Dataset]:
+    r"""
+    A multi-dimensional quadratic :class:`Observer`.
+
+    :param x: A tensor whose last dimension is of length greater than zero.
+    :return: A single :class:`Dataset` with key `""`, whose :attr:`query_points` are ``x``, and
+        ``observations`` are the sum :math:`\Sigma x^2` of the squares of ``x`` (the Euclidean
+        norm).
+    :raise ValueError: If ``x`` is a scalar or has empty trailing dimension.
+    """
+    if x.shape == [] or x.shape[-1] == 0:
+        raise ValueError(f"x must have non-empty trailing dimension, got shape {x.shape}")
+
+    return {"": Dataset(x, tf.reduce_sum(x ** 2, axis=-1, keepdims=True))}
+
+
 class FixedAcquisitionRule(AcquisitionRule[None, SearchSpace]):
     """ An acquisition rule that returns the same fixed value on every step. """
 

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import copy
 import traceback
 from dataclasses import dataclass
-from typing import Generic, List, Mapping, Optional, TypeVar, cast
+from typing import Generic, List, Mapping, Optional, Tuple, TypeVar, cast, overload
 
 import gpflow
 import tensorflow as tf
@@ -30,6 +30,7 @@ from .data import Dataset
 from .models import ModelSpec, TrainableProbabilisticModel, create_model
 from .observer import Observer
 from .space import SearchSpace
+from .utils import Err, Ok, Result
 
 S = TypeVar("S")
 """ Unbound type variable. """
@@ -39,47 +40,69 @@ SP = TypeVar("SP", bound=SearchSpace)
 
 
 @dataclass(frozen=True)
-class LoggingState(Generic[S]):
-    """
-    Container for the state of the optimization process in :class:`BayesianOptimizer` at each
-    optimization step.
-    """
+class Record(Generic[S]):
+    """ Container to record the state of each step of the optimization process. """
 
     datasets: Mapping[str, Dataset]
-    """ All observer data at this optimization step. """
+    """ The known data from the observer. """
 
     models: Mapping[str, TrainableProbabilisticModel]
     """ The models over the :attr:`datasets`. """
 
     acquisition_state: Optional[S]
-    """ The acquisition state after this optimization step. """
+    """ The acquisition state. """
 
 
+# this should be a generic NamedTuple, but mypy doesn't support them
+#  https://github.com/python/mypy/issues/685
 @dataclass(frozen=True)
 class OptimizationResult(Generic[S]):
-    """ Container for the final result of the optimization process. """
+    """ The final result, and the historical data of the optimization process. """
 
-    datasets: Mapping[str, Dataset]
+    final_result: Result[Record[S]]
     """
-    All data from the observer (unless :attr:`error` is populated, in which case this is the data
-    from the point at which the process was interrupted).
+    The final result of the optimization process. This contains either a :class:`Record` or an
+    exception.
     """
 
-    models: Mapping[str, TrainableProbabilisticModel]
+    history: List[Record[S]]
+    r"""
+    The history of the :class:`Record`\ s from each step of the optimization process. These
+    :class:`Record`\ s are created at the *start* of each loop, and as such will never include the
+    :attr:`final_result`.
     """
-    The models over the :attr:`datasets` (unless :attr:`error` is populated, in which case this is
-    the models from the point at which the process was interrupted). """
 
-    history: List[LoggingState[S]]
-    """ The data, models, and acquisition state at each completed optimization step. """
+    def astuple(self) -> Tuple[Result[Record[S]], List[Record[S]]]:
+        """
+        **Note:** In contrast to the standard library function :func:`dataclasses.astuple`, this
+        method does *not* deepcopy instance attributes.
 
-    error: Optional[Exception]
-    """ The exception that occurred, if any. """
+        :return: The :attr:`final_result` and :attr:`history` as a 2-tuple.
+        """
+        return self.final_result, self.history
+
+    def try_get_final_data(self) -> Mapping[str, Dataset]:
+        """
+        Convenience method to attempt to get the final data.
+
+        :return: The final data, if the optimization completed successfully.
+        :raise Exception: If an exception occurred during optimization.
+        """
+        return self.final_result.unwrap().datasets
+
+    def try_get_final_models(self) -> Mapping[str, TrainableProbabilisticModel]:
+        """
+        Convenience method to attempt to get the final models.
+
+        :return: The final models, if the optimization completed successfully.
+        :raise Exception: If an exception occurred during optimization.
+        """
+        return self.final_result.unwrap().models
 
 
 class BayesianOptimizer(Generic[SP]):
     """
-    This class performs Bayesian optimization, the data efficient optimization of an expensive
+    This class performs Bayesian optimization, the data-efficient optimization of an expensive
     black-box *objective function* over some *search space*. Since we may not have access to the
     objective function itself, we speak instead of an *observer* that observes it.
     """
@@ -94,18 +117,41 @@ class BayesianOptimizer(Generic[SP]):
         self._search_space = search_space
 
     def __repr__(self) -> str:
+        """"""
         return f"BayesianOptimizer({self._observer!r}, {self._search_space!r})"
+
+    @overload
+    def optimize(
+        self,
+        num_steps: int,
+        datasets: Mapping[str, Dataset],
+        model_specs: Mapping[str, ModelSpec],
+        *,
+        track_state: bool = True,
+    ) -> OptimizationResult[None]:
+        ...
+
+    @overload
+    def optimize(
+        self,
+        num_steps: int,
+        datasets: Mapping[str, Dataset],
+        model_specs: Mapping[str, ModelSpec],
+        acquisition_rule: AcquisitionRule[S, SP],
+        acquisition_state: Optional[S] = None,
+        *,
+        track_state: bool = True,
+    ) -> OptimizationResult[S]:
+        ...
 
     def optimize(
         self,
         num_steps: int,
-        # note the transforms, datasets and model_specs are kept as separate dicts rather than
-        # merged into one dict as that was the style strongly preferred by the researcher we
-        # asked at the time
         datasets: Mapping[str, Dataset],
         model_specs: Mapping[str, ModelSpec],
         acquisition_rule: Optional[AcquisitionRule[S, SP]] = None,
         acquisition_state: Optional[S] = None,
+        *,
         track_state: bool = True,
     ) -> OptimizationResult[S]:
         """
@@ -115,29 +161,30 @@ class BayesianOptimizer(Generic[SP]):
         For each step in ``num_steps``, this method:
             - Finds the next points with which to query the ``observer`` using the
               ``acquisition_rule``'s :meth:`acquire` method, passing it the ``search_space``,
-              ``datasets`` and models built from the ``model_specs``.
+              ``datasets``, models built from the ``model_specs``, and current acquisition state.
             - Queries the ``observer`` *once* at those points.
             - Updates the datasets and models with the data from the ``observer``.
 
-        Within the optimization loop, this method will catch any errors raised and return them
-        instead, along with the latest data, models, and the history of the optimization process.
-        This enables the caller to restart the optimization loop from the latest successful step.
-        **Note that if an error occurred, the latest data and models might not be from the
-        ``num_steps``-th optimization step, but from the step where the error occurred. It is up to
-        the caller to check if this has happened, by checking if the result's `error` attribute is
-        populated.** Any errors encountered within this method, but outside the optimization loop,
-        will be raised as normal. These are documented below.
+        If any errors are raised during the optimization loop, this method will catch and return
+        them instead, along with the history of the optimization process, and print a message (using
+        `absl` at level `logging.ERROR`).
+
+        **Note:** While the :class:`~trieste.models.TrainableProbabilisticModel` interface implies
+        mutable models, it is *not* guaranteed that the model passed to :meth:`optimize` will be
+        updated during the optimization process. For example, if ``track_state`` is `True`, a copied
+        model will be used on each optimization step. Use the models in the return value for
+        reliable access to the updated models.
 
         **Type hints:**
             - The ``acquisition_rule`` must use the same type of
               :class:`~trieste.space.SearchSpace` as specified in :meth:`__init__`.
-            - The history, if populated, will contain an acquisition state of the same type as used
-              by the ``acquisition_rule``.
+            - The ``acquisition_state`` must be of the type expected by the ``acquisition_rule``.
+              Any acquisition state in the optimization result will also be of this type.
 
         :param num_steps: The number of optimization steps to run.
         :param datasets: The known observer query points and observations for each tag.
-        :param model_specs: The model to use for each :class:`~trieste.data.Dataset` (matched
-            by tag).
+        :param model_specs: The model to use for each :class:`~trieste.data.Dataset` in
+            ``datasets``.
         :param acquisition_rule: The acquisition rule, which defines how to search for a new point
             on each optimization step. Defaults to
             :class:`~trieste.acquisition.rule.EfficientGlobalOptimization` with default
@@ -145,18 +192,26 @@ class BayesianOptimizer(Generic[SP]):
             `OBJECTIVE`, the search space can be any :class:`~trieste.space.SearchSpace`, and the
             acquisition state returned in the :class:`OptimizationResult` will be `None`.
         :param acquisition_state: The acquisition state to use on the first optimization step.
-            This argument allows the caller to restore the optimization process from a previous
-            :class:`LoggingState`.
+            This argument allows the caller to restore the optimization process from an existing
+            :class:`Record`.
         :param track_state: If `True`, this method saves the optimization state at the start of each
-            step.
-        :return: The updated models, data, history containing information from every optimization
-            step (see ``track_state``), and the error if any error was encountered during
-            optimization.
+            step. Models and acquisition state are copied using `copy.deepcopy`.
+        :return: An :class:`OptimizationResult`. The :attr:`final_result` element contains either
+            the final optimization data, models and acquisition state, or, if an exception was
+            raised while executing the optimization loop, it contains the exception raised. In
+            either case, the :attr:`history` element is the history of the data, models and
+            acquisition state at the *start* of each optimization step (up to and including any step
+            that fails to complete). The history will never include the final optimization result.
         :raise ValueError: If any of the following are true:
+
+            - ``num_steps`` is negative.
             - the keys in ``datasets`` and ``model_specs`` do not match
             - ``datasets`` or ``model_specs`` are empty
             - the default `acquisition_rule` is used and the tags are not `OBJECTIVE`.
         """
+        if num_steps < 0:
+            raise ValueError(f"num_steps must be at least 0, got {num_steps}")
+
         if datasets.keys() != model_specs.keys():
             raise ValueError(
                 f"datasets and model_specs should contain the same keys. Got {datasets.keys()} and"
@@ -176,12 +231,16 @@ class BayesianOptimizer(Generic[SP]):
             acquisition_rule = cast(AcquisitionRule[S, SP], EfficientGlobalOptimization())
 
         models = {tag: create_model(spec) for tag, spec in model_specs.items()}
-        history: List[LoggingState[S]] = []
+        history: List[Record[S]] = []
 
         for step in range(num_steps):
+            if track_state:
+                history.append(Record(datasets, models, acquisition_state))
+
             try:
                 if track_state:
-                    _save_to_history(history, datasets, models, acquisition_state)
+                    models = {tag: gpflow.utilities.deepcopy(m) for tag, m in models.items()}
+                    acquisition_state = copy.deepcopy(acquisition_state)
 
                 query_points, acquisition_state = acquisition_rule.acquire(
                     self._search_space, datasets, models, acquisition_state
@@ -198,24 +257,16 @@ class BayesianOptimizer(Generic[SP]):
 
             except Exception as error:
                 tf.print(
-                    f"Optimization failed at step {step}, encountered error with traceback:"
+                    f"\nOptimization failed at step {step}, encountered error with traceback:"
                     f"\n{traceback.format_exc()}"
-                    f"\nAborting process and returning results",
+                    f"\nTerminating optimization and returning the optimization history. You may "
+                    f"be able to use the history to restart the process from a previous successful "
+                    f"optimization step.\n",
                     output_stream=logging.ERROR,
                 )
+                return OptimizationResult(Err(error), history)
 
-                return OptimizationResult(datasets, models, history, error)
+        tf.print("Optimization completed without errors", output_stream=logging.INFO)
 
-        return OptimizationResult(datasets, models, history, None)
-
-
-def _save_to_history(
-    history: List[LoggingState[S]],
-    datasets: Mapping[str, Dataset],
-    models: Mapping[str, TrainableProbabilisticModel],
-    acquisition_state: Optional[S],
-) -> None:
-    models_copy = {tag: gpflow.utilities.deepcopy(m) for tag, m in models.items()}
-    datasets_copy = {tag: ds for tag, ds in datasets.items()}
-    logging_state = LoggingState(datasets_copy, models_copy, copy.deepcopy(acquisition_state))
-    history.append(logging_state)
+        record = Record(datasets, models, acquisition_state)
+        return OptimizationResult(Ok(record), history)

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -81,7 +81,7 @@ class OptimizationResult(Generic[S]):
         """
         return self.final_result, self.history
 
-    def try_get_final_data(self) -> Mapping[str, Dataset]:
+    def try_get_final_datasets(self) -> Mapping[str, Dataset]:
         """
         Convenience method to attempt to get the final data.
 

--- a/trieste/observer.py
+++ b/trieste/observer.py
@@ -14,13 +14,13 @@
 """ Definitions and utilities for observers of objective functions. """
 from __future__ import annotations
 
-from typing import Callable, Dict
+from typing import Callable, Mapping
 
 import tensorflow as tf
 
 from .data import Dataset
 
-Observer = Callable[[tf.Tensor], Dict[str, Dataset]]
+Observer = Callable[[tf.Tensor], Mapping[str, Dataset]]
 """
 Type alias for an observer of the objective function (that takes query points and returns labelled
 datasets).

--- a/trieste/utils/__init__.py
+++ b/trieste/utils/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """ This package contains library utilities. """
 from . import objectives
-from .misc import jit, shapes_equal, to_numpy
+from .misc import Err, Ok, Result, T_co, jit, shapes_equal, to_numpy

--- a/trieste/utils/misc.py
+++ b/trieste/utils/misc.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, TypeVar
+from abc import ABC, abstractmethod
+from typing import Callable, Generic, NoReturn, TypeVar
 
 import numpy as np
 import tensorflow as tf
+from typing_extensions import final
 
 from ..type import TensorType
 
@@ -55,3 +57,114 @@ def to_numpy(t: TensorType) -> np.ndarray:
         return t.numpy()
 
     return t
+
+
+T_co = TypeVar("T_co", covariant=True)
+""" An unbounded covariant type variable. """
+
+
+class Result(Generic[T_co], ABC):
+    """
+    Represents the result of an operation that can fail with an exception. It contains either the
+    operation return value (in an :class:`Ok`), or the exception raised (in an :class:`Err`).
+
+    To check whether instances such as
+
+        >>> res = Ok(1)
+        >>> other_res = Err(ValueError("whoops"))
+
+    contain a value, use :attr:`is_ok` (or :attr:`is_err`)
+
+        >>> res.is_ok
+        True
+        >>> other_res.is_ok
+        False
+
+    We can access the value if it :attr:`is_ok` using :meth:`unwrap`.
+
+        >>> res.unwrap()
+        1
+
+    Trying to access the value of a failed :class:`Result`, or :class:`Err`, will raise the wrapped
+    exception
+
+        >>> other_res.unwrap()
+        Traceback (most recent call last):
+            ...
+        ValueError: whoops
+
+    **Note:** This class is not intended to be subclassed other than by :class:`Ok` and
+    :class:`Err`.
+    """
+
+    @property
+    @abstractmethod
+    def is_ok(self) -> bool:
+        """ `True` if this :class:`Result` contains a value, else `False`. """
+
+    @property
+    def is_err(self) -> bool:
+        """
+        `True` if this :class:`Result` contains an error, else `False`. The opposite of
+        :attr:`is_ok`.
+        """
+        return not self.is_ok
+
+    @abstractmethod
+    def unwrap(self) -> T_co:
+        """
+        :return: The contained value, if it exists.
+        :raise Exception: If there is no contained value.
+        """
+
+
+@final
+class Ok(Result[T_co]):
+    """ Wraps the result of a successful evaluation. """
+
+    def __init__(self, value: T_co):
+        """
+        :param value: The result of a successful evaluation.
+        """
+        self._value = value
+
+    def __repr__(self) -> str:
+        """"""
+        return f"Ok({self._value!r})"
+
+    @property
+    def is_ok(self) -> bool:
+        """ `True` always. """
+        return True
+
+    def unwrap(self) -> T_co:
+        """
+        :return: The wrapped value.
+        """
+        return self._value
+
+
+@final
+class Err(Result[NoReturn]):
+    """ Wraps the exception that occurred during a failed evaluation. """
+
+    def __init__(self, exc: Exception):
+        """
+        :param exc: The exception that occurred.
+        """
+        self._exc = exc
+
+    def __repr__(self) -> str:
+        """"""
+        return f"Err({self._exc!r})"
+
+    @property
+    def is_ok(self) -> bool:
+        """ `False` always. """
+        return False
+
+    def unwrap(self) -> NoReturn:
+        """
+        :raise Exception: Always. Raises the wrapped exception.
+        """
+        raise self._exc


### PR DESCRIPTION
The return type of `BayesianOptimizer.optimize` is a combination of `LoggingState` and `OptimizationResult`. There are a few problem points in these:

* there is duplication between the two: the `datasets` and `models` fields
* `OptimizationResult` should have an `acquisition_state` field if users are going to restart the optimization process from a previous run. Note this would become another duplicate field
* error handling in `OptimizationResult` is not safe. It's very easy to forget to check for the presence of an `error` in `OptimizationResult`, and start unknowingly working with data from a failed run. If the process failed while updating either the model or data, this can mean e.g. returning a model that's not been updated with the data, or a corrupted model.

To resolve all of these problems, I propose

* a single type that contains all the things of interest in each step. I've called this a `Record`
* since the history of `Record`s from successful steps is _always_ returned whether the process failed or not, but the final `Record` is only returned on success, I've separated the two in the `OptimizationResult`
* if the process failed, the final `Record` isn't created or returned, so there's no chance of receiving corrupted state. On failure, we return only the error. There are several ways we could do this. I've adapted a method used in Rust/Scala/Haskell/Swift: creating a result type which is a container for either a value or an error, along with helper methods for handling the contents. Note it's not as powerful as it is in those other languages cos we don't have pattern matching