### PR TITLE
Fix synthetic examples output

### DIFF
--- a/tests/unit/utils/test_objectives.py
+++ b/tests/unit/utils/test_objectives.py
@@ -56,7 +56,9 @@ from trieste.utils.objectives import (
 def test_objective_maps_minimizers_to_minimum(
     objective: Callable[[TensorType], TensorType], minimizers: TensorType, minimum: TensorType
 ) -> None:
-    npt.assert_allclose(objective(minimizers), tf.squeeze(minimum), rtol=1e-5)
+    objective_values_at_minisers = objective(minimizers)
+    tf.debugging.assert_shapes([(objective_values_at_minisers, ["N", 1])])
+    npt.assert_allclose(objective_values_at_minisers, tf.squeeze(minimum), rtol=1e-5)
 
 
 def test_branin_no_function_values_are_less_than_global_minimum() -> None:

--- a/tests/unit/utils/test_objectives.py
+++ b/tests/unit/utils/test_objectives.py
@@ -57,7 +57,9 @@ def test_objective_maps_minimizers_to_minimum(
     objective: Callable[[TensorType], TensorType], minimizers: TensorType, minimum: TensorType
 ) -> None:
     objective_values_at_minisers = objective(minimizers)
-    tf.debugging.assert_shapes([(objective_values_at_minisers, ["N", 1])])
+    tf.debugging.assert_shapes(
+        [(objective_values_at_minisers, [len(objective_values_at_minisers), 1])]
+    )
     npt.assert_allclose(objective_values_at_minisers, tf.squeeze(minimum), rtol=1e-5)
 
 

--- a/tests/unit/utils/test_objectives.py
+++ b/tests/unit/utils/test_objectives.py
@@ -56,11 +56,9 @@ from trieste.utils.objectives import (
 def test_objective_maps_minimizers_to_minimum(
     objective: Callable[[TensorType], TensorType], minimizers: TensorType, minimum: TensorType
 ) -> None:
-    objective_values_at_minisers = objective(minimizers)
-    tf.debugging.assert_shapes(
-        [(objective_values_at_minisers, [len(objective_values_at_minisers), 1])]
-    )
-    npt.assert_allclose(objective_values_at_minisers, tf.squeeze(minimum), rtol=1e-5)
+    objective_values_at_minimizers = objective(minimizers)
+    tf.debugging.assert_shapes([(objective_values_at_minimizers, [len(minimizers), 1])])
+    npt.assert_allclose(objective_values_at_minimizers, tf.squeeze(minimum), rtol=1e-5)
 
 
 def test_branin_no_function_values_are_less_than_global_minimum() -> None:

--- a/trieste/utils/objectives.py
+++ b/trieste/utils/objectives.py
@@ -147,7 +147,7 @@ def hartmann_3(x: TensorType) -> TensorType:
     ]
 
     inner_sum = -tf.reduce_sum(A * (tf.expand_dims(x, 1) - P) ** 2, -1)
-    return -tf.reduce_sum(a * tf.math.exp(inner_sum), -1)
+    return -tf.reduce_sum(a * tf.math.exp(inner_sum), -1, keepdims=True)
 
 
 HARTMANN_3_MINIMIZER = tf.constant([[0.114614, 0.555649, 0.852547]], tf.float64)
@@ -191,7 +191,7 @@ def hartmann_6(x: TensorType) -> TensorType:
     ]
 
     inner_sum = -tf.reduce_sum(A * (tf.expand_dims(x, 1) - P) ** 2, -1)
-    return -tf.reduce_sum(a * tf.math.exp(inner_sum), -1)
+    return -tf.reduce_sum(a * tf.math.exp(inner_sum), -1, keepdims=True)
 
 
 HARTMANN_6_MINIMIZER = tf.constant(


### PR DESCRIPTION
Small fix so that the output of the two Hartmann synthetic test functions returns the right dimensions (ie. [N,1] rather than N). Also added a unit test to make sure this does not happen again.