### PR TITLE
move imports to body in notebooks

### DIFF
--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -2,11 +2,9 @@
 # # EGO with a failure region
 
 # %%
-import gpflow
 import numpy as np
 import tensorflow as tf
 
-gpflow.config.set_default_jitter(1e-5)
 np.random.seed(1234)
 tf.random.set_seed(1234)
 
@@ -30,6 +28,8 @@ def masked_branin(x):
 # As mentioned, we'll search over the hypercube $[0, 1]^2$ ...
 
 # %%
+import gpflow
+
 mins = [0.0, 0.0]
 maxs = [1.0, 1.0]
 

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -7,7 +7,6 @@ import numpy as np
 import tensorflow as tf
 
 gpflow.config.set_default_jitter(1e-5)
-gpflow.config.set_default_float(np.float64)
 np.random.seed(1234)
 tf.random.set_seed(1234)
 

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -113,15 +113,13 @@ classification_model = create_classification_model(initial_data[FAILURE])
 # The new `NatGradTrainedVGP` class has a custom `optimize` method that alternates between Adam steps to optimize the lengthscales and NatGrad steps to optimize the variational parameters:
 
 # %%
-from gpflow.optimizers import NaturalGradient
-
 class NatGradTrainedVGP(trieste.models.VariationalGaussianProcess):
     def optimize(self, dataset):
         gpflow.set_trainable(self.model.q_mu, False)
         gpflow.set_trainable(self.model.q_sqrt, False)
         variational_params = [(self.model.q_mu, self.model.q_sqrt)]
         adam_opt = tf.optimizers.Adam(1e-3)
-        natgrad_opt = NaturalGradient(gamma=0.1)
+        natgrad_opt = gpflow.optimizers.NaturalGradient(gamma=0.1)
 
         for step in range(100):
             natgrad_opt.minimize(self.model.training_loss, var_list=variational_params)

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -81,7 +81,6 @@ def observer(x):
 num_init_points = 15
 initial_data = observer(search_space.sample(num_init_points))
 
-
 # %% [markdown]
 # ## Model the data
 #

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -194,7 +194,6 @@ plt.show()
 # We can also plot the mean and variance of the predictive distribution over the search space, first for the objective data and model ...
 
 # %%
-
 from util.plotting_plotly import plot_gp_plotly, add_bo_points_plotly
 
 arg_min_idx = tf.squeeze(tf.argmin(final_data[OBJECTIVE].observations, axis=0))

--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -42,9 +42,9 @@ search_space = trieste.space.Box(
 
 # %%
 import matplotlib.pyplot as plt
-from util import inequality_constraints_utils as util
+from util.inequality_constraints_utils import plot_objective_and_constraints
 
-util.plot_objective_and_constraints(search_space, Sim)
+plot_objective_and_constraints(search_space, Sim)
 plt.show()
 
 # %% [markdown]
@@ -60,7 +60,6 @@ def observer(query_points):
         CONSTRAINT: trieste.data.Dataset(query_points, Sim.constraint(query_points)),
     }
 
-
 # %% [markdown]
 # Let's randomly sample some initial data from the observer ...
 
@@ -72,8 +71,9 @@ initial_data = observer(search_space.sample(5))
 
 # %%
 from dataclasses import astuple
+from util.inequality_constraints_utils import plot_init_query_points
 
-util.plot_init_query_points(
+plot_init_query_points(
     search_space,
     Sim,
     astuple(initial_data[OBJECTIVE]),
@@ -102,7 +102,6 @@ def create_bo_model(data):
             },
         }
     )
