### PR TITLE
Victor/failure notebook

### DIFF
--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -47,7 +47,7 @@ tf.random.set_seed(1234)
 #
 # This notebook is similar to the _Introduction_ notebook, where we look to find the minimum value of the two-dimensional Branin function over the hypercube $[0, 1]^2$. But here, we constrain the problem, by adding an area to the search space in which the objective fails to evaluate.
 #
-# We represent this setup with a function `masked_branin` that produces null values when evaluated in the rectangle with corners $(0.25, 0.1)$, $(0.75, 0.9)$. It's important to remember that while _we_ know where this _failure region_ is, this function is a black box from the optimizer's point of view: the optimizer must learn it.
+# We represent this setup with a function `masked_branin` that produces null values when evaluated in the disk with center $(0.5, 0.4)$ and radius $0.3$. It's important to remember that while _we_ know where this _failure region_ is, this function is a black box from the optimizer's point of view: the optimizer must learn it.
 
 # %%
 def masked_branin(x):

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -140,14 +140,11 @@ classification_model = create_classification_model(initial_data[FAILURE])
 
 # %%
 class NatGradTrainedVGP(VariationalGaussianProcess):
-    def __init__(self, model: VGP, maxiter: int = 100, learning_rate: float = 1e-3, gamma: float = 0.1):
-        """
-        :param model: The GPflow model to wrap.
-        """
+    def __init__(self, model):
         super().__init__(model)
-        self._learning_rate = learning_rate
-        self._gamma = gamma
-        self._maxiter = maxiter
+        self._learning_rate = 1e-3
+        self._gamma = 0.1
+        self._maxiter = 100
 
     def optimize(self):
         set_trainable(self.model.q_mu, False)

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -24,10 +24,11 @@ from gpflow import set_trainable
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-
+from typing import Dict
 import trieste
 from trieste.utils import objectives
 from trieste.models.model_interfaces import VariationalGaussianProcess
+from trieste.models import ModelSpec
 from gpflow.models import VGP
 from gpflow.optimizers import NaturalGradient
 

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -152,7 +152,7 @@ class NatGradTrainedVGP(VariationalGaussianProcess):
             adam_opt.minimize(self.model.training_loss, var_list=self.model.trainable_variables)
 
 # %% [markdown]
-# The GPR model will be trained with an L-BFGS-based optimizer. The GPC model will be trained using a custom algorithm.
+# We'll train the GPR model with an L-BFGS-based optimizer, and the GPC model with the custom algorithm above.
 
 # %%
 models = {

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -155,7 +155,7 @@ class NatGradTrainedVGP(VariationalGaussianProcess):
 # We'll train the GPR model with an L-BFGS-based optimizer, and the GPC model with the custom algorithm above.
 
 # %%
-models = {
+models: Dict[str, ModelSpec] = {
     OBJECTIVE: {
         "model": regression_model,
         "optimizer": gpflow.optimizers.Scipy(),

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -140,22 +140,16 @@ classification_model = create_classification_model(initial_data[FAILURE])
 
 # %%
 class NatGradTrainedVGP(VariationalGaussianProcess):
-    def __init__(self, model):
-        super().__init__(model)
-        self._learning_rate = 1e-3
-        self._gamma = 0.1
-        self._maxiter = 100
-
     def optimize(self):
         set_trainable(self.model.q_mu, False)
         set_trainable(self.model.q_sqrt, False)
         variational_params = [(self.model.q_mu, self.model.q_sqrt)]
-        adam_opt_for_vgp = tf.optimizers.Adam(self._learning_rate)
-        natgrad_opt = NaturalGradient(gamma=self._gamma)
+        adam_opt = tf.optimizers.Adam(1e-3)
+        natgrad_opt = NaturalGradient(gamma=0.1)
 
-        for step in range(self._maxiter):
+        for step in range(100):
             natgrad_opt.minimize(self.model.training_loss, var_list=variational_params)
-            adam_opt_for_vgp.minimize(self.model.training_loss, var_list=self.model.trainable_variables)
+            adam_opt.minimize(self.model.training_loss, var_list=self.model.trainable_variables)
 
 # %% [markdown]
 # The GPR model will be trained with an L-BFGS-based optimizer. The GPC model will be trained using a custom algorithm.

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -16,15 +16,12 @@ from typing import Callable, Dict, Iterable, Optional, Tuple, Union, Any
 
 import gpflow
 from gpflow.models import GPModel, GPR, SGPR, VGP, SVGP
-from gpflow.utilities import set_trainable
 import numpy as np
 import tensorflow as tf
-from gpflow.covariances.kuus import Kuu
 
 from .. import utils
 from ..data import Dataset
 from ..type import ObserverEvaluations, QueryPoints, TensorType
-from ..utils import to_numpy
 
 class ModelInterface(ABC):
     """ A trainable probabilistic model. """


### PR DESCRIPTION
This PR fixes the failure notebook by implementing the following:
- the failure domain changed from a rectangle to a disk to limit the risk of having deceiving observations (that would lead to a very large lengthscale in one direction)
- the VGP model has a fixed variance set to a large value: this is equivalent to having a sharp link function. A sharp link is useful here as the failures are deterministic.
- the VGP model now has a "smart" update for q_mu and q_sqrt based on the previous model posterior. This code has been used in the BO vertical.
- the VGP model has a custom training procedure: an alternate scheme between natgrads over the VI parameters and adam over the lengthscales.

The BO results after 20 iterations are very convincing, as the 3 optimal regions have been explored and not many observations are "wasted" in the failure region. 