### PR TITLE
DO NOT MERGE remove master branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@
 
 on:
   push:
-    branches: master
+    tags: v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
   docs:

--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -14,7 +14,7 @@
 
 on:
   pull_request:
-    branches: [ develop, master ]
+    branches: develop
 
 jobs:
   common:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ $ tox -e tests
 
 #### Continuous integration
 
-[GitHub actions](https://docs.github.com/en/actions) will automatically run the quality checks against pull requests to develop or master, by calling into tox. The GitHub repository is set up such that these need to pass in order to merge.
+[GitHub actions](https://docs.github.com/en/actions) will automatically run the quality checks against pull requests to the develop branch, by calling into tox. The GitHub repository is set up such that these need to pass in order to merge.
 
 ### Updating dependencies
 


### PR DESCRIPTION
**DO NOT MERGE** without asking. There are external changes that need to happen at the same time as this being merged.

the master branch is superfluous. This PR does the code prep needed to remove it. Instead of building the docs on pushes to master (which, incidentally, is fragile to people pushing to master outside of releases), this PR proposes we build the docs when a semver-compliant tag is pushed. If a tag is pushed by mistake, thus building the docs for the wrong point in the code, we can delete and redeploy the latest correct tag (taking care with associated github releases)

We'll also need to
  - delete the master branch
  - check the github releases are still in place
  - remove the master branch protection rules
  - probably mention in slack #trieste so that people aren't confused