### PR TITLE
add tests for AcquisitionFunctionBuilder reducers & refactor

### DIFF
--- a/tests/unit/acquisition/test_combination.py
+++ b/tests/unit/acquisition/test_combination.py
@@ -13,138 +13,91 @@
 # limitations under the License.
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
-from functools import partial
+from collections.abc import Mapping, Sequence
 
-import numpy as np
+import numpy.testing as npt
 import pytest
 import tensorflow as tf
 
-from tests.util.misc import raise_
+from tests.util.misc import raise_, zero_dataset
 from tests.util.model import QuadraticMeanAndRBFKernel
-from trieste.acquisition import (
-    AcquisitionFunction,
-    AcquisitionFunctionBuilder,
-    ExpectedImprovement,
-    NegativeLowerConfidenceBound,
-    Reducer,
-    expected_improvement,
-    lower_confidence_bound,
-)
-from trieste.acquisition.combination import Product, Sum
+from trieste.acquisition import AcquisitionFunction
+from trieste.acquisition.combination import Product, Reducer, Sum
+from trieste.acquisition.rule import AcquisitionFunctionBuilder
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 
 
-def test_reducer__repr_builders() -> None:
-    class Acq1(AcquisitionFunctionBuilder):
-        def __repr__(self) -> str:
-            return "Acq1()"
-
-        def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
-        ) -> AcquisitionFunction:
-            return raise_
-
-    class Acq2(AcquisitionFunctionBuilder):
-        def __repr__(self) -> str:
-            return "Acq2()"
-
-        def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
-        ) -> AcquisitionFunction:
-            return raise_
-
-    class Foo(Reducer):
-        def __repr__(self) -> str:
-            return f"Foo({self._repr_builders()})"
-
+def test_reducer_raises_for_no_builders() -> None:
+    class UseFirst(Reducer):
         def _reduce(self, inputs: Sequence[tf.Tensor]) -> tf.Tensor:
             return inputs[0]
 
-    assert repr(Foo(Acq1())) == "Foo(Acq1())"
-    assert repr(Foo(Acq1(), Acq2())) == "Foo(Acq1(), Acq2())"
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        UseFirst()
 
 
-@dataclass
-class ReducerTestData:
-    type_class: type[Sum | Product]
-    raw_reduce_op: Callable[[Sequence], float]
-    dataset: Dataset = Dataset(
-        np.arange(5, dtype=np.float64).reshape(-1, 1), np.zeros(5).reshape(-1, 1)
-    )
-    query_point: tf.Tensor = tf.convert_to_tensor(np.array([[0.1], [0.2]]))
+def test_reducer__repr_builders() -> None:
+    class Dummy(Reducer):
+        def __repr__(self):
+            return f"Dummy({self._repr_builders()})"
+
+        _reduce = raise_
+
+    class Builder(AcquisitionFunctionBuilder):
+        def __init__(self, name: str):
+            self._name = name
+
+        def __repr__(self) -> str:
+            return f"Builder({self._name!r})"
+
+        def prepare_acquisition_function(
+            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+        ) -> AcquisitionFunction:
+            return raise_
+
+    assert repr(Dummy(Builder("foo"))) == "Dummy(Builder('foo'))"
+    assert repr(Dummy(Builder("foo"), Builder("bar"))) == "Dummy(Builder('foo'), Builder('bar'))"
 
 
-_sum_fn = partial(np.sum, axis=0)
-_prod_fn = partial(np.prod, axis=0)
-_reducers = [ReducerTestData(Sum, _sum_fn), ReducerTestData(Product, _prod_fn)]
-
-
-@pytest.mark.parametrize("reducer", _reducers)
-def test_reducers_on_ei(reducer):
-    m = 6
-    zero = tf.convert_to_tensor([0.0], dtype=tf.float64)
-    model = QuadraticMeanAndRBFKernel()
-    acqs = [ExpectedImprovement().using("foo") for _ in range(m)]
-    acq = reducer.type_class(*acqs)
-    acq_fn = acq.prepare_acquisition_function({"foo": reducer.dataset}, {"foo": model})
-    individual_ei = [expected_improvement(model, zero, reducer.query_point) for _ in range(m)]
-    expected = reducer.raw_reduce_op(individual_ei)
-    desired = acq_fn(reducer.query_point)
-    np.testing.assert_array_almost_equal(desired, expected)
-
-
-@pytest.mark.parametrize("reducer", _reducers)
-def test_reducers_on_lcb(reducer):
-    m = 6
-    beta = tf.convert_to_tensor(1.96, dtype=tf.float64)
-    model = QuadraticMeanAndRBFKernel()
-    acqs = [NegativeLowerConfidenceBound(beta).using("foo") for _ in range(m)]
-    acq = reducer.type_class(*acqs)
-    acq_fn = acq.prepare_acquisition_function({"foo": reducer.dataset}, {"foo": model})
-    individual_lcb = [-lower_confidence_bound(model, beta, reducer.query_point) for _ in range(m)]
-    expected = reducer.raw_reduce_op(individual_lcb)
-    desired = acq_fn(reducer.query_point)
-    np.testing.assert_array_almost_equal(expected, desired)
-
-
-@pytest.mark.parametrize("reducer_class", [Sum, Product])
-def test_reducer_fails(reducer_class):
-    with pytest.raises(TypeError):
-        reducer_class(1, 2, 3)
-
-    with pytest.raises(ValueError):
-        reducer_class()
-
-
-class _InputIdentity(AcquisitionFunctionBuilder):
-    def __init__(self, result: tf.Tensor):
-        self._result = result
+class _Static(AcquisitionFunctionBuilder):
+    def __init__(self, f: AcquisitionFunction):
+        self._f = f
 
     def prepare_acquisition_function(
         self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
     ) -> AcquisitionFunction:
