### PR TITLE
add batch EI example to tutorials

### DIFF
--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -207,7 +207,7 @@ plot_bo_points(
 # Sometimes it is practically convenient to query several points at a time. We can do this in `trieste` using `BatchMonteCarloExpectedImprovement`. Note that this acquisition is computed using a Monte-Carlo method (so it requires a `sample_size`), but with a reparametrisation trick, which makes it deterministic. To use it, we change the acquisition rule and specify the number of query points (`num_query_points`) to be chosen, then observed simultaneously:
 
 # %%
-qei = trieste.acquisition.BatchMonteCarloExpectedImprovement(sample_size=100)
+qei = trieste.acquisition.BatchMonteCarloExpectedImprovement(sample_size=1000)
 batch_rule = trieste.acquisition.rule.BatchAcquisitionRule(num_query_points=3, builder=qei.using(OBJECTIVE))
 
 batch_bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)

--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -204,7 +204,7 @@ plot_bo_points(
 # %% [markdown]
 # ## Batch-sequential strategy
 #
-# Sometimes it is practically more efficient to query several points at a time. We can do this in `trieste` using `BatchMonteCarloExpectedImprovement`. Note that this acquisition is computed using a Monte-Carlo method, but with a reparametrisation trick, which makes it deterministic. To use, it we change the acquisition rule:
+# Sometimes it is practically convenient to query several points at a time. We can do this in `trieste` using `BatchMonteCarloExpectedImprovement`. Note that this acquisition is computed using a Monte-Carlo method (so it requires a `sample_size`), but with a reparametrisation trick, which makes it deterministic. To use it, we change the acquisition rule and specify the number of query points (`num_query_points`) to be chosen, then observed simultaneously:
 
 # %%
 qei = trieste.acquisition.BatchMonteCarloExpectedImprovement(sample_size=100)
@@ -218,7 +218,7 @@ batch_query_points = batch_dataset.query_points.numpy()
 batch_observations = batch_dataset.observations.numpy()
 
 # %% [markdown]
-# We can visualise again the model and query points.
+# We can visualise again the GP model and query points.
 
 # %%
 fig = plot_gp_plotly(

--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -242,7 +242,7 @@ fig = add_bo_points_plotly(
 fig.show()
 
 # %% [markdown]
-# We can also compare the regrets between the purely sequential approach and the batch one. 
+# We can also compare the regret between the purely sequential approach and the batch one. 
 
 # %%
 _, ax = plt.subplots(1, 2)

--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -213,14 +213,14 @@ batch_rule = trieste.acquisition.rule.BatchAcquisitionRule(num_query_points=3, b
 
 model = build_model(initial_data[OBJECTIVE])
 batch_result = bo.optimize(5, initial_data, model, acquisition_rule=batch_rule)
-batch_dataset = batch_result.try_get_final_datasets()[OBJECTIVE]
-batch_query_points = batch_dataset.query_points.numpy()
-batch_observations = batch_dataset.observations.numpy()
 
 # %% [markdown]
 # We can again visualise the GP model and query points.
 
 # %%
+batch_dataset = batch_result.try_get_final_datasets()[OBJECTIVE]
+batch_query_points = batch_dataset.query_points.numpy()
+batch_observations = batch_dataset.observations.numpy()
 fig = plot_gp_plotly(
     batch_result.try_get_final_models()[OBJECTIVE].model,
     search_space.lower,

--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -218,7 +218,7 @@ batch_query_points = batch_dataset.query_points.numpy()
 batch_observations = batch_dataset.observations.numpy()
 
 # %% [markdown]
-# We can visualise again the GP model and query points.
+# We can again visualise the GP model and query points.
 
 # %%
 fig = plot_gp_plotly(

--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -204,15 +204,15 @@ plot_bo_points(
 # %% [markdown]
 # ## Batch-sequential strategy
 #
-# Sometimes it is practically convenient to query several points at a time. We can do this in `trieste` using `BatchMonteCarloExpectedImprovement`. Note that this acquisition is computed using a Monte-Carlo method (so it requires a `sample_size`), but with a reparametrisation trick, which makes it deterministic. To use it, we change the acquisition rule and specify the number of query points (`num_query_points`) to be chosen, then observed simultaneously:
+# Sometimes it is practically convenient to query several points at a time. We can do this in `trieste` using a `BatchAcquisitionRule` and a `BatchAcquisitionFunctionBuilder`, that together recommend a number of query points `num_query_points` (instead of one as previously). The optimizer then queries the observer at all these points simultaneously.
+# Here we use the `BatchMonteCarloExpectedImprovement` function. Note that this acquisition function is computed using a Monte-Carlo method (so it requires a `sample_size`), but with a reparametrisation trick, which makes it deterministic.
 
 # %%
 qei = trieste.acquisition.BatchMonteCarloExpectedImprovement(sample_size=1000)
 batch_rule = trieste.acquisition.rule.BatchAcquisitionRule(num_query_points=3, builder=qei.using(OBJECTIVE))
 
-batch_bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
-
-batch_result = batch_bo.optimize(5, initial_data, model, acquisition_rule=batch_rule)
+model = build_model(initial_data[OBJECTIVE])
+batch_result = bo.optimize(5, initial_data, model, acquisition_rule=batch_rule)
 batch_dataset = batch_result.try_get_final_datasets()[OBJECTIVE]
 batch_query_points = batch_dataset.query_points.numpy()
 batch_observations = batch_dataset.observations.numpy()


### PR DESCRIPTION
This PR adds a section at the end of the `expected_improvement` notebook to show how to use batch-EI. After running the loop, it shows the obtained GP and query points, and compares regret with the one-point-at-a-time run.