### PR TITLE
Help with debugging docs build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/autoapi/
 
 # PyBuilder
 target/

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,16 @@ $ tox -e docs
 
 Open `docs/_build/html/index.html` in a browser to view the docs.
 
+### Fixing documentation build errors
+
+Any errors in the notebooks or API documentation markup will result in documentation
+build errors that must be fixed. To fix these, ensure that all new documentation is valid [reST markup](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
+
+Note that since the API documentation is generated from inline Python docstrings, 
+**the line numbers in any API error logs refer to generated reST files,
+not the original Python source files**. You can find these generated reST files
+at `docs/autoapi`.
+
 # License
 
 [Apache License 2.0](../LICENSE)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ autosectionlabel_prefix_document = True
 extensions.append("autoapi.extension")
 autoapi_dirs = ["../trieste"]
 autoapi_add_toctree_entry = False
+autoapi_keep_files = True
 autoapi_python_class_content = "both"
 autoapi_options = [
     "members",


### PR DESCRIPTION
Since the API documentation is generated from inline Python docstrings, the line numbers in any API error logs refer to generated reST files, not the original Python source files! This PR:

1. Ensures we keep these generated reST files around
2. Adds a comment to the docs README explaining this.