### PR TITLE
support lists as bound args for box

### DIFF
--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -33,9 +33,7 @@ class Sim:
         return z[:, None]
 
 
-search_space = trieste.space.Box(
-    tf.cast([0.0, 0.0], gpflow.default_float()), tf.cast([6.0, 6.0], gpflow.default_float())
-)
+search_space = trieste.space.Box([0, 0], [6, 6])
 
 # %% [markdown]
 # The objective and constraint functions are accessible as methods on the `Sim` class. Let's visualise these functions, as well as the constrained objective formed by applying a mask to the objective over regions where the constraint function crosses the threshold.

--- a/docs/notebooks/util/plotting.py
+++ b/docs/notebooks/util/plotting.py
@@ -16,10 +16,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import cm
 
+from trieste.type import TensorType
 from trieste.utils import to_numpy
 
 
-def create_grid(mins, maxs, grid_density=20):
+def create_grid(mins: TensorType, maxs: TensorType, grid_density=20):
     """
     Creates a regular 2D grid of size grid_density*grid_density between mins and maxs.
     :param mins: list of 2 lower bounds
@@ -63,8 +64,8 @@ def plot_surface(xx, yy, f, ax, contour=False, alpha=1.0):
 
 def plot_function_2d(
     obj_func,
-    mins,
-    maxs,
+    mins: TensorType,
+    maxs: TensorType,
     grid_density=20,
     contour=False,
     log=False,
@@ -86,6 +87,8 @@ def plot_function_2d(
     :param ylabel:
     :param figsize:
     """
+    mins = to_numpy(mins)
+    maxs = to_numpy(maxs)
 
     # Create a regular grid on the parameter space
     Xplot, xx, yy = create_grid(mins=mins, maxs=maxs, grid_density=grid_density)
