### PR TITLE
Pareto set: Hypervolume

### DIFF
--- a/tests/unit/test_pareto.py
+++ b/tests/unit/test_pareto.py
@@ -113,7 +113,7 @@ def test_pareto_2d_bounds() -> None:
     )
 
 
-def test_hypervolume() -> None:
+def test_pareto_hypervolume_indicator() -> None:
     objectives = tf.constant(
         [
             [0.9575, 0.4218],

--- a/tests/unit/test_pareto.py
+++ b/tests/unit/test_pareto.py
@@ -11,11 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
 
+from tests.util.misc import TF_DEBUGGING_ERROR_TYPES, NList
 from trieste.utils.pareto import Pareto, non_dominated
 
 
@@ -113,14 +115,35 @@ def test_pareto_2d_bounds() -> None:
     )
 
 
-def test_pareto_hypervolume_indicator() -> None:
-    objectives = tf.constant(
-        [
-            [-1.0, -0.5],
-            [-0.5, -1.0],
-        ]
-    )
+@pytest.mark.parametrize("reference", [0.0, [0.0], [[0.0]]])
+def test_pareto_hypervolume_indicator_raises_for_reference_with_invalid_shape(
+    reference: NList[float]
+) -> None:
+    pareto = Pareto(tf.constant([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]]))
 
-    pareto_2d = Pareto(objectives)
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        pareto.hypervolume_indicator(tf.constant(reference))
 
-    npt.assert_allclose(pareto_2d.hypervolume_indicator(tf.constant([0.0, 0.0])), 0.75, rtol=1e-2)
+
+@pytest.mark.parametrize("reference", [[0.1, -0.65], [-0.7, -0.1]])
+def test_pareto_hypervolume_indicator_raises_for_reference_below_anti_ideal_point(
+    reference: list[float]
+) -> None:
+    pareto = Pareto(tf.constant([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]]))
+
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        pareto.hypervolume_indicator(tf.constant(reference))
+
+
+@pytest.mark.parametrize("objectives, reference, expected", [
+    ([[1.0, 0.5]], [2.3, 2.0], 1.95),
+    ([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]], [0.1, -0.1], 0.92),
+    (  # reference point is equal to one pareto point in one dimension
+        [[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]], [0.1, -0.6], 0.37
+    ),
+])
+def test_pareto_hypervolume_indicator(
+    objectives: list[list[float]], reference: list[float], expected: float
+) -> None:
+    pareto = Pareto(tf.constant(objectives))
+    npt.assert_allclose(pareto.hypervolume_indicator(tf.constant(reference)), expected)

--- a/tests/unit/test_pareto.py
+++ b/tests/unit/test_pareto.py
@@ -117,7 +117,7 @@ def test_pareto_2d_bounds() -> None:
 
 @pytest.mark.parametrize("reference", [0.0, [0.0], [[0.0]]])
 def test_pareto_hypervolume_indicator_raises_for_reference_with_invalid_shape(
-    reference: NList[float]
+    reference: NList[float],
 ) -> None:
     pareto = Pareto(tf.constant([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]]))
 
@@ -127,7 +127,7 @@ def test_pareto_hypervolume_indicator_raises_for_reference_with_invalid_shape(
 
 @pytest.mark.parametrize("reference", [[0.1, -0.65], [-0.7, -0.1]])
 def test_pareto_hypervolume_indicator_raises_for_reference_below_anti_ideal_point(
-    reference: list[float]
+    reference: list[float],
 ) -> None:
     pareto = Pareto(tf.constant([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]]))
 
@@ -135,13 +135,18 @@ def test_pareto_hypervolume_indicator_raises_for_reference_below_anti_ideal_poin
         pareto.hypervolume_indicator(tf.constant(reference))
 
 
-@pytest.mark.parametrize("objectives, reference, expected", [
-    ([[1.0, 0.5]], [2.3, 2.0], 1.95),
-    ([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]], [0.1, -0.1], 0.92),
-    (  # reference point is equal to one pareto point in one dimension
-        [[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]], [0.1, -0.6], 0.37
-    ),
-])
+@pytest.mark.parametrize(
+    "objectives, reference, expected",
+    [
+        ([[1.0, 0.5]], [2.3, 2.0], 1.95),
+        ([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]], [0.1, -0.1], 0.92),
+        (  # reference point is equal to one pareto point in one dimension
+            [[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]],
+            [0.1, -0.6],
+            0.37,
+        ),
+    ],
+)
 def test_pareto_hypervolume_indicator(
     objectives: list[list[float]], reference: list[float], expected: float
 ) -> None:

--- a/tests/unit/test_pareto.py
+++ b/tests/unit/test_pareto.py
@@ -116,17 +116,11 @@ def test_pareto_2d_bounds() -> None:
 def test_pareto_hypervolume_indicator() -> None:
     objectives = tf.constant(
         [
-            [0.9575, 0.4218],
-            [0.9649, 0.9157],
-            [0.1576, 0.7922],
-            [0.9706, 0.9595],
-            [0.9572, 0.6557],
-            [0.4854, 0.0357],
-            [0.8003, 0.8491],
-            [0.1419, 0.9340],
+            [-1.0, -0.5],
+            [-0.5, -1.0],
         ]
     )
 
     pareto_2d = Pareto(objectives)
 
-    npt.assert_allclose(pareto_2d.hypervolume_indicator(tf.constant([2.0, 2.0])), 3.3878, rtol=1e-2)
+    npt.assert_allclose(pareto_2d.hypervolume_indicator(tf.constant([0.0, 0.0])), 0.75, rtol=1e-2)

