### PR TITLE
Extra synthetic benchmarks + tidy

### DIFF
--- a/tests/unit/utils/test_multi_objectives.py
+++ b/tests/unit/utils/test_multi_objectives.py
@@ -1,0 +1,138 @@
+# Copyright 2020 The Trieste Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy.testing as npt
+import pytest
+import tensorflow as tf
+
+from tests.util.misc import TF_DEBUGGING_ERROR_TYPES
+from trieste.type import TensorType
+from trieste.utils.multi_objectives import DTLZ1, DTLZ2, VLMOP2, MultiObjectiveTestProblem, vlmop2
+
+
+@pytest.mark.parametrize(
+    "test_x, expected",
+    [
+        (
+            tf.constant([[0.0, 0.0]]),
+            tf.constant([[0.63212055, 0.63212055]]),
+        ),
+        (
+            tf.constant([[0.5, 1.0]]),
+            tf.constant([[0.12074441, 0.9873655]]),
+        ),
+        (
+            tf.constant([[[0.5, 1.0]], [[0.0, 0.0]]]),
+            tf.constant([[[0.12074441, 0.9873655]], [[0.63212055, 0.63212055]]]),
+        ),
+        (
+            tf.constant([[[0.5, 1.0], [0.0, 0.0]]]),
+            tf.constant([[[0.12074441, 0.9873655], [0.63212055, 0.63212055]]]),
+        ),
+    ],
+)
+def test_vlmop2_has_expected_output(test_x: TensorType, expected: TensorType):
+    npt.assert_allclose(vlmop2(test_x), expected, rtol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "test_x, input_dim, num_obj, expected",
+    [
+        (tf.constant([[0.0, 0.2, 0.4]]), 3, 2, tf.constant([[0.0, 5.5]])),
+        (
+            tf.constant([[[0.0, 0.2, 0.4]], [[0.0, 0.2, 0.4]]]),
+            3,
+            2,
+            tf.constant([[[0.0, 5.5]], [[0.0, 5.5]]]),
+        ),
+        (tf.constant([[0.8, 0.6, 0.4, 0.2]]), 4, 2, tf.constant([[4.8, 1.2]])),
+        (tf.constant([[0.1, 0.2, 0.3, 0.4]]), 4, 3, tf.constant([[0.06, 0.24, 2.7]])),
+        (
+            tf.constant([[[0.1, 0.2, 0.3, 0.4], [0.1, 0.2, 0.3, 0.4]]]),
+            4,
+            3,
+            tf.constant([[[0.06, 0.24, 2.7], [0.06, 0.24, 2.7]]]),
+        ),
+    ],
+)
+def test_dtlz1_has_expected_output(
+    test_x: TensorType, input_dim: int, num_obj: int, expected: TensorType
+):
+    f = DTLZ1(input_dim, num_obj).objective()
+    npt.assert_allclose(f(test_x), expected, rtol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "test_x, input_dim, num_obj, expected",
+    [
+        (tf.constant([[0.0, 0.2, 0.4]]), 3, 2, tf.constant([[1.1, 0.0]])),
+        (
+            tf.constant([[[0.0, 0.2, 0.4]], [[0.0, 0.2, 0.4]]]),
+            3,
+            2,
+            tf.constant([[[1.1, 0.0]], [[1.1, 0.0]]]),
+        ),
+        (tf.constant([[0.8, 0.6, 0.4, 0.2]]), 4, 2, tf.constant([[0.3430008637, 1.055672733]])),
+        (
+            tf.constant([[[0.8, 0.6, 0.4, 0.2], [0.8, 0.6, 0.4, 0.2]]]),
+            4,
+            2,
+            tf.constant([[[0.3430008637, 1.055672733], [0.3430008637, 1.055672733]]]),
+        ),
+        (
+            tf.constant([[0.1, 0.2, 0.3, 0.4]]),
+            4,
+            3,
+            tf.constant([[0.9863148, 0.3204731, 0.16425618]]),
+        ),
+    ],
+)
+def test_dtlz2_has_expected_output(
+    test_x: TensorType, input_dim: int, num_obj: int, expected: TensorType
+):
+    f = DTLZ2(input_dim, num_obj).objective()
+    npt.assert_allclose(f(test_x), expected, rtol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "obj_inst, input_dim, num_obj, gen_pf_num",
+    [
+        (DTLZ1(3, 2), 3, 2, 1000),
+        (DTLZ1(5, 3), 5, 3, 1000),
+        (DTLZ2(3, 2), 3, 2, 1000),
+        (DTLZ2(12, 6), 12, 6, 1000),
+    ],
+)
+def test_gen_pareto_front_is_equal_to_math_defined(
+    obj_inst: MultiObjectiveTestProblem, input_dim: int, num_obj: int, gen_pf_num: int
+):
+    pfs = obj_inst.gen_pareto_optimal_points(gen_pf_num)
+    if isinstance(obj_inst, DTLZ1):
+        tf.assert_equal(tf.reduce_sum(pfs, axis=1), 0.5)
+    elif isinstance(obj_inst, DTLZ2):
+        tf.debugging.assert_near(tf.norm(pfs, axis=1), 1.0, rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "obj_inst, actual_x",
+    [
+        (VLMOP2(), tf.constant([[0.4, 0.2, 0.5]])),
+        (DTLZ1(3, 2), tf.constant([[0.3, 0.1]])),
+        (DTLZ2(5, 2), tf.constant([[0.3, 0.1]])),
+    ],
+)
+def test_func_raises_specified_input_dim_not_align_with_actual_input_dim(
+    obj_inst: MultiObjectiveTestProblem, actual_x: TensorType
+):
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        obj_inst.objective()(actual_x)

