### PR TITLE
Acquisition rule for batches of points

### DIFF
--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -192,29 +192,29 @@ def test_trust_region_for_unsuccessful_local_to_global_trust_region_reduced() ->
 
 
 class _BatchModelMinusMeanMaximumSingleBuilder(BatchAcquisitionFunctionBuilder):
-    def using(self, tag: str) -> BatchAcquisitionFunctionBuilder:
-        """
-        :param tag: The tag for the model, dataset pair to use to build this acquisition function.
-        :return: An acquisition function builder that selects the model and dataset specified by
-            ``tag``, as defined in :meth:`prepare_acquisition_function`.
-        """
-        single_builder = self
-
-        class _Anon(BatchAcquisitionFunctionBuilder):
-            def prepare_acquisition_function(
-                self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
-            ) -> BatchAcquisitionFunction:
-                return single_builder.prepare_acquisition_function(datasets[tag], models[tag])
-
-            def __repr__(self) -> str:
-                return f"{single_builder!r} using tag {tag!r}"
-
-        return _Anon()
+    # def using(self, tag: str) -> BatchAcquisitionFunctionBuilder:
+    #     """
+    #     :param tag: The tag for the model, dataset pair to use to build this acquisition function.
+    #     :return: An acquisition function builder that selects the model and dataset specified by
+    #         ``tag``, as defined in :meth:`prepare_acquisition_function`.
+    #     """
+    #     single_builder = self
+    #
+    #     class _Anon(BatchAcquisitionFunctionBuilder):
+    #         def prepare_acquisition_function(
+    #             self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+    #         ) -> BatchAcquisitionFunction:
+    #             return single_builder.prepare_acquisition_function(datasets[tag], models[tag])
+    #
+    #         def __repr__(self) -> str:
+    #             return f"{single_builder!r} using tag {tag!r}"
+    #
+    #     return _Anon()
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self, dataset: Dataset, model: Mapping[str, ProbabilisticModel]
     ) -> BatchAcquisitionFunction:
-        return lambda at: -tf.reduce_max(model.predict(at)[0], axis=-2)
+        return lambda at: -tf.reduce_max(model[OBJECTIVE].predict(at)[0], axis=-2)
 
 
 def test_batch_acquisition_returns_batches_of_right_size() -> None:
@@ -222,7 +222,7 @@ def test_batch_acquisition_returns_batches_of_right_size() -> None:
     num_query_points = 3
     ego = BatchAcquisitionRule(
         num_query_points,
-        _BatchModelMinusMeanMaximumSingleBuilder().using(OBJECTIVE))
+        _BatchModelMinusMeanMaximumSingleBuilder())
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
     query_point, _ = ego.acquire(
         search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticWithUnitVariance()}
@@ -236,7 +236,7 @@ def test_batch_acquisition_finds_minimum() -> None:
     num_query_points = 4
     ego = BatchAcquisitionRule(
         num_query_points,
-        _BatchModelMinusMeanMaximumSingleBuilder().using(OBJECTIVE))
+        _BatchModelMinusMeanMaximumSingleBuilder())
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
     query_point, _ = ego.acquire(
         search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticWithUnitVariance()}

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -198,6 +198,19 @@ class _BatchModelMinusMeanMaximumSingleBuilder(BatchAcquisitionFunctionBuilder):
         return lambda at: -tf.reduce_max(model[OBJECTIVE].predict(at)[0], axis=-2)
 
 
+def test_batch_acquisition_returns_batches_of_right_size() -> None:
+    search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
+    num_query_points = 3
+    ego = BatchAcquisitionRule(
+        num_query_points,
+        _BatchModelMinusMeanMaximumSingleBuilder())
+    dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
+    query_point, _ = ego.acquire(
+        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticWithUnitVariance()}
+    )
+    assert query_point.shape == [num_query_points, 2]
+
+
 def test_batch_acquisition_finds_minimum() -> None:
     search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
     num_query_points = 4

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -213,7 +213,7 @@ class _BatchModelMinusMeanMaximumSingleBuilder(BatchAcquisitionFunctionBuilder):
 
     def prepare_acquisition_function(
         self, dataset: Dataset, model: ProbabilisticModel
-    ) -> AcquisitionFunction:
+    ) -> BatchAcquisitionFunction:
         return lambda at: -tf.reduce_max(model.predict(at)[0], axis=-2)
 
 

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -24,10 +24,14 @@ from trieste.acquisition.rule import (
     ThompsonSampling,
     TrustRegion,
     OBJECTIVE,
+    BatchAcquisitionRule,
 )
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.space import SearchSpace, DiscreteSearchSpace, Box
+from trieste.acquisition import SingleModelAcquisitionBuilder
+
+from trieste.acquisition.function import AcquisitionFunction
 
 from tests.util.misc import one_dimensional_range, zero_dataset
 from tests.util.model import QuadraticWithUnitVariance
@@ -186,3 +190,33 @@ def test_trust_region_for_unsuccessful_local_to_global_trust_region_reduced() ->
     npt.assert_array_less(current_state.eps, previous_state.eps)  # current TR smaller than previous
     assert current_state.is_global
     npt.assert_array_almost_equal(current_state.acquisition_space.lower, lower_bound)
