### PR TITLE
add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/secondmind-labs/trieste",
     packages=find_packages(include=("trieste*",)),
+    package_data={
+        "trieste": ["py.typed"],
+    },
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
`py.typed` tells `mypy` to follow imports into this package, allowing users of the package to find more bugs with `mypy`.

Further reading:
https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages
https://www.python.org/dev/peps/pep-0561/#packaging-type-information

Fixes #103