--- a/tests/unit/utils/test_objectives.py
+++ b/tests/unit/utils/test_objectives.py
@@ -17,11 +17,11 @@ import numpy.testing as npt
 import pytest
 import tensorflow as tf
 
-from tests.util.misc import TF_DEBUGGING_ERROR_TYPES
 from trieste.space import Box
 from trieste.type import TensorType
-from trieste.utils.multi_objectives import DTLZ1, DTLZ2, VLMOP2, MultiObjectiveTestProblem, vlmop2
 from trieste.utils.objectives import (
+    ACKLEY_5_MINIMIZER,
+    ACKLEY_5_MINIMUM,
     BRANIN_MINIMIZERS,
     BRANIN_MINIMUM,
     GRAMACY_LEE_MINIMIZER,
@@ -32,12 +32,16 @@ from trieste.utils.objectives import (
     HARTMANN_6_MINIMUM,
     LOGARITHMIC_GOLDSTEIN_PRICE_MINIMIZER,
     LOGARITHMIC_GOLDSTEIN_PRICE_MINIMUM,
+    ROSENBROCK_4_MINIMIZER,
+    ROSENBROCK_4_MINIMUM,
+    ackley_5,
     branin,
     gramacy_lee,
     hartmann_3,
     hartmann_6,
     logarithmic_goldstein_price,
     mk_observer,
+    rosenbrock_4,
 )
 
 
@@ -52,6 +56,8 @@ from trieste.utils.objectives import (
             LOGARITHMIC_GOLDSTEIN_PRICE_MINIMUM,
         ),
         (hartmann_3, HARTMANN_3_MINIMIZER, HARTMANN_3_MINIMUM),
+        (rosenbrock_4, ROSENBROCK_4_MINIMIZER, ROSENBROCK_4_MINIMUM),
+        (ackley_5, ACKLEY_5_MINIMIZER, ACKLEY_5_MINIMUM),
         (hartmann_6, HARTMANN_6_MINIMIZER, HARTMANN_6_MINIMUM),
     ],
 )
@@ -60,153 +66,30 @@ def test_objective_maps_minimizers_to_minimum(
 ) -> None:
     objective_values_at_minimizers = objective(minimizers)
     tf.debugging.assert_shapes([(objective_values_at_minimizers, [len(minimizers), 1])])
