### PR TITLE
Move samplers

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -95,10 +95,3 @@
     year={2019},
     publisher={Springer}
 }
-
-@inproceedings{Gonzalez:2016,
-    title={Batch Bayesian optimization via local penalization},
-    author={Gonz{\'a}lez, Javier and Dai, Zhenwen and Hennig, Philipp and Lawrence, Neil},
-    booktitle={Artificial intelligence and statistics},
-    year={2016}
-}

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -95,3 +95,10 @@
     year={2019},
     publisher={Springer}
 }
+
+@inproceedings{Gonzalez:2016,
+    title={Batch Bayesian optimization via local penalization},
+    author={Gonz{\'a}lez, Javier and Dai, Zhenwen and Hennig, Philipp and Lawrence, Neil},
+    booktitle={Artificial intelligence and statistics},
+    year={2016}
+}

--- a/tests/unit/acquisition/test_sampler.py
+++ b/tests/unit/acquisition/test_sampler.py
@@ -1,0 +1,265 @@
+# Copyright 2020 The Trieste Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import math
+
+import numpy.testing as npt
+import pytest
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from tests.util.misc import TF_DEBUGGING_ERROR_TYPES, ShapeLike, quadratic, random_seed
+from tests.util.model import GaussianProcess, QuadraticMeanAndRBFKernel, rbf
+from trieste.acquisition.sampler import (
+    BatchReparametrizationSampler,
+    DiscreteThompsonSampler,
+    GumbelSampler,
+    IndependentReparametrizationSampler,
+)
+from trieste.data import Dataset
+from trieste.space import Box
+from trieste.utils.objectives import branin
+
+
+@pytest.mark.parametrize("sample_size", [0, -2])
+def test_gumbel_sampler_raises_for_invalid_sample_size(
+    sample_size: int,
+) -> None:
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        GumbelSampler(sample_size, QuadraticMeanAndRBFKernel())
+
+
+@pytest.mark.parametrize("shape", [[], [1], [2], [1, 2, 3]])
+def test_gumbel_sampler_sample_raises_for_invalid_at_shape(
+    shape: ShapeLike,
+) -> None:
+    sampler = GumbelSampler(1, QuadraticMeanAndRBFKernel())
+
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        sampler.sample(tf.zeros(shape))
+
+
+@pytest.mark.parametrize("sample_size", [10, 100])
+def test_gumbel_sampler_returns_correctly_shaped_samples(sample_size: int) -> None:
+    search_space = Box([0, 0], [1, 1])
+    gumbel_sampler = GumbelSampler(sample_size, QuadraticMeanAndRBFKernel())
+    query_points = search_space.sample(5)
+    gumbel_samples = gumbel_sampler.sample(query_points)
+    tf.debugging.assert_shapes([(gumbel_samples, [sample_size, 1])])
+
+
+def test_gumbel_samples_are_minima() -> None:
+    dataset = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
+    search_space = Box([0, 0], [1, 1])
+    model = QuadraticMeanAndRBFKernel()
+    gumbel_sampler = GumbelSampler(5, model)
+
+    query_points = search_space.sample(100)
+    query_points = tf.concat([dataset.query_points, query_points], 0)
+    gumbel_samples = gumbel_sampler.sample(query_points)
+
+    fmean, _ = model.predict(dataset.query_points)
+    assert max(gumbel_samples) < min(fmean)
+
+
+@pytest.mark.parametrize("sample_size", [0, -2])
+def test_discrete_thompson_sampler_raises_for_invalid_sample_size(
+    sample_size: int,
+) -> None:
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        DiscreteThompsonSampler(sample_size, QuadraticMeanAndRBFKernel())
+
+
+@pytest.mark.parametrize("shape", [[], [1], [2], [1, 2, 3]])
+def test_discrete_thompson_sampler_sample_raises_for_invalid_at_shape(
+    shape: ShapeLike,
+) -> None:
+    sampler = DiscreteThompsonSampler(1, QuadraticMeanAndRBFKernel())
+
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        sampler.sample(tf.zeros(shape))
+
+
+@pytest.mark.parametrize("sample_size", [10, 100])
+def test_discrete_thompson_sampler_returns_correctly_shaped_samples(sample_size: int) -> None:
+    search_space = Box([0, 0], [1, 1])
+    thompson_sampler = DiscreteThompsonSampler(sample_size, QuadraticMeanAndRBFKernel())
+    query_points = search_space.sample(100)
+    thompson_samples = thompson_sampler.sample(query_points)
+    tf.debugging.assert_shapes([(thompson_samples, ["N", 2])])
+
+
+def test_discrete_thompson_sampler_returns_unique_samples() -> None:
+    search_space = Box([0, 0], [1, 1])
+    thompson_sampler = DiscreteThompsonSampler(20, QuadraticMeanAndRBFKernel())
+    query_points = search_space.sample(10)
+    thompson_samples = thompson_sampler.sample(query_points)
+    assert len(thompson_samples) < 10
+
+
+@pytest.mark.parametrize("sample_size", [0, -2])
+def test_independent_reparametrization_sampler_raises_for_invalid_sample_size(
+    sample_size: int,
+) -> None:
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        IndependentReparametrizationSampler(sample_size, QuadraticMeanAndRBFKernel())
+
+
+@pytest.mark.parametrize("shape", [[], [1], [2], [2, 3]])
+def test_independent_reparametrization_sampler_sample_raises_for_invalid_at_shape(
+    shape: ShapeLike,
+) -> None:
+    sampler = IndependentReparametrizationSampler(1, QuadraticMeanAndRBFKernel())
+
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        sampler.sample(tf.zeros(shape))
+
+
+def _assert_kolmogorov_smirnov_95(
+    # fmt: off
+    samples: tf.Tensor,  # [..., S]
+    distribution: tfp.distributions.Distribution
+    # fmt: on
+) -> None:
+    assert distribution.event_shape == ()
+    tf.debugging.assert_shapes([(samples, [..., "S"])])
+
+    sample_size = samples.shape[-1]
+    samples_sorted = tf.sort(samples, axis=-1)  # [..., S]
+    edf = tf.range(1.0, sample_size + 1, dtype=samples.dtype) / sample_size  # [S]
+    expected_cdf = distribution.cdf(samples_sorted)  # [..., S]
+
+    _95_percent_bound = 1.36 / math.sqrt(sample_size)
+    assert tf.reduce_max(tf.abs(edf - expected_cdf)) < _95_percent_bound
+
+
+def _dim_two_gp(mean_shift: tuple[float, float] = (0.0, 0.0)) -> GaussianProcess:
+    matern52 = tfp.math.psd_kernels.MaternFiveHalves(
+        amplitude=tf.cast(2.3, tf.float64), length_scale=tf.cast(0.5, tf.float64)
+    )
+    return GaussianProcess(
+        [lambda x: mean_shift[0] + branin(x), lambda x: mean_shift[1] + quadratic(x)],
+        [matern52, rbf()],
+    )
+
+
+@random_seed
+def test_independent_reparametrization_sampler_samples_approximate_expected_distribution() -> None:
+    sample_size = 1000
+    x = tf.random.uniform([100, 1, 2], minval=-10.0, maxval=10.0, dtype=tf.float64)
+
+    model = _dim_two_gp()
+    samples = IndependentReparametrizationSampler(sample_size, model).sample(x)  # [N, S, 1, L]
+
+    assert samples.shape == [len(x), sample_size, 1, 2]
+
+    mean, var = model.predict(tf.squeeze(x, -2))  # [N, L], [N, L]
+    _assert_kolmogorov_smirnov_95(
+        tf.linalg.matrix_transpose(tf.squeeze(samples, -2)),
+        tfp.distributions.Normal(mean[..., None], tf.sqrt(var[..., None])),
+    )
+
+
+@random_seed
+def test_independent_reparametrization_sampler_sample_is_continuous() -> None:
+    sampler = IndependentReparametrizationSampler(100, _dim_two_gp())
+    xs = tf.random.uniform([100, 1, 2], minval=-10.0, maxval=10.0, dtype=tf.float64)
+    npt.assert_array_less(tf.abs(sampler.sample(xs + 1e-20) - sampler.sample(xs)), 1e-20)
+
+
+def test_independent_reparametrization_sampler_sample_is_repeatable() -> None:
+    sampler = IndependentReparametrizationSampler(100, _dim_two_gp())
+    xs = tf.random.uniform([100, 1, 2], minval=-10.0, maxval=10.0, dtype=tf.float64)
+    npt.assert_allclose(sampler.sample(xs), sampler.sample(xs))
+
+
+@random_seed
+def test_independent_reparametrization_sampler_samples_are_distinct_for_new_instances() -> None:
+    sampler1 = IndependentReparametrizationSampler(100, _dim_two_gp())
+    sampler2 = IndependentReparametrizationSampler(100, _dim_two_gp())
+    xs = tf.random.uniform([100, 1, 2], minval=-10.0, maxval=10.0, dtype=tf.float64)
+    npt.assert_array_less(1e-9, tf.abs(sampler2.sample(xs) - sampler1.sample(xs)))
+
+
+@pytest.mark.parametrize("sample_size", [0, -2])
+def test_batch_reparametrization_sampler_raises_for_invalid_sample_size(sample_size: int) -> None:
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        BatchReparametrizationSampler(sample_size, _dim_two_gp())
+
+
+@random_seed
+def test_batch_reparametrization_sampler_samples_approximate_mean_and_covariance() -> None:
+    model = _dim_two_gp()
+    sample_size = 10_000
+    leading_dims = [3]
+    batch_size = 4
+    xs = tf.random.uniform(leading_dims + [batch_size, 2], maxval=1.0, dtype=tf.float64)
+    samples = BatchReparametrizationSampler(sample_size, model).sample(xs)
+
+    assert samples.shape == leading_dims + [sample_size, batch_size, 2]
+
+    samples_mean = tf.reduce_mean(samples, axis=-3)
+    samples_covariance = tf.transpose(
+        tfp.stats.covariance(samples, sample_axis=-3, event_axis=-2), [0, 3, 1, 2]
+    )
+
+    model_mean, model_cov = model.predict_joint(xs)
+
+    npt.assert_allclose(samples_mean, model_mean, rtol=0.02)
+    npt.assert_allclose(samples_covariance, model_cov, rtol=0.04)
+
+
+def test_batch_reparametrization_sampler_samples_are_continuous() -> None:
+    sampler = BatchReparametrizationSampler(100, _dim_two_gp())
+    xs = tf.random.uniform([3, 5, 7, 2], dtype=tf.float64)
+    npt.assert_array_less(tf.abs(sampler.sample(xs + 1e-20) - sampler.sample(xs)), 1e-20)
+
+
+def test_batch_reparametrization_sampler_samples_are_repeatable() -> None:
+    sampler = BatchReparametrizationSampler(100, _dim_two_gp())
+    xs = tf.random.uniform([3, 5, 7, 2], dtype=tf.float64)
+    npt.assert_allclose(sampler.sample(xs), sampler.sample(xs))
+
+
+@random_seed
+def test_batch_reparametrization_sampler_samples_are_distinct_for_new_instances() -> None:
+    model = _dim_two_gp()
+    sampler1 = BatchReparametrizationSampler(100, model)
+    sampler2 = BatchReparametrizationSampler(100, model)
+    xs = tf.random.uniform([3, 5, 7, 2], dtype=tf.float64)
+    npt.assert_array_less(1e-9, tf.abs(sampler2.sample(xs) - sampler1.sample(xs)))
+
+
+@pytest.mark.parametrize("at", [tf.constant([0.0]), tf.constant(0.0), tf.ones([0, 1])])
+def test_batch_reparametrization_sampler_sample_raises_for_invalid_at_shape(at: tf.Tensor) -> None:
+    sampler = BatchReparametrizationSampler(100, QuadraticMeanAndRBFKernel())
+
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        sampler.sample(at)
+
+
+def test_batch_reparametrization_sampler_sample_raises_for_negative_jitter() -> None:
+    sampler = BatchReparametrizationSampler(100, QuadraticMeanAndRBFKernel())
+
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        sampler.sample(tf.constant([[0.0]]), jitter=-1e-6)
+
+
+def test_batch_reparametrization_sampler_sample_raises_for_inconsistent_batch_size() -> None:
+    sampler = BatchReparametrizationSampler(100, QuadraticMeanAndRBFKernel())
+    sampler.sample(tf.constant([[0.0], [1.0], [2.0]]))
+
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        sampler.sample(tf.constant([[0.0], [1.0]]))

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -40,11 +40,9 @@ from .function import (
     AcquisitionFunction,
     AcquisitionFunctionBuilder,
     BatchMonteCarloExpectedImprovement,
-    BatchReparametrizationSampler,
     ExpectedConstrainedImprovement,
     ExpectedHypervolumeImprovement,
     ExpectedImprovement,
-    IndependentReparametrizationSampler,
     MinValueEntropySearch,
     NegativeLowerConfidenceBound,
     NegativePredictiveMean,
@@ -55,4 +53,10 @@ from .function import (
     lower_confidence_bound,
     min_value_entropy_search,
     probability_of_feasibility,
+)
+from .sampler import (
+    BatchReparametrizationSampler,
+    DiscreteThompsonSampler,
+    GumbelSampler,
+    IndependentReparametrizationSampler,
 )

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This module contains acquisition function builders, which build acquisition functions
-that estimate the utility of evaluating sets of candidate points.
+This module contains acquisition function builders, which build and define our acquisition
+functions --- functions that estimate the utility of evaluating sets of candidate points.
 """
 from __future__ import annotations
 

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -11,6 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+This module contains acquisition function builders, which build acquisition functions
+that estimate the utility of evaluating sets of candidate points.
+"""
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -641,156 +645,6 @@ def expected_hv_improvement(
         )
 
     return acquisition
-
-
-class IndependentReparametrizationSampler:
-    r"""
-    This sampler employs the *reparameterization trick* to approximate samples from a
-    :class:`ProbabilisticModel`\ 's predictive distribution as
-
-    .. math:: x \mapsto \mu(x) + \epsilon \sigma(x)
-
-    where :math:`\epsilon \sim \mathcal N (0, 1)` is constant for a given sampler, thus ensuring
-    samples form a continuous curve.
-    """
-
-    def __init__(self, sample_size: int, model: ProbabilisticModel):
-        """
-        :param sample_size: The number of samples to take at each point. Must be positive.
-        :param model: The model to sample from.
-        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
-        """
-        tf.debugging.assert_positive(sample_size)
-
-        self._sample_size = sample_size
-
-        # _eps is essentially a lazy constant. It is declared and assigned an empty tensor here, and
-        # populated on the first call to sample
-        self._eps = tf.Variable(
-            tf.ones([sample_size, 0], dtype=tf.float64), shape=[sample_size, None]
-        )  # [S, 0]
-        self._model = model
-
-    def __repr__(self) -> str:
-        """"""
-        return f"IndependentReparametrizationSampler({self._sample_size!r}, {self._model!r})"
-
-    def sample(self, at: TensorType) -> TensorType:
-        """
-        Return approximate samples from the `model` specified at :meth:`__init__`. Multiple calls to
-        :meth:`sample`, for any given :class:`IndependentReparametrizationSampler` and ``at``, will
-        produce the exact same samples. Calls to :meth:`sample` on *different*
-        :class:`IndependentReparametrizationSampler` instances will produce different samples.
-
-        :param at: Where to sample the predictive distribution, with shape `[..., 1, D]`, for points
-            of dimension `D`.
-        :return: The samples, of shape `[..., S, 1, L]`, where `S` is the `sample_size` and `L` is
-            the number of latent model dimensions.
-        :raise ValueError (or InvalidArgumentError): If ``at`` has an invalid shape.
-        """
-        tf.debugging.assert_shapes([(at, [..., 1, None])])
-        mean, var = self._model.predict(at[..., None, :, :])  # [..., 1, 1, L], [..., 1, 1, L]
-
-        if tf.size(self._eps) == 0:
-            self._eps.assign(
-                tf.random.normal([self._sample_size, mean.shape[-1]], dtype=tf.float64)
-            )  # [S, L]
-
-        return mean + tf.sqrt(var) * tf.cast(self._eps[:, None, :], var.dtype)  # [..., S, 1, L]
-
-
-class BatchReparametrizationSampler:
-    r"""
-    This sampler employs the *reparameterization trick* to approximate batches of samples from a
-    :class:`ProbabilisticModel`\ 's predictive joint distribution as
-
-    .. math:: x \mapsto \mu(x) + \epsilon L(x)
-
-    where :math:`L` is the Cholesky factor s.t. :math:`LL^T` is the covariance, and
-    :math:`\epsilon \sim \mathcal N (0, 1)` is constant for a given sampler, thus ensuring samples
-    form a continuous curve.
-    """
-
-    def __init__(self, sample_size: int, model: ProbabilisticModel):
-        """
-        :param sample_size: The number of samples for each batch of points. Must be positive.
-        :param model: The model to sample from.
-        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
-        """
-        tf.debugging.assert_positive(sample_size)
-
-        self._sample_size = sample_size
-
-        # _eps is essentially a lazy constant. It is declared and assigned an empty tensor here, and
-        # populated on the first call to sample
-        self._eps = tf.Variable(
-            tf.ones([0, 0, sample_size], dtype=tf.float64), shape=[None, None, sample_size]
-        )  # [0, 0, S]
-        self._model = model
-
-    def __repr__(self) -> str:
-        """"""
-        return f"BatchReparametrizationSampler({self._sample_size!r}, {self._model!r})"
-
-    def sample(self, at: TensorType, *, jitter: float = DEFAULTS.JITTER) -> TensorType:
-        """
-        Return approximate samples from the `model` specified at :meth:`__init__`. Multiple calls to
-        :meth:`sample`, for any given :class:`BatchReparametrizationSampler` and ``at``, will
-        produce the exact same samples. Calls to :meth:`sample` on *different*
-        :class:`BatchReparametrizationSampler` instances will produce different samples.
-
-        :param at: Batches of query points at which to sample the predictive distribution, with
-            shape `[..., B, D]`, for batches of size `B` of points of dimension `D`. Must have a
-            consistent batch size across all calls to :meth:`sample` for any given
-            :class:`BatchReparametrizationSampler`.
-        :param jitter: The size of the jitter to use when stabilising the Cholesky decomposition of
-            the covariance matrix.
-        :return: The samples, of shape `[..., S, B, L]`, where `S` is the `sample_size`, `B` the
-            number of points per batch, and `L` the dimension of the model's predictive
-            distribution.
-        :raise ValueError (or InvalidArgumentError): If any of the following are true:
-
-            - ``at`` is a scalar.
-            - The batch size `B` of ``at`` is not positive.
-            - The batch size `B` of ``at`` differs from that of previous calls.
-            - ``jitter`` is negative.
-        """
-        tf.debugging.assert_rank_at_least(at, 2)
-        tf.debugging.assert_greater_equal(jitter, 0.0)
-
-        batch_size = at.shape[-2]
-
-        tf.debugging.assert_positive(batch_size)
-
-        eps_is_populated = tf.size(self._eps) != 0
-
-        if eps_is_populated:
-            tf.debugging.assert_equal(
-                batch_size,
-                tf.shape(self._eps)[-2],
-                f"{type(self).__name__} requires a fixed batch size. Got batch size {batch_size}"
-                f" but previous batch size was {tf.shape(self._eps)[-2]}.",
-            )
-
-        mean, cov = self._model.predict_joint(at)  # [..., B, L], [..., L, B, B]
-
-        if not eps_is_populated:
-            self._eps.assign(
-                tf.random.normal(
-                    [mean.shape[-1], batch_size, self._sample_size], dtype=tf.float64
-                )  # [L, B, S]
-            )
-
-        identity = tf.eye(batch_size, dtype=cov.dtype)  # [B, B]
-        cov_cholesky = tf.linalg.cholesky(cov + jitter * identity)  # [..., L, B, B]
-
-        variance_contribution = cov_cholesky @ tf.cast(self._eps, cov.dtype)  # [..., L, B, S]
-
-        leading_indices = tf.range(tf.rank(variance_contribution) - 3)
-        absolute_trailing_indices = [-1, -2, -3] + tf.rank(variance_contribution)
-        new_order = tf.concat([leading_indices, absolute_trailing_indices], axis=0)
-
-        return mean[..., None, :, :] + tf.transpose(variance_contribution, new_order)
 
 
 class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder):

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -37,6 +37,7 @@ from .optimizer import (
     batchify,
     optimize_continuous,
 )
+from .sampler import DiscreteThompsonSampler
 
 S = TypeVar("S")
 """ Unbound type variable. """
@@ -207,13 +208,11 @@ class ThompsonSampling(AcquisitionRule[None, SearchSpace]):
                 f"dict of models must contain the single key {OBJECTIVE}, got keys {models.keys()}"
             )
 
-        nqp, ns = self._num_query_points, self._num_search_space_samples
-        query_points = search_space.sample(ns)  # [ns, ...]
-        samples = models[OBJECTIVE].sample(query_points, nqp)  # [..., nqp, ns, 1]
-        samples_2d = tf.squeeze(samples, -1)  # [nqp, ns]
-        indices = tf.math.argmin(samples_2d, axis=1)
-        unique_indices = tf.unique(indices).y
-        return tf.gather(query_points, unique_indices), None
+        thompson_sampler = DiscreteThompsonSampler(self._num_query_points, models[OBJECTIVE])
+        query_points = search_space.sample(self._num_search_space_samples)
+        thompson_samples = thompson_sampler.sample(query_points)
+
+        return thompson_samples, None
 
 
 class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):

--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -35,16 +35,20 @@ class Sampler(ABC):
     underlying :class:`ProbabilisticModel`.
     """
 
-    @abstractmethod
     def __init__(self, sample_size: int, model: ProbabilisticModel):
         """
         :param sample_size: The desired number of samples.
         :param model: The model to sample from.
+        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
         """
         tf.debugging.assert_positive(sample_size)
 
         self._sample_size = sample_size
         self._model = model
+
+    def __repr__(self) -> str:
+        """"""
+        return f"{self.__class__.__name__}({self._sample_size!r}, {self._model!r})"
 
     @abstractmethod
     def sample(self, at: TensorType) -> TensorType:
@@ -59,18 +63,6 @@ class DiscreteThompsonSampler(Sampler):
     This sampler provides approximate Thompson samples of the objective function's
     maximiser :math:`x^*` over a discrete set of input locations.
     """
-
-    def __init__(self, sample_size: int, model: ProbabilisticModel):
-        """
-        :param sample_size: The number of samples to take at each point. Must be positive.
-        :param model: The model to sample from.
-        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
-        """
-        super().__init__(sample_size, model)
-
-    def __repr__(self) -> str:
-        """"""
-        return f"DiscreteThompsonSampler({self._sample_size!r}, {self._model!r})"
 
     def sample(self, at: TensorType) -> TensorType:
         """
@@ -104,18 +96,6 @@ class GumbelSampler(Sampler):
     :math:`[0, 1]` and applying the inverse probability integral transform
     :math:`y = \mathcal G^{-1}(r; a, b)`.
     """
-
-    def __init__(self, sample_size: int, model: ProbabilisticModel):
-        """
-        :param sample_size: The number of samples to take at each point. Must be positive.
-        :param model: The model to sample from.
-        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
-        """
-        super().__init__(sample_size, model)
-
-    def __repr__(self) -> str:
-        """"""
-        return f"DiscreteThompsonSampler({self._sample_size!r}, {self._model!r})"
 
     def sample(self, at: TensorType) -> TensorType:
         """
@@ -182,10 +162,6 @@ class IndependentReparametrizationSampler(Sampler):
             tf.ones([sample_size, 0], dtype=tf.float64), shape=[sample_size, None]
         )  # [S, 0]
 
-    def __repr__(self) -> str:
-        """"""
-        return f"IndependentReparametrizationSampler({self._sample_size!r}, {self._model!r})"
-
     def sample(self, at: TensorType) -> TensorType:
         """
         Return approximate samples from the `model` specified at :meth:`__init__`. Multiple calls to
@@ -235,10 +211,6 @@ class BatchReparametrizationSampler(Sampler):
         self._eps = tf.Variable(
             tf.ones([0, 0, sample_size], dtype=tf.float64), shape=[None, None, sample_size]
         )  # [0, 0, S]
-
-    def __repr__(self) -> str:
-        """"""
-        return f"BatchReparametrizationSampler({self._sample_size!r}, {self._model!r})"
 
     def sample(self, at: TensorType, *, jitter: float = DEFAULTS.JITTER) -> TensorType:
         """

--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -1,0 +1,232 @@
+# Copyright 2020 The Trieste Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module is the home of the sampling functionality required by Trieste's
+acquisiiton functions.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from itertools import product
+from math import inf
+from typing import Callable
+
+import tensorflow as tf
+import tensorflow_probability as tfp
+from scipy.optimize import bisect
+
+from ..data import Dataset
+from ..models import ProbabilisticModel
+from ..space import SearchSpace
+from ..type import TensorType
+from ..utils import DEFAULTS
+from ..utils.pareto import Pareto, get_reference_point
+
+
+
+class Sampler(ABC):
+    """ 
+    An :class:`Sampler` samples a specific quantity according to an underlying
+    :class:`ProbabilisticModel`.
+    """
+
+    @abstractmethod
+    def sample(
+        self, datasets: Mapping[str, Dataset], model: ProbabilisticModel
+    ) -> AcquisitionFunction:
+        """
+        :param at: Where to sample the predictive distribution, with shape `[..., 1, D]`, for points
+            of dimension `D`.
+        :param models: The models over each dataset in ``datasets``.
+        :return: An acquisition function.
+        """
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+class IndependentReparametrizationSampler(Sampler):
+    r"""
+    This sampler employs the *reparameterization trick* to approximate samples from a
+    :class:`ProbabilisticModel`\ 's predictive distribution as
+
+    .. math:: x \mapsto \mu(x) + \epsilon \sigma(x)
+
+    where :math:`\epsilon \sim \mathcal N (0, 1)` is constant for a given sampler, thus ensuring
+    samples form a continuous curve.
+    """
+
+    def __init__(self, sample_size: int, model: ProbabilisticModel):
+        """
+        :param sample_size: The number of samples to take at each point. Must be positive.
+        :param model: The model to sample from.
+        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
+        """
+        tf.debugging.assert_positive(sample_size)
+
+        self._sample_size = sample_size
+
+        # _eps is essentially a lazy constant. It is declared and assigned an empty tensor here, and
+        # populated on the first call to sample
+        self._eps = tf.Variable(
+            tf.ones([sample_size, 0], dtype=tf.float64), shape=[sample_size, None]
+        )  # [S, 0]
+        self._model = model
+
+    def __repr__(self) -> str:
+        """"""
+        return f"IndependentReparametrizationSampler({self._sample_size!r}, {self._model!r})"
+
+    def sample(self, at: TensorType) -> TensorType:
+        """
+        Return approximate samples from the `model` specified at :meth:`__init__`. Multiple calls to
+        :meth:`sample`, for any given :class:`IndependentReparametrizationSampler` and ``at``, will
+        produce the exact same samples. Calls to :meth:`sample` on *different*
+        :class:`IndependentReparametrizationSampler` instances will produce different samples.
+
+        :param at: Where to sample the predictive distribution, with shape `[..., 1, D]`, for points
+            of dimension `D`.
+        :return: The samples, of shape `[..., S, 1, L]`, where `S` is the `sample_size` and `L` is
+            the number of latent model dimensions.
+        :raise ValueError (or InvalidArgumentError): If ``at`` has an invalid shape.
+        """
+        tf.debugging.assert_shapes([(at, [..., 1, None])])
+        mean, var = self._model.predict(at[..., None, :, :])  # [..., 1, 1, L], [..., 1, 1, L]
+
+        if tf.size(self._eps) == 0:
+            self._eps.assign(
+                tf.random.normal([self._sample_size, mean.shape[-1]], dtype=tf.float64)
+            )  # [S, L]
+
+        return mean + tf.sqrt(var) * tf.cast(self._eps[:, None, :], var.dtype)  # [..., S, 1, L]
+
+
+class BatchReparametrizationSampler(Sampler):
+    r"""
+    This sampler employs the *reparameterization trick* to approximate batches of samples from a
+    :class:`ProbabilisticModel`\ 's predictive joint distribution as
+
+    .. math:: x \mapsto \mu(x) + \epsilon L(x)
+
+    where :math:`L` is the Cholesky factor s.t. :math:`LL^T` is the covariance, and
+    :math:`\epsilon \sim \mathcal N (0, 1)` is constant for a given sampler, thus ensuring samples
+    form a continuous curve.
+    """
+
+    def __init__(self, sample_size: int, model: ProbabilisticModel):
+        """
+        :param sample_size: The number of samples for each batch of points. Must be positive.
+        :param model: The model to sample from.
+        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
+        """
+        tf.debugging.assert_positive(sample_size)
+
+        self._sample_size = sample_size
+
+        # _eps is essentially a lazy constant. It is declared and assigned an empty tensor here, and
+        # populated on the first call to sample
+        self._eps = tf.Variable(
+            tf.ones([0, 0, sample_size], dtype=tf.float64), shape=[None, None, sample_size]
+        )  # [0, 0, S]
+        self._model = model
+
+    def __repr__(self) -> str:
+        """"""
+        return f"BatchReparametrizationSampler({self._sample_size!r}, {self._model!r})"
+
+    def sample(self, at: TensorType, *, jitter: float = DEFAULTS.JITTER) -> TensorType:
+        """
+        Return approximate samples from the `model` specified at :meth:`__init__`. Multiple calls to
+        :meth:`sample`, for any given :class:`BatchReparametrizationSampler` and ``at``, will
+        produce the exact same samples. Calls to :meth:`sample` on *different*
+        :class:`BatchReparametrizationSampler` instances will produce different samples.
+
+        :param at: Batches of query points at which to sample the predictive distribution, with
+            shape `[..., B, D]`, for batches of size `B` of points of dimension `D`. Must have a
+            consistent batch size across all calls to :meth:`sample` for any given
+            :class:`BatchReparametrizationSampler`.
+        :param jitter: The size of the jitter to use when stabilising the Cholesky decomposition of
+            the covariance matrix.
+        :return: The samples, of shape `[..., S, B, L]`, where `S` is the `sample_size`, `B` the
+            number of points per batch, and `L` the dimension of the model's predictive
+            distribution.
+        :raise ValueError (or InvalidArgumentError): If any of the following are true:
+
+            - ``at`` is a scalar.
+            - The batch size `B` of ``at`` is not positive.
+            - The batch size `B` of ``at`` differs from that of previous calls.
+            - ``jitter`` is negative.
+        """
+        tf.debugging.assert_rank_at_least(at, 2)
+        tf.debugging.assert_greater_equal(jitter, 0.0)
+
+        batch_size = at.shape[-2]
+
+        tf.debugging.assert_positive(batch_size)
+
+        eps_is_populated = tf.size(self._eps) != 0
+
+        if eps_is_populated:
+            tf.debugging.assert_equal(
+                batch_size,
+                tf.shape(self._eps)[-2],
+                f"{type(self).__name__} requires a fixed batch size. Got batch size {batch_size}"
+                f" but previous batch size was {tf.shape(self._eps)[-2]}.",
+            )
+
+        mean, cov = self._model.predict_joint(at)  # [..., B, L], [..., L, B, B]
+
+        if not eps_is_populated:
+            self._eps.assign(
+                tf.random.normal(
+                    [mean.shape[-1], batch_size, self._sample_size], dtype=tf.float64
+                )  # [L, B, S]
+            )
+
+        identity = tf.eye(batch_size, dtype=cov.dtype)  # [B, B]
+        cov_cholesky = tf.linalg.cholesky(cov + jitter * identity)  # [..., L, B, B]
+
+        variance_contribution = cov_cholesky @ tf.cast(self._eps, cov.dtype)  # [..., L, B, S]
+
+        leading_indices = tf.range(tf.rank(variance_contribution) - 3)
+        absolute_trailing_indices = [-1, -2, -3] + tf.rank(variance_contribution)
+        new_order = tf.concat([leading_indices, absolute_trailing_indices], axis=0)
+
+        return mean[..., None, :, :] + tf.transpose(variance_contribution, new_order)


### PR DESCRIPTION
This PR tidies up our sampling functionality and reduces the size of function.py .

We now have a new samplers.py file that contains our samplers, including a DiscreteThompsonSampler and GumbelSampler that have been extracted from the ThompsonSampling rule and MinValueEntropySearch builder, respectively.

All relevant tests (aswell as some new tests) have been added in a new test_sampler.py file.
