### PR TITLE
Added a random search acquisition function optimizer

### DIFF
--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -43,37 +43,37 @@ def _quadratic_sum(shift: list[float]) -> AcquisitionFunction:
             DiscreteSearchSpace(tf.constant([[-0.5], [0.2], [1.2], [1.7]])),
             [1.0],
             [[1.2]],
-            [optimize_discrete, generate_random_search_optimizer(10000)],
+            [optimize_discrete, generate_random_search_optimizer()],
         ),  # 1D
         (  # 2D
             DiscreteSearchSpace(tf.constant([[-0.5, -0.3], [-0.2, 0.3], [0.2, -0.3], [1.2, 0.4]])),
             [0.3, -0.4],
             [[0.2, -0.3]],
-            [optimize_discrete, generate_random_search_optimizer(10000)],
+            [optimize_discrete, generate_random_search_optimizer()],
         ),
         (
             Box([-1], [2]),
             [1.0],
             [[1.0]],
-            [optimize_continuous, generate_random_search_optimizer(1000)],
+            [optimize_continuous, generate_random_search_optimizer(10_000)],
         ),  # 1D
         (
             Box([-1, -2], [1.5, 2.5]),
             [0.3, -0.4],
             [[0.3, -0.4]],
-            [optimize_continuous, generate_random_search_optimizer(10000)],
+            [optimize_continuous, generate_random_search_optimizer(10_000)],
         ),  # 2D
         (
             Box([-1, -2], [1.5, 2.5]),
             [1.0, 4],
             [[1.0, 2.5]],
-            [optimize_continuous, generate_random_search_optimizer(10000)],
+            [optimize_continuous, generate_random_search_optimizer(10_000)],
         ),  # 2D with maximum outside search space
         (
             Box([-1, -2, 1], [1.5, 2.5, 1.5]),
             [0.3, -0.4, 0.5],
             [[0.3, -0.4, 1.0]],
-            [optimize_continuous, generate_random_search_optimizer(10000)],
+            [optimize_continuous, generate_random_search_optimizer(100_000)],
         ),  # 3D
     ],
 )
@@ -85,7 +85,12 @@ def test_optimizer(
 ) -> None:
     for optimizer in optimizers:
         maximizer = optimizer(search_space, _quadratic_sum(shift))
-        npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-3)
+        if optimizer is optimize_continuous:
+            npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-3)
+        elif optimizer is optimize_discrete:
+            npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-4)
+        else:
+            npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-1)
 
 
 def test_optimize_batch_raises_with_invalid_batch_size() -> None:

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -130,7 +130,8 @@ def batchify(
     :param batch_size: The number of points in the batch.
     :return: An :const:`AcquisitionOptimizer` that will provide a batch of points with shape [B, D].
     """
-    tf.debugging.assert_positive(batch_size)
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
 
     def optimizer(search_space: SP, f: AcquisitionFunction) -> TensorType:
         expanded_search_space = search_space ** batch_size  # points have shape [B * D]
@@ -151,7 +152,9 @@ def batchify(
 def generate_random_search_optimizer(num_samples: int=1000) -> AcquisitionOptimizer[SP]:
     # Generate an acquistion optimizer that samples `num_samples` random points across the search space.
 
-    tf.debugging.assert_positive(num_samples)
+
+    if num_samples <= 0:
+        raise ValueError(f"num_samples must be positive, got {num_samples}")
 
     def optimizer(space: SP, target_func: AcquisitionFunction) -> TensorType:
         """

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -149,9 +149,8 @@ def batchify(
     return optimizer
 
 
-def generate_random_search_optimizer(num_samples: int=1000) -> AcquisitionOptimizer[SP]:
-    # Generate an acquistion optimizer that samples `num_samples` random points across the search space.
-
+def generate_random_search_optimizer(num_samples: int = 1000) -> AcquisitionOptimizer[SP]:
+    # Generate an acquistion optimizer that samples `num_samples` random points across the space.
 
     if num_samples <= 0:
         raise ValueError(f"num_samples must be positive, got {num_samples}")
@@ -170,9 +169,11 @@ def generate_random_search_optimizer(num_samples: int=1000) -> AcquisitionOptimi
         """
 
         if isinstance(space, DiscreteSearchSpace) and (num_samples > len(space.points)):
-            num_samples = len(space.points)
-            
-        samples = space.sample(num_samples)
+            _num_samples = len(space.points)
+        else:
+            _num_samples = num_samples
+
+        samples = space.sample(_num_samples)
         target_func_values = target_func(samples[:, None, :])
         max_value_idx = tf.argmax(target_func_values, axis=0)[0]
         return samples[max_value_idx : max_value_idx + 1]

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -142,7 +142,12 @@ def optimize_random(
         raise ValueError(f"num_samples must be positive, got {num_samples}")
 
     if isinstance(space, DiscreteSearchSpace) and num_samples > len(space.points):
-        num_samples = len(space.points)
+        raise ValueError(
+            f"""
+            Cannot get {num_samples} samples from a discrete search space
+            containing only {len(space.points)} points.
+            """
+        )
 
     samples = space.sample(num_samples)
     target_func_values = target_func(samples[:, None, :])


### PR DESCRIPTION
Added a random search acquisition function optimizer. 

This is a simple (but often effective) optimizer that we are currently missing and is useful for benchmarking.

Random search can be applied to any search space with a sample method and so will be useful for when we start to support a wider range of search space types. At the moment, each of our optimizers only work for a single search space type.