-    npt.assert_allclose(objective_values_at_minimizers, tf.squeeze(minimum), rtol=1e-5)
-
-
-def test_branin_no_function_values_are_less_than_global_minimum() -> None:
-    samples = Box([0.0, 0.0], [1.0, 1.0]).sample(1000)
-    npt.assert_array_less(tf.squeeze(BRANIN_MINIMUM) - 1e-6, branin(samples))
-
-
-def test_gramacy_lee_no_points_are_less_than_global_minimum() -> None:
-    samples = Box([0.5], [2.5]).sample(1000)
-    npt.assert_array_less(tf.squeeze(GRAMACY_LEE_MINIMUM) - 1e-6, gramacy_lee(samples))
-
-
-def test_logarithmic_goldstein_price_no_function_values_are_less_than_global_minimum() -> None:
-    samples = Box([0.0, 0.0], [1.0, 1.0]).sample(1000)
-    npt.assert_array_less(
-        tf.squeeze(LOGARITHMIC_GOLDSTEIN_PRICE_MINIMUM) - 1e-6,
-        logarithmic_goldstein_price(samples),
-    )
+    npt.assert_allclose(objective_values_at_minimizers, tf.squeeze(minimum), atol=1e-5)
 
 
 @pytest.mark.parametrize(
-    "test_x, expected",
+    "objective, space, minimum",
     [
+        (branin, Box([0.0, 0.0], [1.0, 1.0]), BRANIN_MINIMUM),
+        (gramacy_lee, Box([0.5], [2.5]), GRAMACY_LEE_MINIMUM),
         (
-            tf.constant([[0.0, 0.0]]),
-            tf.constant([[0.63212055, 0.63212055]]),
+            logarithmic_goldstein_price,
+            Box([0.0, 0.0], [1.0, 1.0]),
+            LOGARITHMIC_GOLDSTEIN_PRICE_MINIMUM,
         ),
-        (
-            tf.constant([[0.5, 1.0]]),
-            tf.constant([[0.12074441, 0.9873655]]),
-        ),
-        (
-            tf.constant([[[0.5, 1.0]], [[0.0, 0.0]]]),
-            tf.constant([[[0.12074441, 0.9873655]], [[0.63212055, 0.63212055]]]),
-        ),
-        (
-            tf.constant([[[0.5, 1.0], [0.0, 0.0]]]),
-            tf.constant([[[0.12074441, 0.9873655], [0.63212055, 0.63212055]]]),
-        ),
+        (hartmann_3, Box([0.0] * 3, [1.0] * 3), HARTMANN_3_MINIMUM),
+        (rosenbrock_4, Box([0.0] * 4, [1.0] * 4), ROSENBROCK_4_MINIMUM),
+        (ackley_5, Box([0.0] * 5, [1.0] * 5), ACKLEY_5_MINIMUM),
+        (hartmann_6, Box([0.0] * 6, [1.0] * 6), HARTMANN_6_MINIMUM),
     ],
 )
