### PR TITLE
added greedy batch optimizer

### DIFF
--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -152,7 +152,8 @@ def batchify_greedy(
     """
     A wrapper around our :const:`AcquisitionOptimizer`s. This class wraps a
     :const:`AcquisitionOptimizer` to allow it to approximately optimize batch acquisition functions
-        by greedily choosing each batch element in sequence.
+        by greedily choosing each batch point in sequence, i.e choosing the point that provides
+        the largest increase in the acquisiton function over the current (partial) batch.
     :param batch_size_one_optimizer: An optimizer that returns only batch size one, i.e. produces a
         single point with shape [1, D].
     :param batch_size: The number of points in the batch.


### PR DESCRIPTION
I have added a greedy batch optimizer in optimizer.py .

This is a simple first step in implementing more batch acquisition functions (i.e Local Penalisation and GIBBON).

This new optimizer can be used to optimize our current batch EI acquisition function in a greedy sequential manner, i.e. we build up the batch element by element.