-        return lambda _: self._result
+        return self._f
 
 
-@pytest.mark.parametrize("combination", [(Product, _prod_fn), (Sum, _sum_fn)])
-@pytest.mark.parametrize(
-    "inputs",
-    [
-        [2.0, 3.0],
-        [np.arange(5.0), np.flip(np.arange(5.0))],
-        [np.arange(6.0).reshape(2, 3), np.flip(np.arange(6.0)).reshape(2, 3)],
-    ],
-)
-def test_product_reducer_multiplies_tensors(combination, inputs):
-    combination_builder, expected_fn = combination
-    inputs = [np.array(i) for i in inputs]
-    expected = expected_fn(inputs)
-    builders = [_InputIdentity(i) for i in inputs]
-    reducer = combination_builder(*builders)
-    data = Dataset(tf.zeros((1, 1)), tf.zeros((1, 1)))
-    prepared_fn = reducer.prepare_acquisition_function(data, QuadraticMeanAndRBFKernel())
-    result = prepared_fn(tf.zeros(1))
-    np.testing.assert_allclose(result, expected)
+def test_reducer__reduce() -> None:
+    class Mean(Reducer):
+        def _reduce(self, inputs: Sequence[tf.Tensor]) -> tf.Tensor:
+            return tf.reduce_mean(inputs, axis=0)
+
+    mean = Mean(_Static(lambda x: -2.0 * x), _Static(lambda x: 3.0 * x))
+    acq = mean.prepare_acquisition_function({"": zero_dataset()}, {"": QuadraticMeanAndRBFKernel()})
+    xs = tf.random.uniform([3, 5, 1], minval=-1.0)
+    npt.assert_allclose(acq(xs), 0.5 * xs)
+
+
+def test_sum() -> None:
+    sum_ = Sum(_Static(lambda x: x), _Static(lambda x: x ** 2), _Static(lambda x: x ** 3))
+    acq = sum_.prepare_acquisition_function({"": zero_dataset()}, {"": QuadraticMeanAndRBFKernel()})
+    xs = tf.random.uniform([3, 5, 1], minval=-1.0)
+    npt.assert_allclose(acq(xs), xs + xs ** 2 + xs ** 3)
+
+
+def test_product() -> None:
+    prod = Product(_Static(lambda x: x + 1), _Static(lambda x: x + 2))
+    acq = prod.prepare_acquisition_function({"": zero_dataset()}, {"": QuadraticMeanAndRBFKernel()})
+    xs = tf.random.uniform([3, 5, 1], minval=-1.0, dtype=tf.float64)
+    npt.assert_allclose(acq(xs), (xs + 1) * (xs + 2))
+
+
+@pytest.mark.parametrize("reducer_class", [Sum, Product])
+def test_sum_and_product_for_single_builder(reducer_class: type[Sum | Product]) -> None:
+    data, models = {"": zero_dataset()}, {"": QuadraticMeanAndRBFKernel()}
+    acq = reducer_class(_Static(lambda x: x ** 2)).prepare_acquisition_function(data, models)
+    xs = tf.random.uniform([3, 5, 1], minval=-1.0)
+    npt.assert_allclose(acq(xs), xs ** 2)

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -32,7 +32,7 @@ TF_DEBUGGING_ERROR_TYPES: Final[tuple[type[Exception], ...]] = (
     ValueError,
     tf.errors.InvalidArgumentError,
 )
