### PR TITLE
VGP update

### DIFF
--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -33,7 +33,6 @@ from util.plotting_plotly import (
 )
 from util.plotting import plot_gp_2d, plot_function_2d, plot_bo_points
 
-
 # %%
 gpflow.config.set_default_jitter(1e-5)
 gpflow.config.set_default_float(np.float64)

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -33,6 +33,7 @@ from util.plotting_plotly import (
 )
 from util.plotting import plot_gp_2d, plot_function_2d, plot_bo_points
 
+
 # %%
 gpflow.config.set_default_jitter(1e-5)
 gpflow.config.set_default_float(np.float64)

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -180,6 +180,27 @@ def test_vgp_update_updates_num_data() -> None:
 
 
 @random_seed(1357)
+def test_vgp_update_updates_vi() -> None:
+    x_observed = tf.constant(np.arange(100).reshape((-1, 1)), dtype=gpflow.default_float())
+    y_observed = _3x_plus_gaussian_noise(x_observed)
+    model = VariationalGaussianProcess(_vgp(x_observed, y_observed))
+
+    gpflow.optimizers.Scipy().minimize(
+        model.loss, model.trainable_variables,
+    )
+    old_q_mu = model.q_mu.value()
+    old_q_sqrt = model.q_sqrt.value()
+
+    model.update(Dataset(x_observed, y_observed))
+
+    new_q_mu = model.q_mu.value()
+    new_q_sqrt = model.q_sqrt.value()
+
+    npt.assert_allclose(old_q_mu, new_q_mu)
+    npt.assert_allclose(old_q_sqrt, new_q_sqrt)
+
+
+@random_seed(1357)
 def test_gaussian_process_regression_default_optimize(gpr_interface_factory) -> None:
     model = gpr_interface_factory(*_mock_data())
     loss = model.loss()

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -190,8 +190,8 @@ def test_vgp_update_updates_vi() -> None:
     )
     old_q_mu = model.model.q_mu.numpy()
     old_q_sqrt = model.model.q_sqrt.numpy()
-
-    model.update(Dataset(x_observed, y_observed))
+    data = Dataset(x_observed, y_observed)
+    model.update(data)
 
     new_q_mu = model.model.q_mu.numpy()
     new_q_sqrt = model.model.q_sqrt.numpy()

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -188,16 +188,16 @@ def test_vgp_update_updates_vi() -> None:
     gpflow.optimizers.Scipy().minimize(
         model.loss, model.trainable_variables,
     )
-    old_q_mu = model.q_mu.value()
-    old_q_sqrt = model.q_sqrt.value()
+    old_q_mu = model.model.q_mu.numpy()
+    old_q_sqrt = model.model.q_sqrt.numpy()
 
     model.update(Dataset(x_observed, y_observed))
 
-    new_q_mu = model.q_mu.value()
-    new_q_sqrt = model.q_sqrt.value()
+    new_q_mu = model.model.q_mu.numpy()
+    new_q_sqrt = model.model.q_sqrt.numpy()
 
     npt.assert_allclose(old_q_mu, new_q_mu)
-    npt.assert_allclose(old_q_sqrt, new_q_sqrt)
+    npt.assert_allclose(old_q_sqrt, new_q_sqrt, atol=1e-5)
 
 
 @random_seed(1357)

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -124,7 +124,7 @@ def _vgp(x: tf.Tensor, y: tf.Tensor) -> VGP:
     return m
 
 
-def _vgp2(x: tf.Tensor, y: tf.Tensor) -> VGP:
+def _vgp_matern(x: tf.Tensor, y: tf.Tensor) -> VGP:
     likelihood = gpflow.likelihoods.Gaussian()
     kernel = gpflow.kernels.Matern32(lengthscales=0.2)
     m = VGP((x, y), kernel, likelihood)
@@ -153,7 +153,7 @@ def _3x_plus_10(x: tf.Tensor) -> tf.Tensor:
     return 3.0 * x + 10
 
 