@@ -250,8 +253,8 @@ def plot_regret(
 
 def plot_gp_2d(
     model,
-    mins,
-    maxs,
+    mins: TensorType,
+    maxs: TensorType,
     grid_density=20,
     contour=False,
     xlabel=None,
@@ -270,6 +273,8 @@ def plot_gp_2d(
     :param ylabel: optional string
     :param figsize:
     """
+    mins = to_numpy(mins)
+    maxs = to_numpy(maxs)
 
     # Create a regular grid on the parameter space
     Xplot, xx, yy = create_grid(mins=mins, maxs=maxs, grid_density=grid_density)

--- a/docs/notebooks/util/plotting.py
+++ b/docs/notebooks/util/plotting.py
@@ -15,6 +15,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import cm
+import tensorflow as tf
 
 from trieste.type import TensorType
 from trieste.utils import to_numpy
@@ -22,12 +23,14 @@ from trieste.utils import to_numpy
 
 def create_grid(mins: TensorType, maxs: TensorType, grid_density=20):
     """
-    Creates a regular 2D grid of size grid_density*grid_density between mins and maxs.
+    Creates a regular 2D grid of size `grid_density^2` between mins and maxs.
     :param mins: list of 2 lower bounds
     :param maxs: list of 2 upper bounds
     :param grid_density: scalar
     :return: Xplot [grid_density**2, 2], xx, yy from meshgrid for the specific formatting of contour / surface plots
     """
+    tf.debugging.assert_shapes([(mins, [2]), (maxs, [2])])
+
     xspaced = np.linspace(mins[0], maxs[0], grid_density)
     yspaced = np.linspace(mins[1], maxs[1], grid_density)
     xx, yy = np.meshgrid(xspaced, yspaced)
@@ -77,8 +80,8 @@ def plot_function_2d(
     """
     2D/3D plot of an obj_func for a grid of size grid_density**2 between mins and maxs
     :param obj_func: a function that returns a n-array given a [n, d] array
-    :param mins: list of 2 lower bounds
-    :param maxs: list of 2 upper bounds
+    :param mins: 2 lower bounds
+    :param maxs: 2 upper bounds
     :param grid_density: positive integer for the grid size
     :param contour: Boolean. If False, a 3d plot is produced
     :param log: Boolean. If True, the log transformation (log(f - min(f) + 0.1)) is applied
@@ -265,8 +268,8 @@ def plot_gp_2d(
     """
     2D/3D plot of a gp model for a grid of size grid_density**2 between mins and maxs
     :param model: a gpflow model
-    :param mins: list of 2 lower bounds
-    :param maxs: list of 2 upper bounds
+    :param mins: 2 lower bounds
+    :param maxs: 2 upper bounds
     :param grid_density: positive integer for the grid size
     :param contour: Boolean. If False, a 3d plot is produced
     :param xlabel: optional string

--- a/docs/notebooks/util/plotting_plotly.py
+++ b/docs/notebooks/util/plotting_plotly.py
@@ -17,6 +17,7 @@ import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
+from trieste.type import TensorType
 from trieste.utils import to_numpy
 
 from .plotting import create_grid
@@ -114,7 +115,7 @@ def add_bo_points_plotly(x, y, z, fig, num_init, idx_best=None, mask_fail=None, 
     return fig
 
 
-def plot_gp_plotly(model, mins, maxs, grid_density=20):
+def plot_gp_plotly(model, mins: TensorType, maxs: TensorType, grid_density=20):
     """
 
     :param model: a gpflow model
@@ -123,6 +124,8 @@ def plot_gp_plotly(model, mins, maxs, grid_density=20):
     :param grid_density: integer (grid size)
     :return: a plotly figure
     """
+    mins = to_numpy(mins)
+    maxs = to_numpy(maxs)
 
     # Create a regular grid on the parameter space
     Xplot, xx, yy = create_grid(mins=mins, maxs=maxs, grid_density=grid_density)
@@ -151,7 +154,14 @@ def plot_gp_plotly(model, mins, maxs, grid_density=20):
 
 
 def plot_function_plotly(
-    obj_func, mins, maxs, grid_density=20, title=None, xlabel=None, ylabel=None, alpha=1.0
+    obj_func,
+    mins: TensorType,
+    maxs: TensorType,
+    grid_density=20,
+    title=None,
+    xlabel=None,
+    ylabel=None,
+    alpha=1.0,
 ):
     """
     Draws an objective function.

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import gpflow
-import numpy as np
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
@@ -50,7 +48,7 @@ from trieste.utils.objectives import (
 def test_optimizer_finds_minima_of_the_branin_function(
     num_steps: int, acquisition_rule: AcquisitionRule
 ) -> None:
-    search_space = Box(np.array([0.0, 0.0]), np.array([1.0, 1.0]))
+    search_space = Box([0, 0], [1, 1])
 
     def build_model(data: Dataset) -> GaussianProcessRegression:
         variance = tf.math.reduce_variance(data.observations)

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-from typing import List, Tuple
+import itertools
+from typing import Container, FrozenSet, Tuple
 
 import numpy.testing as npt
 import pytest
@@ -126,37 +127,47 @@ def test_discrete_search_space_deepcopy() -> None:
     npt.assert_allclose(copy.deepcopy(dss).points, _points_in_2D_search_space())
 
 
-def _pairs_of_different_shapes() -> List[Tuple[ShapeLike, ShapeLike]]:
-    return [
-        ((), (1,)),
-        ((1,), (1, 2)),
-        ((1, 2), (1, 2, 3)),
-    ]
+def test_box_converts_lists_to_float64_tensors() -> None:
+    box = Box([0.0], [1.0])
+    assert box.lower.dtype is tf.float64
+    assert box.upper.dtype is tf.float64
+    npt.assert_array_equal(box.lower, [0.0])
+    npt.assert_array_equal(box.upper, [1.0])
 
 
-@pytest.mark.parametrize("lower_shape, upper_shape", _pairs_of_different_shapes())
-def test_box_raises_if_bounds_have_different_shape(
+def _pairs_of_shapes(
+    *, excluding_ranks: Container[int] = ()
+) -> FrozenSet[Tuple[ShapeLike, ShapeLike]]:
+    shapes = various_shapes(excluding_ranks=excluding_ranks)
+    return frozenset(itertools.product(shapes, shapes))
+
+
+@pytest.mark.parametrize(
+    "lower_shape, upper_shape", _pairs_of_shapes(excluding_ranks={1}) | {((1,), (2,)), ((0,), (0,))}
+)
+def test_box_raises_if_bounds_have_invalid_shape(
     lower_shape: ShapeLike, upper_shape: ShapeLike
 ) -> None:
     lower, upper = tf.zeros(lower_shape), tf.ones(upper_shape)
 
-    with pytest.raises(ValueError, match="bound"):
+    with pytest.raises(ValueError):
         Box(lower, upper)
 
 
 @pytest.mark.parametrize(
     "lower_dtype, upper_dtype",
     [
-        (tf.int8, tf.uint16),
+        (tf.uint32, tf.uint32),  # same dtypes
+        (tf.int8, tf.uint16),  # different dtypes ...
         (tf.uint32, tf.float32),
         (tf.float32, tf.float64),
         (tf.float64, tf.bfloat16),
     ],
 )
-def test_box_raises_if_bounds_have_different_dtypes(
-    lower_dtype: Tuple[tf.DType, tf.DType], upper_dtype: Tuple[tf.DType, tf.DType]
+def test_box_raises_if_bounds_have_invalid_dtypes(
+    lower_dtype: tf.DType, upper_dtype: tf.DType
 ) -> None:
-    lower, upper = tf.zeros((1, 2), dtype=lower_dtype), tf.ones((1, 2), dtype=upper_dtype)
+    lower, upper = tf.zeros([3], dtype=lower_dtype), tf.ones([3], dtype=upper_dtype)
 
     with pytest.raises(TypeError, match="dtype"):
         Box(lower, upper)
@@ -177,7 +188,7 @@ def test_box_raises_if_bounds_have_different_dtypes(
 def test_box_raises_if_any_lower_bound_is_not_less_than_upper_bound(
     lower: tf.Tensor, upper: tf.Tensor
 ) -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, tf.errors.InvalidArgumentError)):
         Box(lower, upper)
 
 
@@ -213,7 +224,10 @@ def test_box_does_not_contain_point(point: tf.Tensor) -> None:
     assert point not in Box(tf.constant([-1.0, 0.0, -2.0]), tf.constant([2.0, 1.0, -0.5]))
 
 
-@pytest.mark.parametrize("bound_shape, point_shape", _pairs_of_different_shapes())
+@pytest.mark.parametrize(
+    "bound_shape, point_shape",
+    ((bs, ps) for bs, ps in _pairs_of_shapes() if bs != ps and len(bs) == 1 and bs != (0,)),
+)
 def test_box_contains_raises_on_point_of_different_shape(
     bound_shape: ShapeLike,
     point_shape: ShapeLike,

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -169,7 +169,7 @@ def test_box_raises_if_bounds_have_invalid_dtypes(
 ) -> None:
     lower, upper = tf.zeros([3], dtype=lower_dtype), tf.ones([3], dtype=upper_dtype)
 
-    with pytest.raises(TypeError, match="dtype"):
+    with pytest.raises((ValueError, tf.errors.InvalidArgumentError)):
         Box(lower, upper)
 
 

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -129,8 +129,8 @@ def test_discrete_search_space_deepcopy() -> None:
 
 def test_box_converts_lists_to_float64_tensors() -> None:
     box = Box([0.0], [1.0])
-    assert box.lower.dtype is tf.float64
-    assert box.upper.dtype is tf.float64
+    assert tf.as_dtype(box.lower.dtype) is tf.float64
+    assert tf.as_dtype(box.upper.dtype) is tf.float64
     npt.assert_array_equal(box.lower, [0.0])
     npt.assert_array_equal(box.upper, [1.0])
 

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -137,11 +137,13 @@ def various_shapes(*, excluding_ranks: Container[int] = ()) -> FrozenSet[Tuple[i
     :return: A reasonably comprehensive variety of tensor shapes, where no shapes will have a rank
         in ``excluding_ranks``.
     """
-    shapes = {
-        # fmt: off
-        (), (0,), (1,), (0, 0), (1, 0), (0, 1), (3, 4), (1, 0, 3), (1, 2, 3), (1, 2, 3, 4, 5, 6),
-        # fmt: on
-    }
+    shapes = (
+        {()}
+        | {(0,), (1,), (3,)}
+        | {(0, 0), (1, 0), (0, 1), (3, 4)}
+        | {(1, 0, 3), (1, 2, 3)}
+        | {(1, 2, 3, 4, 5, 6)}
+    )
     return frozenset(s for s in shapes if len(s) not in excluding_ranks)
 
 


### PR DESCRIPTION
The most important thing about this PR is that it assumes a default float type for trieste of `tf.float64`. The plan is to use f64 for now, as the global default, and consider what to do with f32 later