-def test_vlmop2_has_expected_output(test_x: TensorType, expected: TensorType):
-    npt.assert_allclose(vlmop2(test_x), expected, rtol=1e-5)
-
-
-@pytest.mark.parametrize(
-    "test_x, input_dim, num_obj, expected",
-    [
-        (tf.constant([[0.0, 0.2, 0.4]]), 3, 2, tf.constant([[0.0, 5.5]])),
-        (
-            tf.constant([[[0.0, 0.2, 0.4]], [[0.0, 0.2, 0.4]]]),
-            3,
-            2,
-            tf.constant([[[0.0, 5.5]], [[0.0, 5.5]]]),
-        ),
-        (tf.constant([[0.8, 0.6, 0.4, 0.2]]), 4, 2, tf.constant([[4.8, 1.2]])),
-        (tf.constant([[0.1, 0.2, 0.3, 0.4]]), 4, 3, tf.constant([[0.06, 0.24, 2.7]])),
-        (
-            tf.constant([[[0.1, 0.2, 0.3, 0.4], [0.1, 0.2, 0.3, 0.4]]]),
-            4,
-            3,
-            tf.constant([[[0.06, 0.24, 2.7], [0.06, 0.24, 2.7]]]),
-        ),
-    ],
-)
-def test_dtlz1_has_expected_output(
-    test_x: TensorType, input_dim: int, num_obj: int, expected: TensorType
-):
-    f = DTLZ1(input_dim, num_obj).objective()
-    npt.assert_allclose(f(test_x), expected, rtol=1e-5)
-
-
-@pytest.mark.parametrize(
-    "test_x, input_dim, num_obj, expected",
-    [
-        (tf.constant([[0.0, 0.2, 0.4]]), 3, 2, tf.constant([[1.1, 0.0]])),
-        (
-            tf.constant([[[0.0, 0.2, 0.4]], [[0.0, 0.2, 0.4]]]),
-            3,
-            2,
-            tf.constant([[[1.1, 0.0]], [[1.1, 0.0]]]),
-        ),
-        (tf.constant([[0.8, 0.6, 0.4, 0.2]]), 4, 2, tf.constant([[0.3430008637, 1.055672733]])),
-        (
-            tf.constant([[[0.8, 0.6, 0.4, 0.2], [0.8, 0.6, 0.4, 0.2]]]),
-            4,
-            2,
-            tf.constant([[[0.3430008637, 1.055672733], [0.3430008637, 1.055672733]]]),
-        ),
-        (
-            tf.constant([[0.1, 0.2, 0.3, 0.4]]),
-            4,
-            3,
-            tf.constant([[0.9863148, 0.3204731, 0.16425618]]),
-        ),
-    ],
-)
-def test_dtlz2_has_expected_output(
-    test_x: TensorType, input_dim: int, num_obj: int, expected: TensorType
-):
-    f = DTLZ2(input_dim, num_obj).objective()
-    npt.assert_allclose(f(test_x), expected, rtol=1e-4)
-
-
-@pytest.mark.parametrize(
-    "obj_inst, input_dim, num_obj, gen_pf_num",
-    [
-        (DTLZ1(3, 2), 3, 2, 1000),
-        (DTLZ1(5, 3), 5, 3, 1000),
-        (DTLZ2(3, 2), 3, 2, 1000),
-        (DTLZ2(12, 6), 12, 6, 1000),
-    ],
-)
-def test_gen_pareto_front_is_equal_to_math_defined(
-    obj_inst: MultiObjectiveTestProblem, input_dim: int, num_obj: int, gen_pf_num: int
-):
-    pfs = obj_inst.gen_pareto_optimal_points(gen_pf_num)
-    if isinstance(obj_inst, DTLZ1):
-        tf.assert_equal(tf.reduce_sum(pfs, axis=1), 0.5)
-    elif isinstance(obj_inst, DTLZ2):
-        tf.debugging.assert_near(tf.norm(pfs, axis=1), 1.0, rtol=1e-6)
-
-
-@pytest.mark.parametrize(
-    "obj_inst, actual_x",
-    [
-        (VLMOP2(), tf.constant([[0.4, 0.2, 0.5]])),
-        (DTLZ1(3, 2), tf.constant([[0.3, 0.1]])),
-        (DTLZ2(5, 2), tf.constant([[0.3, 0.1]])),
-    ],
-)
-def test_func_raises_specified_input_dim_not_align_with_actual_input_dim(
-    obj_inst: MultiObjectiveTestProblem, actual_x: TensorType
-):
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        obj_inst.objective()(actual_x)
-
-
-def test_hartmann_3_no_function_values_are_less_than_global_minimum() -> None:
-    samples = Box([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]).sample(1000)
-    npt.assert_array_less(tf.squeeze(HARTMANN_3_MINIMUM) - 1e-6, hartmann_3(samples))
-
-
-def test_hartmann_6_no_function_values_are_less_than_global_minimum() -> None:
-    samples = Box([0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]).sample(1000)
-    npt.assert_array_less(tf.squeeze(HARTMANN_6_MINIMUM) - 1e-6, hartmann_6(samples))
+def test_no_function_values_are_less_than_global_minimum(
+    objective: Callable[[TensorType], TensorType], space: Box, minimum: TensorType
+) -> None:
+    samples = space.sample(1000 * len(space.lower))
+    npt.assert_array_less(tf.squeeze(minimum) - 1e-6, objective(samples))
 
 
 def test_mk_observer() -> None:

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 from typing import Sequence, TypeVar, overload
 
 import tensorflow as tf
+from tensorflow_probability.mcmc import sample_halton_sequence
 
 from .type import TensorType
 from .utils import shapes_equal
@@ -163,6 +164,8 @@ class Box(SearchSpace):
     Continuous :class:`SearchSpace` representing a :math:`D`-dimensional box in
     :math:`\mathbb{R}^D`. Mathematically it is equivalent to the Cartesian product of :math:`D`
     closed bounded intervals in :math:`\mathbb{R}`.