-def _sin_10_x(x: tf.Tensor) -> tf.Tensor:
+def _2sin_x_over_3(x: tf.Tensor) -> tf.Tensor:
     return 2.0 * tf.math.sin(x/3.)
 
 
@@ -193,10 +193,10 @@ def test_vgp_update_updates_num_data() -> None:
 
 
 @random_seed(1357)
-def test_vgp_update_updates_vi() -> None:
+def test_vgp_update_q_mu_sqrt_unchanged() -> None:
     x_observed = tf.constant(np.arange(10).reshape((-1, 1)), dtype=gpflow.default_float())
-    y_observed = _sin_10_x(x_observed)
-    model = VariationalGaussianProcess(_vgp2(x_observed, y_observed))
+    y_observed = _2sin_x_over_3(x_observed)
+    model = VariationalGaussianProcess(_vgp_matern(x_observed, y_observed))
 
     old_q_mu = model.model.q_mu.numpy()
     old_q_sqrt = model.model.q_sqrt.numpy()

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -274,13 +274,18 @@ class VariationalGaussianProcess(GaussianProcessRegression):
         assert dataset.observations.shape[-1] == y.shape[-1]
         data = (dataset.query_points, dataset.observations)
         num_data = data[0].shape[0]
-        num_latent_gps = model.num_latent_gps
+
+        new_q_mu, new_q_var = self.model.predict_f(dataset.query_points, full_cov=True)
+
+        new_q_sqrt = tf.linalg.cholesky(
+            new_q_var
+            + gpflow.config.default_jitter() * (tf.eye(num_data, dtype=new_q_var.dtype)[None])
+        )
+
         model.data = data
         model.num_data = num_data
-        model.q_mu = gpflow.Parameter(np.zeros((num_data, num_latent_gps)))
-        q_sqrt = np.eye(num_data)
-        q_sqrt = np.repeat(q_sqrt[None], num_latent_gps, axis=0)
-        model.q_sqrt = gpflow.Parameter(q_sqrt, transform=gpflow.utilities.triangular())
+        model.q_mu = gpflow.Parameter(new_q_mu)
+        model.q_sqrt = gpflow.Parameter(new_q_sqrt, transform=gpflow.utilities.triangular())
 
     def predict(self, query_points: QueryPoints) -> Tuple[ObserverEvaluations, TensorType]:
         return self.model.predict_y(query_points)

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -278,7 +278,7 @@ class VariationalGaussianProcess(GaussianProcessRegression):
         f_mu, f_cov = self.model.predict_f(dataset.query_points, full_cov=True)  # [N, L], [L, N, N]
         assert self.model.q_sqrt.shape.ndims == 3
 
-        jitter = 10 * gpflow.config.default_jitter()
+        jitter = gpflow.config.default_jitter()
         Knn = model.kernel(dataset.query_points, full_cov=True)  # [N, N]
         Lnn = tf.linalg.cholesky(Knn + tf.eye(num_data, dtype=Knn.dtype) * jitter)  # [N, N]
         new_q_mu = tf.linalg.triangular_solve(Lnn, f_mu)  # [N, L]

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -278,7 +278,7 @@ class VariationalGaussianProcess(GaussianProcessRegression):
         f_mu, f_cov = self.model.predict_f(dataset.query_points, full_cov=True)  # [N, L], [L, N, N]
         assert self.model.q_sqrt.shape.ndims == 3
 
-        jitter = gpflow.config.default_jitter()
+        jitter = 10 * gpflow.config.default_jitter()
         Knn = model.kernel(dataset.query_points, full_cov=True)  # [N, N]
         Lnn = tf.linalg.cholesky(Knn + tf.eye(num_data, dtype=Knn.dtype) * jitter)  # [N, N]
         new_q_mu = tf.linalg.triangular_solve(Lnn, f_mu)  # [N, L]


### PR DESCRIPTION
this PR replaces the current VGP update that re-initializes q_mu and q_sqrt to 0 and 1 resp. to values based on the current model posterior