### PR TITLE
Support arbitrary tensor-likes not just lists

### DIFF
--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -608,7 +608,7 @@ def test_batch_monte_carlo_expected_improvement_raises_for_empty_data() -> None:
 
 def test_batch_monte_carlo_expected_improvement_raises_for_model_with_wrong_event_shape() -> None:
     builder = BatchMonteCarloExpectedImprovement(100)
-    data = mk_dataset([[0.0, 0.0]], [[0.0, 0.0]])
+    data = mk_dataset([(0.0, 0.0)], [(0.0, 0.0)])
     matern52 = tfp.math.psd_kernels.MaternFiveHalves(
         amplitude=tf.cast(2.3, tf.float64), length_scale=tf.cast(0.5, tf.float64)
     )

--- a/tests/unit/test_pareto.py
+++ b/tests/unit/test_pareto.py
@@ -17,7 +17,7 @@ import numpy.testing as npt
 import pytest
 import tensorflow as tf
 
-from tests.util.misc import TF_DEBUGGING_ERROR_TYPES, ListN
+from tests.util.misc import TF_DEBUGGING_ERROR_TYPES, SequenceN
 from trieste.utils.pareto import Pareto, non_dominated
 
 
@@ -141,7 +141,7 @@ def test_pareto_2d_bounds() -> None:
 
 @pytest.mark.parametrize("reference", [0.0, [0.0], [[0.0]]])
 def test_pareto_hypervolume_indicator_raises_for_reference_with_invalid_shape(
-    reference: ListN[float],
+    reference: SequenceN[float],
 ) -> None:
     pareto = Pareto(tf.constant([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]]))
 
@@ -241,7 +241,7 @@ def test_pareto_divide_conquer_nd_three_dimension_case() -> None:
 
 @pytest.mark.parametrize("reference", [0.0, [0.0], [[0.0]]])
 def test_pareto_hypercell_bounds_raises_for_reference_with_invalid_shape(
-    reference: ListN[float],
+    reference: SequenceN[float],
 ) -> None:
     pareto = Pareto(tf.constant([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]]))
 