+
+
+class _BatchModelMinusMeanMaximumSingleBuilder(SingleModelAcquisitionBuilder):
+    def prepare_acquisition_function(
+        self, dataset: Dataset, model: ProbabilisticModel
+    ) -> AcquisitionFunction:
+        return lambda at: -tf.reduce_max(model.predict(at)[0], axis=-2)
+
+
+def test_batch_acquisition_returns_batches_of_right_size() -> None:
+    search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
+    num_query_points = 3
+    ego = BatchAcquisitionRule(num_query_points, _BatchModelMinusMeanMaximumSingleBuilder().using(OBJECTIVE))
+    dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
+    query_point, _ = ego.acquire(
+        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticWithUnitVariance()}
+    )
+    assert query_point.shape == [num_query_points, 2]
+
+
+def test_batch_acquisition_finds_minimum() -> None:
+    search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
+    expected_minimum = tf.constant([0., 0.])
+    num_query_points = 4
+    ego = BatchAcquisitionRule(num_query_points, _BatchModelMinusMeanMaximumSingleBuilder().using(OBJECTIVE))
+    dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
+    query_point, _ = ego.acquire(
+        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticWithUnitVariance()}
+    )
+    npt.assert_allclose(query_point - expected_minimum[None, :], 0., atol=1e-3)

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -198,9 +198,8 @@ class _BatchModelMinusMeanMaximumSingleBuilder(BatchAcquisitionFunctionBuilder):
         return lambda at: -tf.reduce_max(model[OBJECTIVE].predict(at)[0], axis=-2)
 
 
-def test_batch_acquisition_returns_batches_of_right_size_and_finds_minimum() -> None:
+def test_batch_acquisition_finds_minimum() -> None:
     search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
-    expected_minimum = tf.constant([0., 0.])
     num_query_points = 4
     ego = BatchAcquisitionRule(
         num_query_points,
@@ -209,4 +208,5 @@ def test_batch_acquisition_returns_batches_of_right_size_and_finds_minimum() -> 
     query_point, _ = ego.acquire(
         search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticWithUnitVariance()}
     )
+
     npt.assert_allclose(query_point, [[0., 0.]] * num_query_points, atol=1e-3)

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -198,20 +198,7 @@ class _BatchModelMinusMeanMaximumSingleBuilder(BatchAcquisitionFunctionBuilder):
         return lambda at: -tf.reduce_max(model[OBJECTIVE].predict(at)[0], axis=-2)
 
 
-def test_batch_acquisition_returns_batches_of_right_size() -> None:
-    search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
-    num_query_points = 3
-    ego = BatchAcquisitionRule(
-        num_query_points,
-        _BatchModelMinusMeanMaximumSingleBuilder())
-    dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
-    query_point, _ = ego.acquire(
-        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticWithUnitVariance()}
-    )
-    assert query_point.shape == [num_query_points, 2]
-
-
-def test_batch_acquisition_finds_minimum() -> None:
+def test_batch_acquisition_returns_batches_of_right_size_and_finds_minimum() -> None:
     search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
     expected_minimum = tf.constant([0., 0.])
     num_query_points = 4

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -192,27 +192,8 @@ def test_trust_region_for_unsuccessful_local_to_global_trust_region_reduced() ->
 
 
 class _BatchModelMinusMeanMaximumSingleBuilder(BatchAcquisitionFunctionBuilder):
-    # def using(self, tag: str) -> BatchAcquisitionFunctionBuilder:
-    #     """
-    #     :param tag: The tag for the model, dataset pair to use to build this acquisition function.
-    #     :return: An acquisition function builder that selects the model and dataset specified by
-    #         ``tag``, as defined in :meth:`prepare_acquisition_function`.
-    #     """
-    #     single_builder = self
-    #
-    #     class _Anon(BatchAcquisitionFunctionBuilder):
-    #         def prepare_acquisition_function(
-    #             self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
-    #         ) -> BatchAcquisitionFunction:
-    #             return single_builder.prepare_acquisition_function(datasets[tag], models[tag])
-    #
-    #         def __repr__(self) -> str:
-    #             return f"{single_builder!r} using tag {tag!r}"
-    #
-    #     return _Anon()
-
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: Mapping[str, ProbabilisticModel]
+        self, dataset: Mapping[str, Dataset], model: Mapping[str, ProbabilisticModel]
     ) -> BatchAcquisitionFunction:
         return lambda at: -tf.reduce_max(model[OBJECTIVE].predict(at)[0], axis=-2)
 

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -222,4 +222,4 @@ def test_batch_acquisition_finds_minimum() -> None:
     query_point, _ = ego.acquire(
         search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticWithUnitVariance()}
     )