--- a/tests/unit/test_pareto.py
+++ b/tests/unit/test_pareto.py
@@ -111,3 +111,22 @@ def test_pareto_2d_bounds() -> None:
     npt.assert_allclose(
         pareto_2d.front, tf.constant([[0.1419, 0.9340], [0.1576, 0.7922], [0.4854, 0.0357]])
     )
+
+
+def test_hypervolume() -> None:
+    objectives = tf.constant(
+        [
+            [0.9575, 0.4218],
+            [0.9649, 0.9157],
+            [0.1576, 0.7922],
+            [0.9706, 0.9595],
+            [0.9572, 0.6557],
+            [0.4854, 0.0357],
+            [0.8003, 0.8491],
+            [0.1419, 0.9340],
+        ]
+    )
+
+    pareto_2d = Pareto(objectives)
+
+    npt.assert_allclose(pareto_2d.hypervolume_indicator(tf.constant([2.0, 2.0])), 3.3878, rtol=1e-2)

--- a/trieste/utils/pareto.py
+++ b/trieste/utils/pareto.py
@@ -108,13 +108,13 @@ class Pareto:
 
     def hypervolume_indicator(self, reference: TensorType) -> TensorType:
         """
-        Method to calculate the hypervolume indicator
+        Calculate the hypervolume indicator
         The hypervolume indicator is the volume of the dominated region.
 
         :param reference: a reference point to use, with shape [D].
-            Should be equal or bigger than the anti-ideal point of the Pareto set
-            for comparing results across runs, the same reference point must be used.
-        :return: hypervolume indicator (the higher the better)
+            Should be equal or bigger than the anti-ideal point of the Pareto set.
+            For comparing results across runs, the same reference point must be used.
+        :return: hypervolume indicator 
         """
 
         min_pfront = tf.reduce_min(self.front, 0, keepdims=True)

--- a/trieste/utils/pareto.py
+++ b/trieste/utils/pareto.py
@@ -116,6 +116,10 @@ class Pareto:
             Should be equal or bigger than the anti-ideal point of the Pareto set.
             For comparing results across runs, the same reference point must be used.
         :return: hypervolume indicator
+        :raise ValueError (or `tf.errors.InvalidArgumentError`): If ``reference`` has an invalid
+            shape.
+        :raise `tf.errors.InvalidArgumentError`: If ``reference`` is less than the anti-ideal point
+            in any dimension.
         """
         tf.debugging.assert_greater_equal(reference, self.front)
 

--- a/trieste/utils/pareto.py
+++ b/trieste/utils/pareto.py
@@ -117,6 +117,8 @@ class Pareto:
             For comparing results across runs, the same reference point must be used.
         :return: hypervolume indicator
         """
+        tf.debugging.assert_greater_equal(reference, self.front)
+
         tf.debugging.assert_shapes(
             [
                 (self.bounds.lower_idx, ["N", "D"]),

--- a/trieste/utils/pareto.py
+++ b/trieste/utils/pareto.py
@@ -127,8 +127,7 @@ class Pareto:
 
         min_pfront = tf.reduce_min(self.front, 0, keepdims=True)
         pseudo_pfront = tf.concat((min_pfront, self.front, reference[None]), 0)
-        D = tf.shape(pseudo_pfront)[1]
-        N = tf.shape(self.bounds.upper_idx)[0]
+        N, D = tf.shape(self.bounds.upper_idx)
 
         idx = tf.tile(tf.expand_dims(tf.range(D), -1), [1, N])
         upper_idx = tf.reshape(

--- a/trieste/utils/pareto.py
+++ b/trieste/utils/pareto.py
@@ -106,7 +106,7 @@ class Pareto:
 
         return BoundedVolumes(lower, upper)
 
-    def hypervolume_indicator(self, reference: tf.Tensor) -> tf.Tensor:
+    def hypervolume_indicator(self, reference: TensorType) -> TensorType:
         """
         Method to calculate the hypervolume indicator
         The hypervolume indicator is the volume of the dominated region.

--- a/trieste/utils/pareto.py
+++ b/trieste/utils/pareto.py
@@ -112,6 +112,7 @@ class Pareto:
         The hypervolume indicator is the volume of the dominated region.
 
         :param reference: a reference point to use, with shape [D].
+            Defines the upper bound of the hypervolume.
             Should be equal or bigger than the anti-ideal point of the Pareto set.
             For comparing results across runs, the same reference point must be used.
         :return: hypervolume indicator

--- a/trieste/utils/pareto.py
+++ b/trieste/utils/pareto.py
@@ -114,8 +114,16 @@ class Pareto:
         :param reference: a reference point to use, with shape [D].
             Should be equal or bigger than the anti-ideal point of the Pareto set.
             For comparing results across runs, the same reference point must be used.
-        :return: hypervolume indicator 
+        :return: hypervolume indicator
         """
+        tf.debugging.assert_shapes(
+            [
+                (self.bounds.lower_idx, ["N", "D"]),
+                (self.bounds.upper_idx, ["N", "D"]),
+                (self.front, ["M", "D"]),
+                (reference, ["D"]),
+            ]
+        )
 
         min_pfront = tf.reduce_min(self.front, 0, keepdims=True)
         pseudo_pfront = tf.concat((min_pfront, self.front, reference[None]), 0)


### PR DESCRIPTION
## Tasks

### Feature Implemented

This is a feature for Pareto functionality needed for Multi-objective BO, the code was ported from [GPFlowopt's pareto class](https://github.com/GPflow/GPflowOpt/blob/master/gpflowopt/pareto.py). This PR is small PR derived from previously large PR #126 and resolve #181
 
### Approach

Inside pareto.py `Pareto` class, this function is implemented:

1. `hypervolume_indicator` function: calculates hypervolume indicator given reference point 

## Status

Need review

## Changes

## Notes