### PR TITLE
use minimal license in notebooks

### DIFF
--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -1,19 +1,4 @@
 # %% [markdown]
-# Copyright 2020 The Trieste Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# %% [markdown]
 # # EGO with a failure region
 
 # %%
@@ -260,3 +245,8 @@ plot_bo_points(
 )
 
 plt.show()
+
+# %% [markdown]
+# LICENSE
+#
+# [Apache License 2.0](LICENSE)

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -247,6 +247,6 @@ plot_bo_points(
 plt.show()
 
 # %% [markdown]
-# LICENSE
+# ## LICENSE
 #
 # [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -249,4 +249,4 @@ plt.show()
 # %% [markdown]
 # LICENSE
 #
-# [Apache License 2.0](LICENSE)
+# [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -1,19 +1,4 @@
 # %% [markdown]
-# Copyright 2020 The Trieste Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# %% [markdown]
 # # Inequality constraints: constrained optimization
 
 # %%
@@ -185,3 +170,8 @@ plt.show()
 #       url={http://proceedings.mlr.press/v32/gardner14.html},
 #     }
 # ```
+
+# %% [markdown]
+# LICENSE
+#
+# [Apache License 2.0](LICENSE)

--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -172,6 +172,6 @@ plt.show()
 # ```
 
 # %% [markdown]
-# LICENSE
+# ## LICENSE
 #
 # [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -174,4 +174,4 @@ plt.show()
 # %% [markdown]
 # LICENSE
 #
-# [Apache License 2.0](LICENSE)
+# [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/docs/notebooks/introduction.pct.py
+++ b/docs/notebooks/introduction.pct.py
@@ -208,6 +208,6 @@ plot_bo_points(
 )
 
 # %% [markdown]
-# LICENSE
+# ## LICENSE
 #
 # [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/docs/notebooks/introduction.pct.py
+++ b/docs/notebooks/introduction.pct.py
@@ -1,19 +1,4 @@
 # %% [markdown]
-# Copyright 2020 The Trieste Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# %% [markdown]
 # # Introduction
 
 # %%
@@ -221,3 +206,8 @@ plot_bo_points(
     num_init=len(dataset.query_points),
     idx_best=arg_min_idx,
 )
+
+# %% [markdown]
+# LICENSE
+#
+# [Apache License 2.0](LICENSE)

--- a/docs/notebooks/introduction.pct.py
+++ b/docs/notebooks/introduction.pct.py
@@ -210,4 +210,4 @@ plot_bo_points(
 # %% [markdown]
 # LICENSE
 #
-# [Apache License 2.0](LICENSE)
+# [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -112,6 +112,6 @@ fig = add_bo_points_plotly(
 fig.show()
 
 # %% [markdown]
-# LICENSE
+# ## LICENSE
 #
 # [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -114,4 +114,4 @@ fig.show()
 # %% [markdown]
 # LICENSE
 #
-# [Apache License 2.0](LICENSE)
+# [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -1,19 +1,4 @@
 # %% [markdown]
-# Copyright 2020 The Trieste Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# %% [markdown]
 # # Optimization with Thompson sampling
 
 # %%
@@ -125,3 +110,8 @@ fig = add_bo_points_plotly(
     figcol=1,
 )
 fig.show()
+
+# %% [markdown]
+# LICENSE
+#
+# [Apache License 2.0](LICENSE)


### PR DESCRIPTION
The license headers in the notebooks are somewhat imposing and distract from the content. This PR replaces them with a simple reference to the license at the bottom of the file instead