-    npt.assert_allclose(query_point - expected_minimum[None, :], 0., atol=1e-3)
+    npt.assert_allclose(query_point, [[0., 0.]] * num_query_points, atol=1e-3)

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -29,9 +29,7 @@ from trieste.acquisition.rule import (
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.space import SearchSpace, DiscreteSearchSpace, Box
-from trieste.acquisition import SingleModelAcquisitionBuilder
-
-from trieste.acquisition.function import AcquisitionFunction
+from trieste.acquisition.function import AcquisitionFunction, BatchAcquisitionFunctionBuilder
 
 from tests.util.misc import one_dimensional_range, zero_dataset
 from tests.util.model import QuadraticWithUnitVariance
@@ -192,7 +190,7 @@ def test_trust_region_for_unsuccessful_local_to_global_trust_region_reduced() ->
     npt.assert_array_almost_equal(current_state.acquisition_space.lower, lower_bound)
 
 
-class _BatchModelMinusMeanMaximumSingleBuilder(SingleModelAcquisitionBuilder):
+class _BatchModelMinusMeanMaximumSingleBuilder(BatchAcquisitionFunctionBuilder):
     def prepare_acquisition_function(
         self, dataset: Dataset, model: ProbabilisticModel
     ) -> AcquisitionFunction:

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -212,3 +212,12 @@ def test_box_discretize_returns_search_space_with_correct_number_of_points(
 
     with pytest.raises(ValueError):
         dss.sample(num_samples + 1)
+
+
+def test_box_combined_with_itself_returns_new_box_with_bounds_twice_as_large(
+) -> None:
+    box = Box(tf.zeros((3,)), tf.ones((3,)))
+    new_box = box * box
+
+    assert len(new_box.lower) == 6
+    assert len(new_box.upper) == 6

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -237,3 +237,23 @@ def test_box_product_raises_if_bounds_have_different_types() -> None:
 
     with pytest.raises(TypeError):
         _ = box1 * box2
+
+def test_discrete_search_space_product_points_is_the_concatenation_of_original_points() -> None:
+    dss1 = DiscreteSearchSpace(tf.constant([[-1., -1.4], [-1.5, -3.6], [-.5, -.6]]))
+    dss2 = DiscreteSearchSpace(tf.constant([[1., 1.4], [1.5, 3.6]]))
+    [n1, d1] = dss1.points.shape
+    [n2, d2] = dss2.points.shape
+    res = dss1 * dss2
+
+    assert res.points.shape[0] == n1*n2
+    assert res.points.shape[1] == d1 + d2
+    assert all(point in dss1 for point in res.points[:, :2])
+    assert all(point in dss2 for point in res.points[:, 2:])
+
+
+def test_discrete_search_space_product_raises_if_points_have_different_types() -> None:
+    dss1 = DiscreteSearchSpace(_points_in_2D_search_space())
+    dss2 = DiscreteSearchSpace(tf.constant([[1., 1.4], [-1.5, 3.6]], tf.float64))
+
+    with pytest.raises(TypeError):
+        _ = dss1 * dss2

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -221,3 +221,22 @@ def test_box_combined_with_itself_returns_new_box_with_bounds_twice_as_large(
 
     assert len(new_box.lower) == 6
     assert len(new_box.upper) == 6
+
+
+def test_box_product_bounds_are_the_concatenation_of_original_bounds(
+) -> None:
+    box1 = Box(tf.constant([0., 1.]), tf.constant([2., 3.]))
+    box2 = Box(tf.constant([4., 5., 6.]), tf.constant([7., 8., 9.]))
+
+    res = box1 * box2
+    npt.assert_allclose(res.lower, [0, 1, 4, 5, 6])
+    npt.assert_allclose(res.upper, [2, 3, 7, 8, 9])
+
+
+def test_box_product_raises_if_bounds_have_different_types(
+) -> None:
+    box1 = Box(tf.constant([0., 1.]), tf.constant([2., 3.]))
+    box2 = Box(tf.constant([4., 5.], tf.float64), tf.constant([6., 7.], tf.float64))
+
+    with pytest.raises(TypeError):
+        _ = box1 * box2

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -238,6 +238,7 @@ def test_box_product_raises_if_bounds_have_different_types() -> None:
     with pytest.raises(TypeError):
         _ = box1 * box2
 
+
 def test_discrete_search_space_product_points_is_the_concatenation_of_original_points() -> None:
     dss1 = DiscreteSearchSpace(tf.constant([[-1., -1.4], [-1.5, -3.6], [-.5, -.6]]))
     dss2 = DiscreteSearchSpace(tf.constant([[1., 1.4], [1.5, 3.6]]))

--- a/tests/util/model.py
+++ b/tests/util/model.py
@@ -57,7 +57,7 @@ class QuadraticWithUnitVariance(GaussianMarginal):
     """
     def __init__(self):
         self._model = CustomMeanWithUnitVariance(
-            lambda x: tf.reduce_sum(x ** 2, axis=1, keepdims=True)
+            lambda x: tf.reduce_sum(x ** 2, axis=-1, keepdims=True)
         )
 
     def predict(self, query_points: QueryPoints) -> Tuple[ObserverEvaluations, TensorType]:

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -25,12 +25,14 @@ from ..space import SearchSpace
 from scipy.optimize import bisect
 
 AcquisitionFunction = Callable[[QueryPoints], tf.Tensor]
-""" Type alias for acquisition functions. """
+""" Type alias for acquisition functions. 
+
+AcquisitionFunction handles query points of shape [..., D] and returns [..., 1] values.
+"""
 BatchAcquisitionFunction = Callable[[QueryPoints], tf.Tensor]
 """ 
 Type alias for batch acquisition functions. 
 
-While an AcquisitionFunction handles query points of shape [..., D] and returns [..., 1] values,
 BatchAcquisitionFunction handles batches of query points of shape [..., B, D] and returns [..., 1] values.
 """
 

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -510,7 +510,7 @@ class BatchAcquisitionFunctionBuilder(ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
-    ) -> AcquisitionFunction:
+    ) -> BatchAcquisitionFunction:
         """
         :param datasets: The data from the observer.
         :param models: The models over each dataset in ``datasets``.

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -505,7 +505,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
 
 
 class BatchAcquisitionFunctionBuilder(ABC):
-    """ An :class:`BatchAcquisitionFunctionBuilder` builds a batch acquisition function. """
+    """ A :class:`BatchAcquisitionFunctionBuilder` builds a batch acquisition function. """
 
     @abstractmethod
     def prepare_acquisition_function(

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -294,3 +294,68 @@ class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):
         state_ = TrustRegion.State(acquisition_space, eps, y_min, is_global)
 
         return point, state_
+
+
+class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
+    """ Implements a acquisition rule for a batch of query points """
+
+    def __init__(self, num_query_points: int,
+                 builder: Optional[AcquisitionFunctionBuilder] = None):
+        """
+        :param num_query_points: The number of points to acquire.
+        :param builder: The acquisition function builder to use.
+            :class:`EfficientGlobalOptimization` will attempt to **maximise** the corresponding
+            acquisition function. Defaults to :class:`~trieste.acquisition.ExpectedImprovement`
+            with tag `OBJECTIVE`.
+        """
+
+        if not num_query_points > 0:
+            raise ValueError(
+                f"Number of query points must be greater than 0, got {num_query_points}"
+            )
+
+        self._num_query_points = num_query_points
+
+        if builder is None:
+            builder = ExpectedImprovement().using(OBJECTIVE)  # this is a placeholder for now
+            # num_samples = 100
+            # builder = MonteCarloExpectedImprovement(eps_shape=[num_samples, num_query_points, 1]).using(OBJECTIVE)  # [S, B, L]
+
+        self._builder = builder
+
+    def _vectorize_batch_acquisition(self, acquisition_function):
+        return lambda at: acquisition_function(tf.reshape(at, [at.shape[:-1], self._num_query_points, -1]))
+
+    def acquire(
+        self,
+        search_space: SearchSpace,
+        datasets: Mapping[str, Dataset],
+        models: Mapping[str, ProbabilisticModel],
+        state: None = None,
+    ) -> Tuple[QueryPoints, None]:
+        """
+        Return the batch of query points that optimizes the acquisition function produced by `builder` (see
+        :meth:`__init__`).
+        :param search_space: The global search space over which the optimization problem
+            is defined.
+        :param datasets: The known observer query points and observations.
+        :param models: The models of the specified ``datasets``.
+        :param state: Unused.
+        :return: The batch of points to query, and `None`.
+        """
+        expanded_search_space = _expand_search_space(search_space, self._num_query_points)
+
+        acquisition_function = self._builder.prepare_acquisition_function(datasets, models)
+        vectorized_batch_acquisition = self._vectorize_batch_acquisition(acquisition_function)
+
+        vectorized_points = _optimizer.optimize(expanded_search_space, vectorized_batch_acquisition)
+        points = tf.reshape(vectorized_points, [self._num_query_points, -1])
+
+        return points, None
+
+
+def _expand_search_space(search_space: SearchSpace, times: int):
+    expanded_search_space = search_space
+    for _ in range(times-1):
+        expanded_search_space *= search_space
+    return expanded_search_space

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -25,7 +25,7 @@ from typing_extensions import Final
 
 from ..data import Dataset
 from ..models import ProbabilisticModel
-from ..space import SearchSpace, Box
+from ..space import SearchSpace, Box, DiscreteSpace
 from ..type import QueryPoints
 from .function import (AcquisitionFunctionBuilder,
                        ExpectedImprovement,
@@ -298,7 +298,7 @@ class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):
         return point, state_
 
 
-class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
+class BatchAcquisitionRule(AcquisitionRule[None, Union[Box, DiscreteSpace]]):
     """ Implements a acquisition rule for a batch of query points """
 
     def __init__(self, num_query_points: int,
@@ -324,7 +324,7 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
 
     def acquire(
         self,
-        search_space: SearchSpace,
+        search_space: Union[Box, DiscreteSpace],
         datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
         state: None = None,

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -308,7 +308,6 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         :param builder: The acquisition function builder to use.
             :class:`BatchAcquisitionRule` will attempt to **maximise** the corresponding
             acquisition function.
-            with tag `OBJECTIVE`.
         """
 
         if not num_query_points > 0:

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -318,7 +318,7 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         self._num_query_points = num_query_points
         self._builder = builder
 
-    def _vectorize_batch_acquisition(self, acquisition_function: AcquisitionFunction) -> BatchAcquisitionFunction:
+    def _vectorize_batch_acquisition(self, acquisition_function: BatchAcquisitionFunction) -> AcquisitionFunction:
         return lambda at: acquisition_function(tf.reshape(at, at.shape[:-1] + [self._num_query_points, -1]))
 
     def acquire(

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TypeVar, Generic, Optional, Tuple, Mapping, Union
-from functools import reduce
-import operator
 
 import tensorflow as tf
 from typing_extensions import Final
@@ -296,68 +294,3 @@ class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):
         state_ = TrustRegion.State(acquisition_space, eps, y_min, is_global)
 
         return point, state_
-
-
-class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
-    """ Implements a acquisition rule for a batch of query points """
-
-    def __init__(self, num_query_points: int,
-                 builder: Optional[AcquisitionFunctionBuilder] = None):
-        """
-        :param num_query_points: The number of points to acquire.
-        :param builder: The acquisition function builder to use.
-            :class:`EfficientGlobalOptimization` will attempt to **maximise** the corresponding
-            acquisition function. Defaults to :class:`~trieste.acquisition.ExpectedImprovement`
-            with tag `OBJECTIVE`.
-        """
-
-        if not num_query_points > 0:
-            raise ValueError(
-                f"Number of query points must be greater than 0, got {num_query_points}"
-            )
-
-        self._num_query_points = num_query_points
-
-        if builder is None:
-            builder = ExpectedImprovement().using(OBJECTIVE)  # this is a placeholder for now
-            # num_samples = 100
-            # builder = MonteCarloExpectedImprovement(eps_shape=[num_samples, num_query_points, 1]).using(OBJECTIVE)  # [S, B, L]
-
-        self._builder = builder
-
-    def _vectorize_batch_acquisition(self, acquisition_function):
-        return lambda at: acquisition_function(tf.reshape(at, [at.shape[:-1], self._num_query_points, -1]))
-
-    def acquire(
-        self,
-        search_space: SearchSpace,
-        datasets: Mapping[str, Dataset],
-        models: Mapping[str, ProbabilisticModel],
-        state: None = None,
-    ) -> Tuple[QueryPoints, None]:
-        """
-        Return the batch of query points that optimizes the acquisition function produced by `builder` (see
-        :meth:`__init__`).
-        :param search_space: The global search space over which the optimization problem
-            is defined.
-        :param datasets: The known observer query points and observations.
-        :param models: The models of the specified ``datasets``.
-        :param state: Unused.
-        :return: The batch of points to query, and `None`.
-        """
-        expanded_search_space = _expand_search_space(search_space, self._num_query_points)
-
-        acquisition_function = self._builder.prepare_acquisition_function(datasets, models)
-        vectorized_batch_acquisition = self._vectorize_batch_acquisition(acquisition_function)
-
-        vectorized_points = _optimizer.optimize(expanded_search_space, vectorized_batch_acquisition)
-        points = tf.reshape(vectorized_points, [self._num_query_points, -1])
-
-        return points, None
-
-
-def _expand_search_space(search_space: SearchSpace, times: int):
-    expanded_search_space = search_space
-    for _ in range(times-1):
-        expanded_search_space *= search_space
-    return expanded_search_space

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -318,7 +318,7 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         self._num_query_points = num_query_points
         self._builder = builder
 
-    def _vectorize_batch_acquisition(self, acquisition_function):
+    def _vectorize_batch_acquisition(self, acquisition_function: AcquisitionFunction) -> BatchAcquisitionFunction:
         return lambda at: acquisition_function(tf.reshape(at, at.shape[:-1].as_list() + [self._num_query_points, -1]))
 
     def acquire(

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -319,7 +319,7 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         self._builder = builder
 
     def _vectorize_batch_acquisition(self, acquisition_function: AcquisitionFunction) -> BatchAcquisitionFunction:
-        return lambda at: acquisition_function(tf.reshape(at, at.shape[:-1].as_list() + [self._num_query_points, -1]))
+        return lambda at: acquisition_function(tf.reshape(at, at.shape[:-1] + [self._num_query_points, -1]))
 
     def acquire(
         self,

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -29,7 +29,9 @@ from ..space import SearchSpace, Box
 from ..type import QueryPoints
 from .function import (AcquisitionFunctionBuilder,
                        ExpectedImprovement,
-                       BatchAcquisitionFunctionBuilder)
+                       BatchAcquisitionFunctionBuilder,
+                       BatchAcquisitionFunction,
+                       AcquisitionFunction)
 from . import _optimizer
 
 
@@ -319,7 +321,7 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         self._builder = builder
 
     def _vectorize_batch_acquisition(self, acquisition_function: BatchAcquisitionFunction) -> AcquisitionFunction:
-        return lambda at: acquisition_function(tf.reshape(at, at.shape[:-1] + [self._num_query_points, -1]))
+        return lambda at: acquisition_function(tf.reshape(at, at.shape[:-1].as_list() + [self._num_query_points, -1]))
 
     def acquire(
         self,

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -25,7 +25,7 @@ from typing_extensions import Final
 
 from ..data import Dataset
 from ..models import ProbabilisticModel
-from ..space import SearchSpace, Box, DiscreteSpace
+from ..space import SearchSpace, Box
 from ..type import QueryPoints
 from .function import (AcquisitionFunctionBuilder,
                        ExpectedImprovement,
@@ -298,7 +298,7 @@ class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):
         return point, state_
 
 
-class BatchAcquisitionRule(AcquisitionRule[None, Union[Box, DiscreteSpace]]):
+class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
     """ Implements a acquisition rule for a batch of query points """
 
     def __init__(self, num_query_points: int,
@@ -324,7 +324,7 @@ class BatchAcquisitionRule(AcquisitionRule[None, Union[Box, DiscreteSpace]]):
 
     def acquire(
         self,
-        search_space: Union[Box, DiscreteSpace],
+        search_space: SearchSpace,
         datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
         state: None = None,

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -324,7 +324,7 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         self._builder = builder
 
     def _vectorize_batch_acquisition(self, acquisition_function):
-        return lambda at: acquisition_function(tf.reshape(at, [at.shape[:-1], self._num_query_points, -1]))
+        return lambda at: acquisition_function(tf.reshape(at, at.shape[:-1].as_list() + [self._num_query_points, -1]))
 
     def acquire(
         self,

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -300,12 +300,12 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
     """ Implements a acquisition rule for a batch of query points """
 
     def __init__(self, num_query_points: int,
-                 builder: Optional[AcquisitionFunctionBuilder] = None):
+                 builder: AcquisitionFunctionBuilder):
         """
         :param num_query_points: The number of points to acquire.
         :param builder: The acquisition function builder to use.
-            :class:`EfficientGlobalOptimization` will attempt to **maximise** the corresponding
-            acquisition function. Defaults to :class:`~trieste.acquisition.ExpectedImprovement`
+            :class:`BatchAcquisitionRule` will attempt to **maximise** the corresponding
+            acquisition function.
             with tag `OBJECTIVE`.
         """
 
@@ -315,12 +315,6 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
             )
 
         self._num_query_points = num_query_points
-
-        if builder is None:
-            builder = ExpectedImprovement().using(OBJECTIVE)  # this is a placeholder for now
-            # num_samples = 100
-            # builder = MonteCarloExpectedImprovement(eps_shape=[num_samples, num_query_points, 1]).using(OBJECTIVE)  # [S, B, L]
-
         self._builder = builder
 
     def _vectorize_batch_acquisition(self, acquisition_function):

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -343,7 +343,7 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         :param state: Unused.
         :return: The batch of points to query, and `None`.
         """
-        expanded_search_space = _expand_search_space(search_space, self._num_query_points)
+        expanded_search_space = search_space ** self._num_query_points
 
         acquisition_function = self._builder.prepare_acquisition_function(datasets, models)
         vectorized_batch_acquisition = self._vectorize_batch_acquisition(acquisition_function)
@@ -352,10 +352,3 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         points = tf.reshape(vectorized_points, [self._num_query_points, -1])
 
         return points, None
-
-
-def _expand_search_space(search_space: SearchSpace, times: int):
-    expanded_search_space = search_space
-    for _ in range(times-1):
-        expanded_search_space *= search_space
-    return expanded_search_space

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -27,7 +27,9 @@ from ..data import Dataset
 from ..models import ProbabilisticModel
 from ..space import SearchSpace, Box
 from ..type import QueryPoints
-from .function import AcquisitionFunctionBuilder, ExpectedImprovement
+from .function import (AcquisitionFunctionBuilder,
+                       ExpectedImprovement,
+                       BatchAcquisitionFunctionBuilder)
 from . import _optimizer
 
 
@@ -300,7 +302,7 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
     """ Implements a acquisition rule for a batch of query points """
 
     def __init__(self, num_query_points: int,
-                 builder: AcquisitionFunctionBuilder):
+                 builder: BatchAcquisitionFunctionBuilder):
         """
         :param num_query_points: The number of points to acquire.
         :param builder: The acquisition function builder to use.
@@ -339,8 +341,8 @@ class BatchAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         """
         expanded_search_space = search_space ** self._num_query_points
 
-        acquisition_function = self._builder.prepare_acquisition_function(datasets, models)
-        vectorized_batch_acquisition = self._vectorize_batch_acquisition(acquisition_function)
+        batch_acquisition_function = self._builder.prepare_acquisition_function(datasets, models)
+        vectorized_batch_acquisition = self._vectorize_batch_acquisition(batch_acquisition_function)
 
         vectorized_points = _optimizer.optimize(expanded_search_space, vectorized_batch_acquisition)
         points = tf.reshape(vectorized_points, [self._num_query_points, -1])

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -126,9 +126,9 @@ class DiscreteSearchSpace(SearchSpace):
             array([[0, 1, 4, 5, 6],
                    [0, 1, 7, 8, 9],
                    [2, 3, 4, 5, 6],
-                   [2, 3, 7, 8, 9]])
+                   [2, 3, 7, 8, 9]], dtype=int32)
 
-        :param dss: :class:`DiscreteSearchSpace`.
+        :param other: :class:`DiscreteSearchSpace`.
         :return: the new combined :class:`DiscreteSearchSpace`
         :raise TypeError: If the lhs and rhs :class:`DiscreteSearchSpace` points have different types.
         """

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -177,11 +177,10 @@ class Box(SearchSpace):
         """
         Return the Cartesian product of the two :class:`Box`\ es (concatenating their respective lower and upper bounds).
         :param box: :class:`Box`.
-        :return: the new combined :class:`Box`.
-        :raise ValueError (or InvalidArgumentError): If ``box`` is not from :class:`Box`.
+        :return: the new combined :class:`Box`, or NotImplemented if respective bounds have different dtypes.
         """
         if self.lower.dtype is not box.lower.dtype:
-            raise TypeError(
+            return NotImplemented(
                 f"Bounds of both boxes must have the same dtype, got {self.lower.dtype} and"
                 f" {box.lower.dtype}"
             )

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -62,7 +62,7 @@ class SearchSpace(ABC):
         :raise ValueError: If the exponent ``other`` is less than 1.
         """
         if other < 1:
-            raise ValueError("message here please")
+            raise ValueError("The exponent ``other`` can only be a strictly positive integer")
 
         space = self
         for _ in range(other-1):

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -47,7 +47,7 @@ class SearchSpace(ABC):
         """
 
     @abstractmethod
-    def __mul__(self: Type[SP], other: SP) -> SP:
+    def __mul__(self: SP, other: SP) -> SP:
         """
         TODO
         :param other:

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -171,3 +171,11 @@ class Box(SearchSpace):
             this :class:`Box`.
         """
         return DiscreteSearchSpace(points=self.sample(num_samples))
+
+    def __mul__(self, other_box):
+        if isinstance(other_box, Box):
+            expanded_lower_bound = tf.concat([self._lower, other_box.lower])
+            expanded_upper_bound = tf.concat([self._upper, other_box.upper])
+            return Box(expanded_lower_bound, expanded_upper_bound)
+        else:
+            raise ValueError(f"Box search space can only be concatenated with another box, got {isinstance(other_box)}")

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -173,6 +173,12 @@ class Box(SearchSpace):
         return DiscreteSearchSpace(points=self.sample(num_samples))
 
     def __mul__(self, other_box):
+        """
+        Combines 2 Box spaces into a single one by concatenating their respective lower and upper bounds.
+        :param other_box: :class:`Box`.
+        :return: the new combined :class:`Box`.
+        :raise ValueError (or InvalidArgumentError): If ``other_box`` is not from :class:`Box`.
+        """
         if isinstance(other_box, Box):
             expanded_lower_bound = tf.concat([self._lower, other_box.lower], axis=-1)
             expanded_upper_bound = tf.concat([self._upper, other_box.upper], axis=-1)

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -174,8 +174,8 @@ class Box(SearchSpace):
 
     def __mul__(self, other_box):
         if isinstance(other_box, Box):
-            expanded_lower_bound = tf.concat([self._lower, other_box.lower])
-            expanded_upper_bound = tf.concat([self._upper, other_box.upper])
+            expanded_lower_bound = tf.concat([self._lower, other_box.lower], axis=-1)
+            expanded_upper_bound = tf.concat([self._upper, other_box.upper], axis=-1)
             return Box(expanded_lower_bound, expanded_upper_bound)
         else:
             raise ValueError(f"Box search space can only be concatenated with another box, got {isinstance(other_box)}")

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -62,6 +62,9 @@ class SearchSpace(ABC):
         :return: The Cartesian product of ``other`` instances of this search space.
         :raise ValueError: If the exponent ``other`` is less than 1.
         """
+        if other < 1:
+            raise ValueError("message here please")
+
         space = self
         for _ in range(other-1):
             space *= self

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -175,7 +175,7 @@ class Box(SearchSpace):
 
     def __mul__(self, other_box: Box):
         """
-        Combines 2 Box spaces into a single one by concatenating their respective lower and upper bounds.
+        Return the Cartesian product of the two :class:`Box`\ es (concatenating their respective lower and upper bounds).
         :param other_box: :class:`Box`.
         :return: the new combined :class:`Box`.
         :raise ValueError (or InvalidArgumentError): If ``other_box`` is not from :class:`Box`.

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -119,7 +119,16 @@ class DiscreteSearchSpace(SearchSpace):
 
     def __mul__(self, other: DiscreteSearchSpace) -> DiscreteSearchSpace:
         """
-        Return the Cartesian product of the two :class:`DiscreteSearchSpace`
+        Return the Cartesian product of the two :class:`DiscreteSearchSpace`\ s. For example:
+        
+            >>> sa = DiscreteSearchSpace(tf.constant([[0, 1], [2, 3]]))
+            >>> sb = DiscreteSearchSpace(tf.constant([[4, 5, 6], [7, 8, 9]]))
+            >>> (sa * sb).points.numpy()
+            array([[0, 1, 4, 5, 6],
+                   [0, 1, 7, 8, 9],
+                   [2, 3, 4, 5, 6],
+                   [2, 3, 7, 8, 9]])
+
         :param dss: :class:`DiscreteSearchSpace`.
         :return: the new combined :class:`DiscreteSearchSpace`
         :raise TypeError: If the lhs and rhs :class:`DiscreteSearchSpace` points have different types.

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ This module contains implementations of various types of search space. """
+from __future__ import annotations
 from abc import abstractmethod, ABC
 from typing import Union
 
@@ -172,16 +173,19 @@ class Box(SearchSpace):
         """
         return DiscreteSearchSpace(points=self.sample(num_samples))
 
-    def __mul__(self, other_box):
+    def __mul__(self, other_box: Box):
         """
         Combines 2 Box spaces into a single one by concatenating their respective lower and upper bounds.
         :param other_box: :class:`Box`.
         :return: the new combined :class:`Box`.
         :raise ValueError (or InvalidArgumentError): If ``other_box`` is not from :class:`Box`.
         """
-        if isinstance(other_box, Box):
-            expanded_lower_bound = tf.concat([self._lower, other_box.lower], axis=-1)
-            expanded_upper_bound = tf.concat([self._upper, other_box.upper], axis=-1)
-            return Box(expanded_lower_bound, expanded_upper_bound)
-        else:
-            raise ValueError(f"Box search space can only be concatenated with another box, got {isinstance(other_box)}")
+        if self.lower.dtype is not other_box.lower.dtype:
+            raise TypeError(
+                f"Bounds of both boxes must have the same dtype, got {self.lower.dtype} and"
+                f" {other_box.lower.dtype}"
+            )
+
+        expanded_lower_bound = tf.concat([self._lower, other_box.lower], axis=-1)
+        expanded_upper_bound = tf.concat([self._upper, other_box.upper], axis=-1)
+        return Box(expanded_lower_bound, expanded_upper_bound)

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -54,7 +54,14 @@ class SearchSpace(ABC):
         """
 
     @abstractmethod
-    def __pow__(self: Type[SP], other: int) -> SP:
+    def __pow__(self: SP, other: int) -> SP:
+        """
+        Return the Cartesian product of ``other`` instances of this search space. For example, for an exponent of `3`, and search space `s`, this is `s ** 3`, which is equivalent to `s * s * s`.
+        
+        :param other: The number of instances of this search space to multiply. Must be strictly positive.
+        :return: The Cartesian product of ``other`` instances of this search space.
+        :raise ValueError: If the exponent ``other`` is less than 1.
+        """
         space = self
         for _ in range(other-1):
             space *= self

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -53,7 +53,6 @@ class SearchSpace(ABC):
         :return: The Cartesian product of this search space with ``other``.
         """
 
-    @abstractmethod
     def __pow__(self: SP, other: int) -> SP:
         """
         Return the Cartesian product of ``other`` instances of this search space. For example, for an exponent of `3`, and search space `s`, this is `s ** 3`, which is equivalent to `s * s * s`.
@@ -133,13 +132,13 @@ class DiscreteSearchSpace(SearchSpace):
         :return: the new combined :class:`DiscreteSearchSpace`
         :raise TypeError: If the lhs and rhs :class:`DiscreteSearchSpace` points have different types.
         """
-        if self._points.dtype is not dss._points.dtype:
+        if self._points.dtype is not other._points.dtype:
             return NotImplemented
 
         N = self._points.shape[0]
-        M = dss._points.shape[0]
+        M = other._points.shape[0]
         tile_self = tf.tile(tf.expand_dims(self.points, 1), [1, M, 1])
-        tile_dss = tf.tile(tf.expand_dims(dss.points, 0), [N, 1, 1])
+        tile_dss = tf.tile(tf.expand_dims(other.points, 0), [N, 1, 1])
         cartesian_product = tf.concat([tile_self, tile_dss], axis=2)
 
         return DiscreteSearchSpace(tf.reshape(cartesian_product, [N * M, -1]))
@@ -226,16 +225,16 @@ class Box(SearchSpace):
         """
         return DiscreteSearchSpace(points=self.sample(num_samples))
 
-    def __mul__(self, box: Box) -> Box:
+    def __mul__(self, other: Box) -> Box:
         """
         Return the Cartesian product of the two :class:`Box`\ es (concatenating their respective lower and upper bounds).
         :param box: :class:`Box`.
         :return: the new combined :class:`Box`
         :raise TypeError: If the lhs and rhs :class:`Box` bounds have different types.
         """
-        if self.lower.dtype is not box.lower.dtype:
+        if self.lower.dtype is not other.lower.dtype:
             return NotImplemented
 
-        expanded_lower_bound = tf.concat([self._lower, box.lower], axis=-1)
-        expanded_upper_bound = tf.concat([self._upper, box.upper], axis=-1)
+        expanded_lower_bound = tf.concat([self._lower, other.lower], axis=-1)
+        expanded_upper_bound = tf.concat([self._upper, other.upper], axis=-1)
         return Box(expanded_lower_bound, expanded_upper_bound)

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -48,10 +48,9 @@ class SearchSpace(ABC):
 
     @abstractmethod
     def __mul__(self: SP, other: SP) -> SP:
-        """
-        TODO
-        :param other:
-        :return:
+        """        
+        :param other: A search space of the same type as this search space.
+        :return: The Cartesian product of this search space with ``other``.
         """
 
     @abstractmethod

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -189,7 +189,7 @@ class Box(SearchSpace):
         expanded_upper_bound = tf.concat([self._upper, box.upper], axis=-1)
         return Box(expanded_lower_bound, expanded_upper_bound)
 
-    def __pow__(self, other: int):
+    def __pow__(self, other: int) -> Box:
         expanded_box = self
         for _ in range(other-1):
             expanded_box *= self

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -189,8 +189,8 @@ class Box(SearchSpace):
         expanded_upper_bound = tf.concat([self._upper, box.upper], axis=-1)
         return Box(expanded_lower_bound, expanded_upper_bound)
 
-    def __pow__(self, power: int):
+    def __pow__(self, other: int):
         expanded_box = self
-        for _ in range(power-1):
+        for _ in range(other-1):
             expanded_box *= self
         return expanded_box

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -117,7 +117,7 @@ class DiscreteSearchSpace(SearchSpace):
 
         return tf.random.shuffle(self._points)[:num_samples, :]
 
-    def __mul__(self, dss: DiscreteSearchSpace) -> DiscreteSearchSpace:
+    def __mul__(self, other: DiscreteSearchSpace) -> DiscreteSearchSpace:
         """
         Return the Cartesian product of the two :class:`DiscreteSearchSpace`
         :param dss: :class:`DiscreteSearchSpace`.

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -188,3 +188,9 @@ class Box(SearchSpace):
         expanded_lower_bound = tf.concat([self._lower, box.lower], axis=-1)
         expanded_upper_bound = tf.concat([self._upper, box.upper], axis=-1)
         return Box(expanded_lower_bound, expanded_upper_bound)
+
+    def __pow__(self, power: int):
+        expanded_box = self
+        for _ in range(power-1):
+            expanded_box *= self
+        return expanded_box

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -173,19 +173,19 @@ class Box(SearchSpace):
         """
         return DiscreteSearchSpace(points=self.sample(num_samples))
 
-    def __mul__(self, other_box: Box):
+    def __mul__(self, box: Box):
         """
         Return the Cartesian product of the two :class:`Box`\ es (concatenating their respective lower and upper bounds).
-        :param other_box: :class:`Box`.
+        :param box: :class:`Box`.
         :return: the new combined :class:`Box`.
-        :raise ValueError (or InvalidArgumentError): If ``other_box`` is not from :class:`Box`.
+        :raise ValueError (or InvalidArgumentError): If ``box`` is not from :class:`Box`.
         """
-        if self.lower.dtype is not other_box.lower.dtype:
+        if self.lower.dtype is not box.lower.dtype:
             raise TypeError(
                 f"Bounds of both boxes must have the same dtype, got {self.lower.dtype} and"
-                f" {other_box.lower.dtype}"
+                f" {box.lower.dtype}"
             )
 
-        expanded_lower_bound = tf.concat([self._lower, other_box.lower], axis=-1)
-        expanded_upper_bound = tf.concat([self._upper, other_box.upper], axis=-1)
+        expanded_lower_bound = tf.concat([self._lower, box.lower], axis=-1)
+        expanded_upper_bound = tf.concat([self._upper, box.upper], axis=-1)
         return Box(expanded_lower_bound, expanded_upper_bound)


### PR DESCRIPTION
Creates a new acquisition rule class that returns a batch of query points instead of a single point. 
Requires an acquisition function that accepts batches of points as input, i.e. of shape [..., B, D] (B=batch size, D=search space dimension).
Comes with two tests: one checking that the rule returns a batch of the right size, the other that checks that the rule returns the batch that optimises a dummy batch acquisition function.