@@ -251,7 +251,7 @@ def test_pareto_hypercell_bounds_raises_for_reference_with_invalid_shape(
 
 @pytest.mark.parametrize("anti_reference", [0.0, [0.0], [[0.0]]])
 def test_pareto_hypercell_bounds_raises_for_anti_reference_with_invalid_shape(
-    anti_reference: ListN[float],
+    anti_reference: SequenceN[float],
 ) -> None:
     pareto = Pareto(tf.constant([[-1.0, -0.6], [-0.8, -0.7], [-0.6, -1.1]]))
 
@@ -304,10 +304,10 @@ def test_pareto_hypercell_bounds_raises_for_front_below_anti_reference_point(
     ],
 )
 def test_pareto_hypercell_bounds(
-    objectives: ListN[float],
+    objectives: SequenceN[float],
     anti_reference: list[float],
     reference: list[float],
-    expected: ListN[float],
+    expected: SequenceN[float],
 ):
     pareto = Pareto(tf.constant(objectives))
     npt.assert_allclose(

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -181,12 +181,20 @@ def test_discrete_search_space_deepcopy() -> None:
     npt.assert_allclose(copy.deepcopy(dss).points, _points_in_2D_search_space())
 
 
-def test_box_converts_lists_to_float64_tensors() -> None:
-    box = Box([0.0], [1.0])
+@pytest.mark.parametrize(
+    "lower, upper",
+    [
+        pytest.param([0.0, 1.0], [1.0, 2.0], id="lists"),
+        pytest.param((0.0, 1.0), (1.0, 2.0), id="tuples"),
+        pytest.param(range(2), range(1, 3), id="ranges"),
+    ],
+)
+def test_box_converts_sequences_to_float64_tensors(lower, upper) -> None:
+    box = Box(lower, upper)
     assert tf.as_dtype(box.lower.dtype) is tf.float64
     assert tf.as_dtype(box.upper.dtype) is tf.float64
-    npt.assert_array_equal(box.lower, [0.0])
-    npt.assert_array_equal(box.upper, [1.0])
+    npt.assert_array_equal(box.lower, [0.0, 1.0])
+    npt.assert_array_equal(box.upper, [1.0, 2.0])
 
 
 def _pairs_of_shapes(

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable, Container, Mapping
-from typing import Any, List, NoReturn, Tuple, TypeVar, Union, cast
+from typing import Any, NoReturn, Sequence, TypeVar, Union, cast
 
 import numpy.testing as npt
 import tensorflow as tf
@@ -55,23 +55,27 @@ def random_seed(f: C) -> C:
 T = TypeVar("T")
 """ Unbound type variable. """
 
-ListN = Union[
-    List[T],
-    List[List[T]],
-    List[List[List[T]]],
-    List[List[List[List[Any]]]],
+SequenceN = Union[
+    Sequence[T],
+    Sequence[Sequence[T]],
+    Sequence[Sequence[Sequence[T]]],
+    Sequence[Sequence[Sequence[Sequence[Any]]]],
 ]
-""" Type alias for a nested list with array shape. """
+""" Type alias for a nested sequence (e.g. list or tuple) with array shape. """
 
 
-def mk_dataset(query_points: ListN[List[float]], observations: ListN[List[float]]) -> Dataset:
+def mk_dataset(
+    query_points: SequenceN[Sequence[float]], observations: SequenceN[Sequence[float]]
+) -> Dataset:
     """
     :param query_points: The query points.
     :param observations: The observations.
     :return: A :class:`Dataset` containing the specified ``query_points`` and ``observations`` with
         dtype `tf.float64`.
     """
-    return Dataset(tf.cast(query_points, tf.float64), tf.cast(observations, tf.float64))
+    return Dataset(
+        tf.constant(query_points, dtype=tf.float64), tf.constant(observations, dtype=tf.float64)
+    )
 
 
 def empty_dataset(query_point_shape: ShapeLike, observation_shape: ShapeLike) -> Dataset:
@@ -112,12 +116,12 @@ def quadratic(x: tf.Tensor) -> tf.Tensor:
 class FixedAcquisitionRule(AcquisitionRule[None, SearchSpace]):
     """ An acquisition rule that returns the same fixed value on every step. """
 
-    def __init__(self, query_points: ListN[List[float]]):
+    def __init__(self, query_points: SequenceN[Sequence[float]]):
         """
         :param query_points: The value to return on each step. Will be converted to a tensor with
             dtype `tf.float64`.
         """
-        self._qp = tf.cast(query_points, tf.float64)
+        self._qp = tf.constant(query_points, dtype=tf.float64)
 
     def __repr__(self) -> str:
         return f"FixedAcquisitionRule({self._qp!r})"
@@ -139,7 +143,7 @@ class FixedAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         return self._qp, None
 
 
-ShapeLike = Union[tf.TensorShape, Tuple[int, ...], List[int]]
+ShapeLike = Union[tf.TensorShape, Sequence[int]]
 """ Type alias for types that can represent tensor shapes. """
 
 

--- a/tests/util/model.py
+++ b/tests/util/model.py
@@ -19,7 +19,7 @@ from collections.abc import Callable, Sequence
 import tensorflow as tf
 import tensorflow_probability as tfp
 
-from tests.util.misc import ListN, quadratic
+from tests.util.misc import SequenceN, quadratic
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel, TrainableProbabilisticModel
 from trieste.type import TensorType
@@ -83,7 +83,7 @@ class QuadraticMeanAndRBFKernel(GaussianProcess):
     def __init__(
         self,
         *,
-        x_shift: float | ListN[float] | TensorType = 0,
+        x_shift: float | SequenceN[float] | TensorType = 0,
         kernel_amplitude: float | TensorType | None = None,
     ):
         kernel = tfp.math.psd_kernels.ExponentiatedQuadratic(kernel_amplitude)

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TypeVar, overload
+from typing import Sequence, TypeVar, overload
 
 import tensorflow as tf
 
@@ -166,17 +166,17 @@ class Box(SearchSpace):
     """
 
     @overload
-    def __init__(self, lower: list[float], upper: list[float]):
+    def __init__(self, lower: Sequence[float], upper: Sequence[float]):
         ...
 
     @overload
     def __init__(self, lower: TensorType, upper: TensorType):
         ...
 
-    def __init__(self, lower: list[float] | TensorType, upper: list[float] | TensorType):
+    def __init__(self, lower: Sequence[float] | TensorType, upper: Sequence[float] | TensorType):
         r"""
-        If ``lower`` and ``upper`` are `list`\ s, they will be converted to tensors of dtype
-        `tf.float64`.
+        If ``lower`` and ``upper`` are `Sequence`\ s of floats (such as lists or tuples),
+        they will be converted to tensors of dtype `tf.float64`.
 
         :param lower: The lower (inclusive) bounds of the box. Must have shape [D] for positive D,
             and if a tensor, must have float type.
@@ -195,9 +195,9 @@ class Box(SearchSpace):
         if len(lower) == 0:
             raise ValueError(f"Bounds must have shape [D] for positive D, got {tf.shape(lower)}.")
 
-        if isinstance(lower, list):
-            self._lower = tf.cast(lower, dtype=tf.float64)
-            self._upper = tf.cast(upper, dtype=tf.float64)
+        if isinstance(lower, Sequence):
+            self._lower = tf.constant(lower, dtype=tf.float64)
+            self._upper = tf.constant(upper, dtype=tf.float64)
         else:
             self._lower = tf.convert_to_tensor(lower)
             self._upper = tf.convert_to_tensor(upper)

--- a/trieste/utils/pareto.py
+++ b/trieste/utils/pareto.py
@@ -14,8 +14,6 @@
 """ This module contains functions and classes for Pareto based multi-objective optimization. """
 from __future__ import annotations
 
-from typing import Tuple
-
 import tensorflow as tf
 from typing_extensions import Final
 
@@ -23,7 +21,7 @@ from ..type import TensorType
 from .misc import DEFAULTS
 
 
-def non_dominated(observations: TensorType) -> Tuple[TensorType, TensorType]:
+def non_dominated(observations: TensorType) -> tuple[TensorType, TensorType]:
     """
     Computes the non-dominated set for a set of data points.
     if there are duplicate point(s) in the non-dominated set, this function will return
@@ -160,7 +158,7 @@ class Pareto:
             divide_conquer_cells: TensorType,
             lower_result: TensorType,
             upper_result: TensorType,
-        ) -> Tuple[TensorType, TensorType, TensorType]:
+        ) -> tuple[TensorType, TensorType, TensorType]:
             divide_conquer_cells_unstacked = tf.unstack(divide_conquer_cells, axis=0)
             cell = divide_conquer_cells_unstacked[-1]
             divide_conquer_cells_new = tf.cond(
@@ -218,7 +216,7 @@ class Pareto:
         upper_result: TensorType,
         lower_idx: TensorType,
         upper_idx: TensorType,
-    ) -> Tuple[TensorType, TensorType]:
+    ) -> tuple[TensorType, TensorType]:
         lower_result_accepted = tf.concat([lower_result, lower_idx[None]], axis=0)
         upper_result_accepted = tf.concat([upper_result, upper_idx[None]], axis=0)
         return lower_result_accepted, upper_result_accepted


### PR DESCRIPTION
Update Box constructor and mk_dataset utility function to support arbitary Tensor-like inputs (e.g. tuples), not just lists.