-""" Error types thrown by TensorFlow's debugging functionality. """
+""" Error types thrown by TensorFlow's debugging functionality for tensor shapes. """
 
 C = TypeVar("C", bound=Callable)
 """ Type variable bound to `typing.Callable`. """

--- a/trieste/acquisition/combination.py
+++ b/trieste/acquisition/combination.py
@@ -26,9 +26,9 @@ from .function import AcquisitionFunction, AcquisitionFunctionBuilder
 
 class Reducer(AcquisitionFunctionBuilder):
     r"""
-    A :class:`Reducer` builds an :data:`~trieste.acquisition.AcquisitionFunction` whose output is
+    A :class:`Reducer` builds an :const:`~trieste.acquisition.AcquisitionFunction` whose output is
     calculated from the outputs of a number of other
-    :data:`~trieste.acquisition.AcquisitionFunction`\ s. How these outputs are composed is defined
+    :const:`~trieste.acquisition.AcquisitionFunction`\ s. How these outputs are composed is defined
     by the method :meth:`_reduce`.
     """
 

--- a/trieste/acquisition/combination.py
+++ b/trieste/acquisition/combination.py
@@ -26,24 +26,21 @@ from .function import AcquisitionFunction, AcquisitionFunctionBuilder
 
 class Reducer(AcquisitionFunctionBuilder):
     r"""
-    A :class:`Reducer` builds an :func:`~trieste.acquisition.AcquisitionFunction` whose output is
+    A :class:`Reducer` builds an :data:`~trieste.acquisition.AcquisitionFunction` whose output is
     calculated from the outputs of a number of other
-    :func:`~trieste.acquisition.AcquisitionFunction`\ s. How these outputs are composed is
-    defined by the method :meth:`_reduce`.
+    :data:`~trieste.acquisition.AcquisitionFunction`\ s. How these outputs are composed is defined
+    by the method :meth:`_reduce`.
     """
 
     def __init__(self, *builders: AcquisitionFunctionBuilder):
         r"""
         :param \*builders: Acquisition function builders. At least one must be provided.
-        :raise ValueError: If no builders are specified.
+        :raise `~tf.errors.InvalidArgumentError`: If no builders are specified.
         """
-        classname = self.__class__.__name__
-        if len(builders) < 1:
-            raise ValueError(f"{classname} expects at least one acquisition builder.")
-        if not all([isinstance(v, AcquisitionFunctionBuilder) for v in builders]):
-            raise TypeError(
-                f"{classname} expects `AcquisitionFunctionBuilder` instances as inputs."
-            )
+        tf.debugging.assert_positive(
+            len(builders), "At least one acquisition builder expected, got none."
+        )
+
         self._acquisitions = builders
 
     def _repr_builders(self) -> str:


### PR DESCRIPTION
This PR completes the test coverage for the `AcquisitionFunctionBuilder` reducers, and refactors the remaining tests to have lighter dependencies. It's part of #57 