### PR TITLE
Local penalization

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -84,3 +84,10 @@
     title = {Towards efficient multiobjective optimization: Multiobjective statistical criterions},
     year = {2012}
 }
+
+@inproceedings{Gonzalez:2016,
+  title={Batch Bayesian optimization via local penalization},
+  author={Gonz{\'a}lez, Javier and Dai, Zhenwen and Hennig, Philipp and Lawrence, Neil},
+  booktitle={Artificial intelligence and statistics},
+  year={2016}
+}

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -806,7 +806,8 @@ class LocallyPenalizedExpectedImprovement(MultiAcquisitionFunctionBuilder[Tensor
     For our penalization function, we implement the soft penalization strategy of :cite:`Gonzalez:2016`, 
     where an estimate of the objective function's Lipschitz constant is used to control the size 
     of penalization. The Lipschitz constant and additionl penalization parameters are estimated once 
-    when preparing  the :const:`AcquisitionFunctionMaker` (not for each individual :const:`AcquisitionFunction`).
+    when preparing the :const:`AcquisitionFunctionMaker` and reused for each 
+    individual :const:`AcquisitionFunction`) it makes.
     
     """
 
@@ -844,6 +845,7 @@ class LocallyPenalizedExpectedImprovement(MultiAcquisitionFunctionBuilder[Tensor
             grads = g.gradient(mean,sampled_points)
             grads_norm =  tf.norm(grads, axis=1)
             max_grads_norm = tf.reduce_max(grads_norm)
+            return max_grads_norm
 
         lipschitz_constant = get_lipschitz_estimate(samples)
 
@@ -863,7 +865,7 @@ class LocallyPenalizedExpectedImprovement(MultiAcquisitionFunctionBuilder[Tensor
                     return base_acquisition
 
                 penalization = local_penalizer(model, pending_points, lipschitz_constant, eta)
-                log_penalized_acquisition = tf.math.log(base_acquisition) + tf.math.log(penalization)
+                log_penalized_acquisition = log_base_acquisition + tf.math.log(penalization)
 
                 return log_penalized_acquisition
 

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -792,7 +792,7 @@ takes input shape `[..., 1, D]` and returns shape `[..., 1]`.
 
 
 class PenalizationFunctionBuilder(ABC):
-    """ An :class:`PenalizationFunctionBuilder` builds a penalization function. """
+    """ An :class:`PenalizationFunctionBuilder` esimtates the parameters of and builds a penalization function. """
 
     @abstractmethod
     def prepare_penalization_function(
@@ -809,11 +809,7 @@ class PenalizationFunctionBuilder(ABC):
         """
         :param search_space: The global search space over which the optimisation is defined.        
         :param models: The models.
-        :return: A penalization function.
         """
-
-
-
 
 
 class SingleModelPenalizationBuilder(ABC):
@@ -859,7 +855,6 @@ class SingleModelPenalizationBuilder(ABC):
         """
         :param search_space: The global search space over which the optimisation is defined.        
         :param model: The model over the specified ``dataset``.
-        :return: A penalization function.
         """
 
 
@@ -875,7 +870,7 @@ class LocalPenalization(SingleModelPenalizationBuilder):
     """
 
 
-def __init__(self, grid_size: int = 5000):
+def __init__(self, grid_size: int = 500):
         """
         :param grid_size: Size of the grid over which the Lipschitz constant is estimated. We recommend
             scaling this with search space dimension.
@@ -890,8 +885,7 @@ def __init__(self, grid_size: int = 5000):
 
     def estimate_penalization_parameters(self, search_space: SearchSpace, model: ProbabilisticModel):
         r"""
-        DESCRIBE MATHS FOR SAMPLES!
-
+        This is to be called once per BO step at the very start
 
         :param search_space: The global search space over which the optimisation is defined.
         :param model: The model over the specified ``dataset``.
@@ -931,14 +925,12 @@ def __init__(self, grid_size: int = 5000):
         if (not self._lipschitz_constant) or (not self._eta):
             raise ValueError("penalization parameters must be estimated before penalization building a penalization function.")  
 
-        return local_penalization(model, pending_points, self._eta, self._lipschitz_constant)
+        return soft_local_penalization(model, pending_points, self._eta, self._lipschitz_constant)
 
 
-
-
-def local_penalization(model: ProbabilisticModel, pending_points: TensorType, eta: TensorType, lipschitz_constant: TensorType) -> PenalizationFunction:
+def soft_local_penalization(model: ProbabilisticModel, pending_points: TensorType, eta: TensorType, lipschitz_constant: TensorType) -> PenalizationFunction:
     r"""
-    Return the local penalizer as used for single-objective greedy batch Bayesian optimization by 
+    Return the soft local penalization function used for single-objective greedy batch Bayesian optimization by 
     :cite:`Gonzalez:2016`.
 
 

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -796,7 +796,7 @@ class LocallyPenalizedExpectedImprovement(MultiAcquisitionFunctionBuilder[Tensor
     points and returns the expected improvment acquisiton function penalized around those points.
     
 
-
+	TODO
     Say it allows us to perofrm batch BO using standard non-batch acqusiton function
     by successively maximizing function penalized around alread selected points.
     Talk about penalization being multiplicative (do log space)

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -723,117 +723,73 @@ class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder):
 
 
 
-class IndependentReparametrizationSampler:
-    r"""
-    This sampler employs the *reparameterization trick* to approximate samples from a
-    :class:`ProbabilisticModel`\ 's predictive distribution as
-
-    .. math:: x \mapsto \mu(x) + \epsilon \sigma(x)
-
-    where :math:`\epsilon \sim \mathcal N (0, 1)` is constant for a given sampler, thus ensuring
-    samples form a continuous curve.
-    """
-
-    def __init__(self, sample_size: int, model: ProbabilisticModel):
-        """
-        :param sample_size: The number of samples to take at each point. Must be positive.
-        :param model: The model to sample from.
-        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
-        """
-        tf.debugging.assert_positive(sample_size)
-
-        self._sample_size = sample_size
-
-        # _eps is essentially a lazy constant. It is declared and assigned an empty tensor here, and
-        # populated on the first call to sample
-        self._eps = tf.Variable(
-            tf.ones([sample_size, 0], dtype=tf.float64), shape=[sample_size, None]
-        )  # [S, 0]
-        self._model = model
-
-    def __repr__(self) -> str:
-        """"""
-        return f"IndependentReparametrizationSampler({self._sample_size!r}, {self._model!r})"
-
-    def sample(self, at: TensorType) -> TensorType:
-        """
-        Return approximate samples from the `model` specified at :meth:`__init__`. Multiple calls to
-        :meth:`sample`, for any given :class:`IndependentReparametrizationSampler` and ``at``, will
-        produce the exact same samples. Calls to :meth:`sample` on *different*
-        :class:`IndependentReparametrizationSampler` instances will produce different samples.
-
-        :param at: Where to sample the predictive distribution, with shape `[..., 1, D]`, for points
-            of dimension `D`.
-        :return: The samples, of shape `[..., S, 1, L]`, where `S` is the `sample_size` and `L` is
-            the number of latent model dimensions.
-        :raise ValueError (or InvalidArgumentError): If ``at`` has an invalid shape.
-        """
-        tf.debugging.assert_shapes([(at, [..., 1, None])])
-        mean, var = self._model.predict(at[..., None, :, :])  # [..., 1, 1, L], [..., 1, 1, L]
-
-        if tf.size(self._eps) == 0:
-            self._eps.assign(
-                tf.random.normal([self._sample_size, mean.shape[-1]], dtype=tf.float64)
-            )  # [S, L]
-
-        return mean + tf.sqrt(var) * tf.cast(self._eps[:, None, :], var.dtype)  # [..., S, 1, L]
 
 
 
-PenalizationFunction = Callable[[TensorType], TensorType]
+
+
+
 """
-Type alias for penalization functions.
+Type alias for greedy acquisition functions.
 
-A :const:`PenalizationFunction` maps a query point (of dimension `D`) to a single
-value that measures how heavily that query point should be penalized (between 0 and 1) with 
-respect to a set of `M` pending points (each of dimension `D`). Thus, with leading dimensions, an :const:`PenalizationFunction`
-takes input shape `[..., 1, D]` and returns shape `[..., 1]`.
+
+TODO
+
+An :const:`AcquisitionFunction` maps a set of `B` query points (each of dimension `D`) to a single
+value that describes how useful it would be evaluate all these points together (to our goal of
+optimizing the objective function). Thus, with leading dimensions, an :const:`AcquisitionFunction`
+takes input shape `[..., B, D]` and returns shape `[..., 1]`.
+
+Note that :const:`AcquisitionFunction`s which do not support batch optimization still expect inputs
+with a batch dimension, i.e. an input of shape `[..., 1, D]`.
 """
 
 
-class PenalizationFunctionBuilder(ABC):
-    """ An :class:`PenalizationFunctionBuilder` esimtates the parameters of and builds a penalization function. """
+
+
+
+
+
+
+
+
+
+AcquisitionFunction = Callable[[TensorType], TensorType]
+
+
+
+
+class GreedyAcquisitionFunctionBuilder(AcquisitionFunctionBuilder, ABC):
+    """ An :class:`AcquisitionFunctionBuilder` builds an acquisition function.TODO """
 
     @abstractmethod
-    def prepare_penalization_function(
-        self, pending_points: TensorType, models: Mapping[str, ProbabilisticModel]
-    ) -> PenalizationFunction:
+    def update_pending_points(self, pending_points: TensorType) :
         """
+        TODO
         :param pending_points: The set of pending points which we penalize with respect to.
-        :param models: The models.
-        :return: A penalization function.
-        """
-
-    @abstractmethod
-    def estimate_penalization_parameters(self, search_space: SearchSpace, models: Mapping[str, ProbabilisticModel]):
-        """
-        :param search_space: The global search space over which the optimisation is defined.        
-        :param models: The models.
         """
 
 
-class SingleModelPenalizationBuilder(ABC):
+class SingleModelGreedyAcquisitionBuilder(ABC):
     """
-    Convenience penalization function builder for an penalization function (or component of a
-    composite penalization function) that requires only one model.
+    TODO
+    Convenience acquisition function builder for an acquisition function (or component of a
+    composite acquisition function) that requires only one model, dataset pair.
     """
 
-    def using(self, tag: str) -> PenalizationFunctionBuilder:
+    def using(self, tag: str) -> GreedyAcquisitionFunctionBuilder:
         """
-        :param tag: The tag for the model used to build this penalization function.
-        :return: An penalization function builder that selects the model specified by
-            ``tag``, as defined in :meth:`prepare_penalization_function`.
+        :param tag: The tag for the model, dataset pair to use to build this acquisition function.
+        :return: An acquisition function builder that selects the model and dataset specified by
+            ``tag``, as defined in :meth:`prepare_acquisition_function`.
         """
         single_builder = self
 
-        class _Anon(PenalizationFunctionBuilder):
-            def prepare_penalization_function(
-                self, pending_points: TensorType, models: Mapping[str, ProbabilisticModel]
-            ) -> PenalizationFunction:
-                return single_builder.prepare_penalization_function(pending_points, models[tag])
-
-            def estimate_penalization_parameters(self, search_space: SearchSpace, models: Mapping[str, ProbabilisticModel]):
-                return single_builder.estimate_penalization_parameters(search_space, models[tag])
+        class _Anon(GreedyAcquisitionFunctionBuilder):
+            def prepare_acquisition_function(
+                self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            ) -> AcquisitionFunction:
+                return single_builder.prepare_acquisition_function(datasets[tag], models[tag])
 
             def __repr__(self) -> str:
                 return f"{single_builder!r} using tag {tag!r}"
@@ -841,38 +797,32 @@ class SingleModelPenalizationBuilder(ABC):
         return _Anon()
 
     @abstractmethod
-    def prepare_penalization_function(
-        self, pending_points: TensorType, model: ProbabilisticModel
-    ) -> PenalizationFunction:
+    def prepare_acquisition_function(
+        self, dataset: Dataset, model: ProbabilisticModel
+    ) -> AcquisitionFunction:
         """
-        :param pending_points: The set of pending points which we penalize with respect to.
+        :param dataset: The data to use to build the acquisition function.
         :param model: The model over the specified ``dataset``.
-        :return: A penalization function.
-        """
-
-    @abstractmethod
-    def estimate_penalization_parameters(self, search_space: SearchSpace, model: ProbabilisticModel):
-        """
-        :param search_space: The global search space over which the optimisation is defined.        
-        :param model: The model over the specified ``dataset``.
+        :return: An acquisition function.
         """
 
 
-class LocalPenalization(SingleModelPenalizationBuilder):
+
+
+
+class LocallyPenalizedExpectedImprovement(SingleModelGreedyAcquisitionBuilder):
     """
-    Builder for the local penalization acqusiition function. See :cite:`Gonzalez:2016` for details.
-
-
-    SAY WHAT THIS IS
-
-    xpected improvement function where the "best" value is taken to be the minimum
-    of the posterior mean at observed points.
+ Builder for the local penalization acqusiition function. See :cite:`Gonzalez:2016` for details.
+TODO say default EI
     """
 
 
-def __init__(self, grid_size: int = 500):
+
+
+    def __init__(self, search_space: SearchSpace, grid_size: int = 500):
         """
-        :param grid_size: Size of the grid over which the Lipschitz constant is estimated. We recommend
+        SAY WHAT GOES ONE HERE!
+       :param grid_size: Size of the grid over which the Lipschitz constant is estimated. We recommend
             scaling this with search space dimension.
         """
 
@@ -880,18 +830,27 @@ def __init__(self, grid_size: int = 500):
             raise ValueError(f"grid_size must be positive, got {grid_size}")
         self._grid_size = grid_size
 
-        self._lipschitz_constant = None
-        self._eta = None
+        self._search_space = search_space
 
-    def estimate_penalization_parameters(self, search_space: SearchSpace, model: ProbabilisticModel):
-        r"""
-        This is to be called once per BO step at the very start
 
-        :param search_space: The global search space over which the optimisation is defined.
-        :param model: The model over the specified ``dataset``.
+       
+
+
+    def prepare_greedy_acquisition_function_constructor(
+        self, dataset: Dataset, model: ProbabilisticModel,
+    ) -> AcquisitionFunction:
         """
-        samples_points = search_space.sample(num_samples=self._grid_size)
-        
+        TODO
+        """
+
+
+        if len(dataset.query_points) == 0:
+            raise ValueError("Dataset must be populated.")
+
+
+        samples_points  = self._search_space.sample(num_samples=self._grid_size)
+        samples_points  = tf.concat([dataset.query_points, samples_points ], 0)
+ 
         with tf.GradientTape() as g: # get gradients of posterior mean at samples
             g.watch(sample_points)
             mean, _ = model.predict(sample_points)
@@ -900,68 +859,88 @@ def __init__(self, grid_size: int = 500):
         max_grads_norm = tf.reduce_max(grads_norm)
 
         if max_grads_norm < 1e-5: # threshold to improve numerical stability for 'flat' models
-                self._lipschitz_constant = 10
+                lipschitz_constant = 10
             else:
-                self._lipschitz_constant = max_grads_norm
+                lipschitz_constant = max_grads_norm
 
-        self._eta = tf.reduce_min(mean, axis=0)
-
-
-    def prepare_penalization_function(
-        self, pending_points: TensorType, model: ProbabilisticModel
-    ) -> PenalizationFunction:
-        """
-        :param pending_points: The set of pending points which we penalize with respect to.
-        :param model: The model over the specified ``dataset``.
-        :return: The local penalization function. This function will raise
-            :exc:`ValueError` or :exc:`~tf.errors.InvalidArgumentError` if used with a batch size
-            greater than one.
-        :raise ValueError: If ``dataset`` is empty or if the penalization parameters have not yet been estimated.
-        """
-
-        if len(pending_points) == 0:
-            raise ValueError("pending_points must be populated.")
-
-        if (not self._lipschitz_constant) or (not self._eta):
-            raise ValueError("penalization parameters must be estimated before penalization building a penalization function.")  
-
-        return soft_local_penalization(model, pending_points, self._eta, self._lipschitz_constant)
+        eta = tf.reduce_min(mean, axis=0)
 
 
-def soft_local_penalization(model: ProbabilisticModel, pending_points: TensorType, eta: TensorType, lipschitz_constant: TensorType) -> PenalizationFunction:
+
+            def greedy_acquisition_function_constructor(pending_points: TensorType=None):
+                """
+                Init params
+                """
+                if not pending_points:
+                    return tf.math.log(expected_improvement(model, eta))
+
+                mean_pending, variance_pending  = model.predict(pending_points)
+                radius = tf.transpose((mean_pending - eta) / lipschitz_constant)
+                scale = tf.transpose(tf.sqrt(variance_pending) / lipschitz_constant)
+
+                base_acquisition = expected_improvement(model, eta)
+                penalization = local_penalizer(radius, scale)
+                log_penalized_acquisition = tf.math.log(base_acquisition) + tf.math.log(penalization)
+                return log_penalized_acquisition
+
+
+        return greedy_acquisition_function_constructor
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+PenalizationFunction = Callable[[TensorType], TensorType]
+"""
+An :const:`PenalizationFunction` maps a query point (of dimension `D`) to a single
+value that described how heavily it should be penalized (a positive quantity). 
+As penalization is applied multiplicatively to acquisition functions, small
+penalization outputs correspond to a stronger penalization effect. Thus, with 
+leading dimensions, an :const:`PenalizationFunction` takes input 
+shape `[..., 1, D]` and returns shape `[..., 1]`.
+"""
+
+def soft_local_penalizer(radius, scale ) -> PenalizationFunction:
     r"""
-    Return the soft local penalization function used for single-objective greedy batch Bayesian optimization by 
+    Return the local penalization function used for single-objective greedy batch Bayesian optimization by 
     :cite:`Gonzalez:2016`.
 
 
     DISCUSS MATHGS
 
+    
 
-    :param model: The model of the objective function.
-    :param pending points: The set of pending points which we penalize with respect to.
-    :param eta: The estimated global minimum value.
-    :param lipschitz_constant: The estimated objective function's Lipschitz constant.
+    SORT OUT
     :return: The local penalization function. This function will raise
         :exc:`ValueError` or :exc:`~tf.errors.InvalidArgumentError` if used with a batch size
         greater than one as it is to be used to build batches greedily 
     """
 
-    mean, variance  = model.predict(self._X_pending)
-    radius = tf.transpose((mean - eta) / lipschitz_constant)
-    scale = tf.transpose(tf.sqrt(variance) / lipschitz_constant)
 
     def penalization_function(x: TensorType) -> TensorType:
         tf.debugging.assert_shapes(
             [(x, [..., 1, None])],
-            message="This penalization function can only be used for greedy batch design.",
+            message="This penalization function cannot be calculated for batches of points.",
         )
 
         pairwise_distances = tf.norm(tf.expand_dims(x,1)-tf.expand_dims(pending_points,0),axis=-1)
         standardised_distances = (pairwise_distances - radius) / scale
 
         normal = tfp.distributions.Normal(tf.cast(0, x.dtype), tf.cast(1, x.dtype))
-        penalisation = normal.cdf(standardised_distances)
-        return penalisation
+        penalization = normal.cdf(standardised_distances)
+
+        return penalization
 
     return penalization_function
+
 

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -176,7 +176,8 @@ class GreedyEfficientGlobalOptimization(AcquisitionRule[None, SP_contra]):
             with the global search space. Defaults to
             :func:`~trieste.acquisition.optimizer.automatic_optimizer_selector`.
         :param num_query_points: The number of points to acquire.
-        :param penalizer_builder: ?????
+        :param penalizer_builder: The penalization function builder to use. Defaults to
+            :class:`~trieste.acquisition.LocalPenalization` with tag :data:`OBJECTIVE`.
         """
 
         if not num_query_points > 0:

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -93,7 +93,7 @@ class EfficientGlobalOptimization(AcquisitionRule[None, SP_contra]):
 
     def __init__(
         self,
-        builder: AcquisitionFunctionBuilder | None = None,
+        builder: AcquisitionFunctionBuilder | MultiAcquisitionFunctionBuilder | None = None,
         optimizer: AcquisitionOptimizer[SP_contra] | None = None,
         num_query_points: int = 1,
     ):


### PR DESCRIPTION
Hi 

This is a draft PR (no tests) for local penalization. @uri-granta  and I have converged on a MultiAcquisitionFunctionBuilder solution (line 740 of function.py). This builder can provide multiple acquisition functions during each BO step, as required for greedy batch selection (with or without local penalization). Crucially, building the Builder allows us to get away with performing some expensive computations (like estimating Lipshitz constants) only once per BO step.

Please have a look at Line 792 (function.py) to see the local penalisation acquisition function and at Line 160-175  (rule.py) to see how our EGO rule deals with greedy and joint batch design.