-
 
 models = {
     OBJECTIVE: create_bo_model(initial_data[OBJECTIVE]),
@@ -141,7 +140,7 @@ new_query_points = constraint_data.query_points[-num_steps:]
 new_observations = constraint_data.observations[-num_steps:]
 new_data = (new_query_points, new_observations)
 
-util.plot_init_query_points(
+plot_init_query_points(
     search_space,
     Sim,
     astuple(initial_data[OBJECTIVE]),

--- a/docs/notebooks/introduction.pct.py
+++ b/docs/notebooks/introduction.pct.py
@@ -2,11 +2,9 @@
 # # Introduction
 
 # %%
-import gpflow
 import numpy as np
 import tensorflow as tf
 
-gpflow.config.set_default_float(np.float64)
 np.random.seed(1793)
 tf.random.set_seed(1793)
 
@@ -35,6 +33,7 @@ fig.show()
 # %%
 import trieste
 from trieste.acquisition.rule import OBJECTIVE
+import gpflow
 
 observer = trieste.utils.objectives.mk_observer(branin, OBJECTIVE)
 lower_bound = tf.cast(mins, gpflow.default_float())

--- a/docs/notebooks/introduction.pct.py
+++ b/docs/notebooks/introduction.pct.py
@@ -2,24 +2,10 @@
 # # Introduction
 
 # %%
-from dataclasses import astuple
-
 import gpflow
-from gpflow.utilities import print_summary, set_trainable
 import numpy as np
 import tensorflow as tf
 
-import trieste
-from trieste.bayesian_optimizer import OptimizationResult
-from trieste.utils.objectives import branin, mk_observer
-from trieste.acquisition.rule import OBJECTIVE
-
-from util.plotting_plotly import (
-    plot_function_plotly, plot_gp_plotly, add_bo_points_plotly
-)
-from util.plotting import plot_function_2d, plot_bo_points, plot_regret
-
-# %%
 gpflow.config.set_default_float(np.float64)
 np.random.seed(1793)
 tf.random.set_seed(1793)
@@ -29,6 +15,9 @@ tf.random.set_seed(1793)
 # In this example, we look to find the minimum value of the two-dimensional Branin function over the hypercube $[0, 1]^2$. We can plot contours of the Branin over this space.
 
 # %%
+from trieste.utils.objectives import branin
+from util.plotting_plotly import plot_function_plotly
+
 mins = [0.0, 0.0]
 maxs = [1.0, 1.0]
 
@@ -44,7 +33,10 @@ fig.show()
 # The optimization procedure will benefit from having some starting data from the objective function to base its search on. We sample five points from the search space and evaluate them on the observer. We can represent the search space using a `Box`.
 
 # %%
-observer = mk_observer(branin, OBJECTIVE)
+import trieste
+from trieste.acquisition.rule import OBJECTIVE
+
+observer = trieste.utils.objectives.mk_observer(branin, OBJECTIVE)
 lower_bound = tf.cast(mins, gpflow.default_float())
 upper_bound = tf.cast(maxs, gpflow.default_float())
 search_space = trieste.space.Box(lower_bound, upper_bound)
@@ -63,11 +55,13 @@ initial_data = observer(initial_query_points)
 # Just like the data output by the observer, the optimization process assumes multiple models, so we'll need to label the model in the same way.
 
 # %%
+from dataclasses import astuple
+
 def build_model(data):
     variance = tf.math.reduce_variance(data.observations)
     kernel = gpflow.kernels.Matern52(variance=variance, lengthscales=0.2 * np.ones(2,))
     gpr = gpflow.models.GPR(astuple(data), kernel, noise_variance=1e-5)
-    set_trainable(gpr.likelihood, False)
+    gpflow.set_trainable(gpr.likelihood, False)
 
     return {OBJECTIVE: trieste.models.create_model({
         "model": gpr,
@@ -93,6 +87,8 @@ model = build_model(initial_data[OBJECTIVE])
 # However, since the optimization loop catches errors so as not to lose progress, we must check if any errors occurred so we know the data is valid. We'll do that crudely here by re-raising any such errors. You may wish instead to use the history to restore the process from an earlier point.
 
 # %%
+from trieste.bayesian_optimizer import OptimizationResult
+
 bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
 
 result: OptimizationResult = bo.optimize(15, initial_data, model)
@@ -119,6 +115,8 @@ print(f"observation: {observations[arg_min_idx, :]}")
 # We can visualise how the optimizer performed by plotting all the acquired observations, along with the true function values and optima, either in a two-dimensional contour plot ...
 
 # %%
+from util.plotting import plot_function_2d, plot_bo_points
+
 _, ax = plot_function_2d(branin, mins, maxs, grid_density=30, contour=True)
 plot_bo_points(query_points, ax[0, 0], num_initial_points, arg_min_idx)
 
@@ -126,6 +124,8 @@ plot_bo_points(query_points, ax[0, 0], num_initial_points, arg_min_idx)
 # ... or as a three-dimensional plot
 
 # %%
+from util.plotting_plotly import add_bo_points_plotly
+
 fig = plot_function_plotly(branin, mins, maxs, grid_density=20)
 fig.update_layout(height=500, width=500)
 
@@ -146,6 +146,7 @@ fig.show()
 
 # %%
 import matplotlib.pyplot as plt
+from util.plotting import plot_regret
 
 _, ax = plt.subplots(1, 2)
 plot_regret(observations, ax[0], num_init=num_initial_points, idx_best=arg_min_idx)
@@ -155,6 +156,8 @@ plot_bo_points(query_points, ax[1], num_init=num_initial_points, idx_best=arg_mi
 # We can visualise the model over the objective function by plotting the mean and 95% confidence intervals of its predictive distribution.
 
 # %%
+from util.plotting_plotly import plot_gp_plotly
+
 fig = plot_gp_plotly(model[OBJECTIVE].model, mins, maxs, grid_density=30)
 
 fig = add_bo_points_plotly(
@@ -174,7 +177,7 @@ fig.show()
 # We can also inspect the model hyperparameters, and use the history to see how the length scales evolved over iterations
 
 # %%
-print_summary(model[OBJECTIVE].model)
+gpflow.utilities.print_summary(model[OBJECTIVE].model)
 
 ls_list = [
     step.models[OBJECTIVE].model.kernel.lengthscales.numpy()  # type: ignore

--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -2,10 +2,10 @@
 # # Optimization with Thompson sampling
 
 # %%
-import gpflow
+import numpy as np
 import tensorflow as tf
 
-gpflow.config.set_default_float(tf.float64)
+np.random.seed(1793)
 tf.random.set_seed(1793)
 
 # %% [markdown]
@@ -19,6 +19,7 @@ tf.random.set_seed(1793)
 import trieste
 from trieste.utils.objectives import branin
 from trieste.acquisition.rule import OBJECTIVE
+import gpflow
 
 lower_bound = tf.constant([0.0, 0.0], gpflow.default_float())
 upper_bound = tf.constant([1.0, 1.0], gpflow.default_float())


### PR DESCRIPTION
When I learnt how to use numpy, pandas etc., the tutorials only imported libraries when it used them, rather than at the start of the notebook. This made it clear what is needed when and why. In this PR I've done that to the notebooks.