+
+    Continous searh spaces can be sampled TODO ...
     """
 
     @overload
@@ -241,10 +244,29 @@ class Box(SearchSpace):
         return tf.reduce_all(value >= self._lower) and tf.reduce_all(value <= self._upper)
 
     def sample(self, num_samples: int) -> TensorType:
+        """
+        :param num_samples: The number of points to sample from this search space.
+        :return: ``num_samples`` i.i.d. random points, sampled uniformly, and without replacement,
+            from this search space.
+        """
         dim = tf.shape(self._lower)[-1]
         return tf.random.uniform(
             (num_samples, dim), minval=self._lower, maxval=self._upper, dtype=self._lower.dtype
         )
+
+
+    def sample_halton(self, num_samples: int) -> TensorType:
+        """
+TODO
+
+        :param num_samples: The number of points to sample from this search space.
+        :return: ``num_samples`` i.i.d. random points, sampled uniformly, and without replacement,
+            from this search space.
+        """
+        dim = tf.shape(self._lower)[-1]
+        unit_samples = sample_halton_sequence(dim, num_samples, dtype=tf.float64)
+        return self._lower + samples * (self._upper - self._lower)
+        
 
     def discretize(self, num_samples: int) -> DiscreteSearchSpace:
         """

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -18,7 +18,6 @@ from abc import ABC, abstractmethod
 from typing import Sequence, TypeVar, overload
 
 import tensorflow as tf
-from tensorflow_probability.mcmc import sample_halton_sequence
 
 from .type import TensorType
 from .utils import shapes_equal
@@ -164,8 +163,6 @@ class Box(SearchSpace):
     Continuous :class:`SearchSpace` representing a :math:`D`-dimensional box in
     :math:`\mathbb{R}^D`. Mathematically it is equivalent to the Cartesian product of :math:`D`
     closed bounded intervals in :math:`\mathbb{R}`.
-
-    Continous searh spaces can be sampled TODO ...
     """
 
     @overload
@@ -244,29 +241,10 @@ class Box(SearchSpace):
         return tf.reduce_all(value >= self._lower) and tf.reduce_all(value <= self._upper)
 
     def sample(self, num_samples: int) -> TensorType:
-        """
-        :param num_samples: The number of points to sample from this search space.
-        :return: ``num_samples`` i.i.d. random points, sampled uniformly, and without replacement,
-            from this search space.
-        """
         dim = tf.shape(self._lower)[-1]
         return tf.random.uniform(
             (num_samples, dim), minval=self._lower, maxval=self._upper, dtype=self._lower.dtype
         )
-
-
-    def sample_halton(self, num_samples: int) -> TensorType:
-        """
-TODO
-
-        :param num_samples: The number of points to sample from this search space.
-        :return: ``num_samples`` i.i.d. random points, sampled uniformly, and without replacement,
-            from this search space.
-        """
-        dim = tf.shape(self._lower)[-1]
-        unit_samples = sample_halton_sequence(dim, num_samples, dtype=tf.float64)
-        return self._lower + samples * (self._upper - self._lower)
-        
 
     def discretize(self, num_samples: int) -> DiscreteSearchSpace:
         """

