### PR TITLE
add astuple method to Dataset

### DIFF
--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -54,12 +54,10 @@ initial_data = observer(initial_query_points)
 # Just like the data output by the observer, the optimization process assumes multiple models, so we'll need to label the model in the same way.
 
 # %%
-from dataclasses import astuple
-
 def build_model(data):
     variance = tf.math.reduce_variance(data.observations)
     kernel = gpflow.kernels.Matern52(variance=variance, lengthscales=0.2 * np.ones(2,))
-    gpr = gpflow.models.GPR(astuple(data), kernel, noise_variance=1e-5)
+    gpr = gpflow.models.GPR(data.astuple(), kernel, noise_variance=1e-5)
     gpflow.set_trainable(gpr.likelihood, False)
 
     return {OBJECTIVE: trieste.models.create_model({

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -86,12 +86,10 @@ initial_data = observer(search_space.sample(num_init_points))
 # We'll model the data on the objective with a regression model, and the data on which points failed with a classification model. The regression model will be a `GaussianProcessRegression` wrapping a GPflow `GPR`, and the classification model a `VariationalGaussianProcess` wrapping a GPflow `VGP` with Bernoulli likelihood.
 
 # %%
-from dataclasses import astuple
-
 def create_regression_model(data):
     variance = tf.math.reduce_variance(data.observations)
     kernel = gpflow.kernels.Matern52(variance=variance, lengthscales=0.2 * np.ones(2))
-    gpr = gpflow.models.GPR(astuple(data), kernel, noise_variance=1e-5)
+    gpr = gpflow.models.GPR(data.astuple(), kernel, noise_variance=1e-5)
     gpflow.set_trainable(gpr.likelihood, False)
     return gpr
 
@@ -99,7 +97,7 @@ def create_regression_model(data):
 def create_classification_model(data):
     kernel = gpflow.kernels.SquaredExponential(variance=100.0, lengthscales=0.2 * np.ones(2))
     likelihood = gpflow.likelihoods.Bernoulli()
-    vgp = gpflow.models.VGP(astuple(data), kernel, likelihood)
+    vgp = gpflow.models.VGP(data.astuple(), kernel, likelihood)
     gpflow.set_trainable(vgp.kernel.variance, False)
     return vgp
 

--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -70,14 +70,13 @@ initial_data = observer(search_space.sample(5))
 # ... and visualise those points on the constrained objective.
 
 # %%
-from dataclasses import astuple
 from util.inequality_constraints_utils import plot_init_query_points
 
 plot_init_query_points(
     search_space,
     Sim,
-    astuple(initial_data[OBJECTIVE]),
-    astuple(initial_data[CONSTRAINT]),
+    initial_data[OBJECTIVE].astuple(),
+    initial_data[CONSTRAINT].astuple(),
 )
 plt.show()
 
@@ -91,7 +90,7 @@ def create_bo_model(data):
     variance = tf.math.reduce_variance(initial_data[OBJECTIVE].observations)
     lengthscale = 1.0 * np.ones(2, dtype=gpflow.default_float())
     kernel = gpflow.kernels.Matern52(variance=variance, lengthscales=lengthscale)
-    gpr = gpflow.models.GPR(astuple(data), kernel, noise_variance=1e-5)
+    gpr = gpflow.models.GPR(data.astuple(), kernel, noise_variance=1e-5)
     gpflow.set_trainable(gpr.likelihood, False)
     return trieste.models.create_model(
         {
@@ -143,8 +142,8 @@ new_data = (new_query_points, new_observations)
 plot_init_query_points(
     search_space,
     Sim,
-    astuple(initial_data[OBJECTIVE]),
-    astuple(initial_data[CONSTRAINT]),
+    initial_data[OBJECTIVE].astuple(),
+    initial_data[CONSTRAINT].astuple(),
     new_data,
 )
 plt.show()

--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -34,11 +34,9 @@ initial_data = observer(initial_query_points)
 # We'll use Gaussian process regression to model the function.
 
 # %%
-from dataclasses import astuple
-
 observations = initial_data[OBJECTIVE].observations
 kernel = gpflow.kernels.Matern52(tf.math.reduce_variance(observations), [0.2, 0.2])
-gpr = gpflow.models.GPR(astuple(initial_data[OBJECTIVE]), kernel, noise_variance=1e-5)
+gpr = gpflow.models.GPR(initial_data[OBJECTIVE].astuple(), kernel, noise_variance=1e-5)
 gpflow.set_trainable(gpr.likelihood, False)
 
 model_config = {

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -351,7 +351,7 @@ def test_sparse_variational_optimize_with_defaults() -> None:
 
 
 def _batcher_1(dataset: Dataset, batch_size: int) -> Iterable:
-    ds = tf.data.Dataset.from_tensor_slices(astuple(dataset))
+    ds = tf.data.Dataset.from_tensor_slices(dataset.astuple())
     ds = ds.shuffle(100)
     ds = ds.batch(batch_size)
     ds = ds.repeat()
@@ -359,7 +359,7 @@ def _batcher_1(dataset: Dataset, batch_size: int) -> Iterable:
 
 
 def _batcher_2(dataset: Dataset, batch_size: int):
-    return astuple(dataset)
+    return dataset.astuple()
 
 
 @pytest.mark.parametrize("compile", [True, False])

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -21,7 +21,6 @@ encapsulation. For example, we should *not* test that methods on the GPflow mode
 (except in the rare case that such behaviour is an explicitly documented behaviour of the
 trieste model).
 """
-from dataclasses import astuple
 from typing import Callable, Iterable, Optional, Tuple, Type, Union
 
 import gpflow

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -188,3 +188,10 @@ def test_dataset_length(data: Dataset, length: int) -> None:
 def test_dataset_deepcopy() -> None:
     data = Dataset(tf.constant([[0.0, 1.0]]), tf.constant([[2.0]]))
     assert_datasets_allclose(data, copy.deepcopy(data))
+
+
+def test_dataset_astuple() -> None:
+    qp, obs = tf.constant([[0.0]]), tf.constant([[1.0]])
+    qp_from_astuple, obs_from_astuple = Dataset(qp, obs).astuple()
+    assert qp_from_astuple is qp
+    assert obs_from_astuple is obs

--- a/trieste/data.py
+++ b/trieste/data.py
@@ -97,6 +97,9 @@ class Dataset:
 
     def astuple(self) -> Tuple[tf.Tensor, tf.Tensor]:
         """
+        **Note:** Unlike the standard library function `dataclasses.astuple`, this method does
+        **not** deepcopy the attributes.
+
         :return: A 2-tuple of the :attr:`query_points` and :attr:`observations`.
         """
         return self.query_points, self.observations

--- a/trieste/data.py
+++ b/trieste/data.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Tuple
 
 import tensorflow as tf
 
@@ -94,3 +94,9 @@ class Dataset:
 
     def __deepcopy__(self, memo: Dict[int, object]) -> Dataset:
         return self
+
+    def astuple(self) -> Tuple[tf.Tensor, tf.Tensor]:
+        """
+        :return: A 2-tuple of the :attr:`query_points` and :attr:`observations`.
+        """
+        return self.query_points, self.observations


### PR DESCRIPTION
according to [this SO post](https://stackoverflow.com/q/51802109/5986907) `dataclasses.astuple` deepcopies dataclass attributes. This is unnecessary and expensive for large datasets. This PR adds an `astuple` method instead.

Note we could instead make `Dataset` a `NamedTuple` with a custom `__new__` but that would change the meaning of `__len__` so I didn't do that in this PR