### PR TITLE
use tensorflow probability lbfgs optimizer

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -35,8 +35,8 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
 @pytest.mark.parametrize(
     "num_steps, acquisition_rule",
     [
-        (20, EfficientGlobalOptimization()),
-        (15, TrustRegion()),
+        (19, EfficientGlobalOptimization()),
+        (12, TrustRegion()),
         (17, ThompsonSampling(500, 3)),
     ],
 )


### PR DESCRIPTION
This PR changes the acquisition optimizer from scipy's L-BFGS-B to TensorFlow Probability's L-BFGS. This changes the performance of the integration tests, and thus presumably trieste in general (individual BO steps take longer, but fewer steps are needed). This also has the benefit of moving down the dependency tree.

Q: We already map the constrained optimization problem to an unconstrained one (using tfp bijectors), so L-BFGS-B is unnecessary and L-BFGS will suffice. Is this true? If not, do we indeed need the -B version?