--- a/trieste/utils/objectives.py
+++ b/trieste/utils/objectives.py
@@ -164,6 +164,85 @@ float64.
 """
 
 
+def rosenbrock_4(x: TensorType) -> TensorType:
+    """
+    The Rosenbrock function, rescaled to have zero mean and unit variance over :math:`[0, 1]^4. See
+    :cite:`Picheny2013` for details.
+
+    This function (also known as the Banana function) is unimodal, however the minima
+    lies in a narrow valley.
+
+    :param x: The points at which to evaluate the function, with shape [..., 4].
+    :return: The function values at ``x``, with shape [..., 1].
+    :raise ValueError (or InvalidArgumentError): If ``x`` has an invalid shape.
+    """
+    tf.debugging.assert_shapes([(x, (..., 4))])
+
+    x = 15.0 * x - 5
+    unscaled_function = tf.reduce_sum(
+        (100.0 * (x[..., 1:] - x[..., :-1]) ** 2 + (1 - x[..., :-1]) ** 2), axis=-1, keepdims=True
+    )
+    return (unscaled_function - 3.827 * 1e5) / (3.755 * 1e5)
+
+
+ROSENBROCK_4_MINIMIZER = tf.constant([[0.4, 0.4, 0.4, 0.4]], tf.float64)
+"""
+The global minimizer for the :func:`rosenbrock_4` function, with shape [1, 4] and
+dtype float64.
+"""
+
+
+ROSENBROCK_4_MINIMUM = tf.constant([-1.01917], tf.float64)
+"""
+The global minimum for the :func:`rosenbrock_4` function, with shape [1] and dtype
+float64.
+"""
+
+
+def ackley_5(x: TensorType) -> TensorType:
+    """
+    The Ackley test function over :math:`[0, 1]^5`. This function has
+    many local minima and a global minima. See https://www.sfu.ca/~ssurjano/ackley.html
+    for details.
+
+    Note that we rescale the original problem, which is typically defined
+    over `[-32.768, 32.768]`
+
+    :param x: The points at which to evaluate the function, with shape [..., 5].
+    :return: The function values at ``x``, with shape [..., 1].
+    :raise ValueError (or InvalidArgumentError): If ``x`` has an invalid shape.
+    """
+    tf.debugging.assert_shapes([(x, (..., 5))])
+
+    x = (x - 0.5) * (32.768 * 2.0)
+
+    exponent_1 = -0.2 * tf.math.sqrt((1 / 5.0) * tf.reduce_sum(x ** 2, -1))
+    exponent_2 = (1 / 5.0) * tf.reduce_sum(tf.math.cos(2.0 * math.pi * x), -1)
+
+    function = (
+        -20.0 * tf.math.exp(exponent_1)
+        - tf.math.exp(exponent_2)
+        + 20.0
+        + tf.cast(tf.math.exp(1.0), dtype=tf.float64)
+    )
+
+    return tf.expand_dims(function, -1)
+
+
+ACKLEY_5_MINIMIZER = tf.constant([[0.5, 0.5, 0.5, 0.5, 0.5]], tf.float64)
+"""
+The global minimizer for the :func:`ackley_5` function, with shape [1, 5] and
+dtype float64.
+"""
+
+
+ACKLEY_5_MINIMUM = tf.constant([0.0], tf.float64)
+"""
+The global minimum for the :func:`ackley_5` function, with shape [1] and dtype
+float64.
+"""
+
+
 def hartmann_6(x: TensorType) -> TensorType:
     """
     The Hartmann 6 test function over :math:`[0, 1]^6`. This function has

--- a/trieste/utils/objectives.py
+++ b/trieste/utils/objectives.py
@@ -178,7 +178,7 @@ def rosenbrock_4(x: TensorType) -> TensorType:
     """
     tf.debugging.assert_shapes([(x, (..., 4))])
 
-    y : TensorType = x * 15.0 - 5
+    y: TensorType = x * 15.0 - 5
     unscaled_function = tf.reduce_sum(
         (100.0 * (y[..., 1:] - y[..., :-1]) ** 2 + (1 - y[..., :-1]) ** 2), axis=-1, keepdims=True
     )

--- a/trieste/utils/objectives.py
+++ b/trieste/utils/objectives.py
@@ -178,9 +178,9 @@ def rosenbrock_4(x: TensorType) -> TensorType:
     """
     tf.debugging.assert_shapes([(x, (..., 4))])
 
-    x = 15.0 * x - 5
+    y : TensorType = x * 15.0 - 5
     unscaled_function = tf.reduce_sum(
-        (100.0 * (x[..., 1:] - x[..., :-1]) ** 2 + (1 - x[..., :-1]) ** 2), axis=-1, keepdims=True
+        (100.0 * (y[..., 1:] - y[..., :-1]) ** 2 + (1 - y[..., :-1]) ** 2), axis=-1, keepdims=True
     )
     return (unscaled_function - 3.827 * 1e5) / (3.755 * 1e5)
 


### PR DESCRIPTION
I have added two extra synthetic benchmarks: a 4-d Rosenbrock and 5-d Ackley function.

As well as adding tests for this new functions, I also combined some existing tests using parametrize and moved the tests of the multi-objective synthetic functions into a separate file (like we did with MO code).