### PR TITLE
More flexible Local Penalization.

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -17,7 +17,10 @@ import pytest
 import tensorflow as tf
 
 from tests.util.misc import random_seed
-from trieste.acquisition.function import BatchMonteCarloExpectedImprovement, LocalPenalization
+from trieste.acquisition.function import (
+    BatchMonteCarloExpectedImprovement,
+    LocalPenalizationAcquisitionFunction,
+)
 from trieste.acquisition.rule import (
     OBJECTIVE,
     AcquisitionRule,
@@ -45,9 +48,9 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
             ),
         ),
         (
-            15,
+            10,
             EfficientGlobalOptimization(
-                LocalPenalization(Box([0, 0], [1, 1])).using(OBJECTIVE),
+                LocalPenalizationAcquisitionFunction(Box([0, 0], [1, 1])).using(OBJECTIVE),
                 num_query_points=3,
             ),
         ),

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -17,10 +17,7 @@ import pytest
 import tensorflow as tf
 
 from tests.util.misc import random_seed
-from trieste.acquisition.function import (
-    BatchMonteCarloExpectedImprovement,
-    LocallyPenalizedExpectedImprovement,
-)
+from trieste.acquisition.function import BatchMonteCarloExpectedImprovement, LocalPenalization
 from trieste.acquisition.rule import (
     OBJECTIVE,
     AcquisitionRule,
@@ -50,7 +47,7 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
         (
             15,
             EfficientGlobalOptimization(
-                LocallyPenalizedExpectedImprovement(Box([0, 0], [1, 1])).using(OBJECTIVE),
+                LocalPenalization(Box([0, 0], [1, 1])).using(OBJECTIVE),
                 num_query_points=3,
             ),
         ),

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -48,7 +48,7 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
             ),
         ),
         (
-            10,
+            15,
             EfficientGlobalOptimization(
                 LocallyPenalizedExpectedImprovement(Box([0, 0], [1, 1])).using(OBJECTIVE),
                 num_query_points=3,

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -769,7 +769,7 @@ def test_locally_penalized_expected_improvement_raises_when_called_with_invalid_
     base_builder = NegativeLowerConfidenceBound()
     with pytest.raises(ValueError):
         LocalPenalizationAcquisitionFunction(
-            search_space, base_acquisition_function_builder=base_builder
+            search_space, base_acquisition_function_builder=base_builder  # type: ignore
         )
 
 

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -769,7 +769,7 @@ def test_locally_penalized_expected_improvement_raises_when_called_before_initia
     "base_builder", [ExpectedImprovement(), MinValueEntropySearch(Box([0, 0], [1, 1]))]
 )
 def test_locally_penalized_acquisition_matches_base_acquisition(
-    base_builder: AcquisitionFunctionBuilder,
+    base_builder,
 ) -> None:
     data = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
     search_space = Box([0, 0], [1, 1])
@@ -801,7 +801,7 @@ def test_locally_penalized_acquisition_matches_base_acquisition(
 )
 def test_locally_penalized_expected_improvement_combines_base_and_penalization_correctly(
     penalizer: Callable[..., PenalizationFunction],
-    base_builder: AcquisitionFunctionBuilder,
+    base_builder,
 ):
     data = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
     search_space = Box([0, 0], [1, 1])

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -42,7 +42,7 @@ from trieste.acquisition.function import (
     ExpectedConstrainedImprovement,
     ExpectedHypervolumeImprovement,
     ExpectedImprovement,
-    LocalPenalization,
+    LocalPenalizationAcquisitionFunction,
     MinValueEntropySearch,
     NegativeLowerConfidenceBound,
     NegativePredictiveMean,
@@ -729,7 +729,7 @@ def test_locally_penalized_expected_improvement_builder_raises_for_empty_data() 
     data = Dataset(tf.zeros([0, 1]), tf.ones([0, 1]))
     space = Box([0, 0], [1, 1])
     with pytest.raises(ValueError):
-        LocalPenalization(search_space=space).prepare_acquisition_function(
+        LocalPenalizationAcquisitionFunction(search_space=space).prepare_acquisition_function(
             data, QuadraticMeanAndRBFKernel()
         )
 
@@ -737,7 +737,7 @@ def test_locally_penalized_expected_improvement_builder_raises_for_empty_data() 
 def test_locally_penalized_expected_improvement_builder_raises_for_invalid_num_samples() -> None:
     search_space = Box([0, 0], [1, 1])
     with pytest.raises(ValueError):
-        LocalPenalization(search_space, num_samples=-5)
+        LocalPenalizationAcquisitionFunction(search_space, num_samples=-5)
 
 
 @pytest.mark.parametrize("pending_points", [tf.constant([0.0]), tf.constant([[[0.0], [1.0]]])])
@@ -746,7 +746,7 @@ def test_locally_penalized_expected_improvement_builder_raises_for_invalid_pendi
 ) -> None:
     data = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
     space = Box([0, 0], [1, 1])
-    builder = LocalPenalization(search_space=space)
+    builder = LocalPenalizationAcquisitionFunction(search_space=space)
     builder.prepare_acquisition_function(
         data, QuadraticMeanAndRBFKernel(), None
     )  # first initialize
@@ -759,7 +759,7 @@ def test_locally_penalized_expected_improvement_raises_when_called_before_initia
     search_space = Box([0, 0], [1, 1])
     pending_points = tf.zeros([1, 2])
     with pytest.raises(ValueError):
-        LocalPenalization(search_space).prepare_acquisition_function(
+        LocalPenalizationAcquisitionFunction(search_space).prepare_acquisition_function(
             data, QuadraticMeanAndRBFKernel(), pending_points
         )
 
@@ -768,7 +768,9 @@ def test_locally_penalized_expected_improvement_raises_when_called_with_invalid_
     search_space = Box([0, 0], [1, 1])
     base_builder = NegativeLowerConfidenceBound()
     with pytest.raises(ValueError):
-        LocalPenalization(search_space, base_acquisition_function_builder=base_builder)
+        LocalPenalizationAcquisitionFunction(
+            search_space, base_acquisition_function_builder=base_builder
+        )
 
 
 @random_seed
@@ -782,7 +784,9 @@ def test_locally_penalized_acquisitions_match_base_acquisition(
     search_space = Box([0, 0], [1, 1])
     model = QuadraticMeanAndRBFKernel()
 
-    lp_acq_builder = LocalPenalization(search_space, base_acquisition_function_builder=base_builder)
+    lp_acq_builder = LocalPenalizationAcquisitionFunction(
+        search_space, base_acquisition_function_builder=base_builder
+    )
     lp_acq = lp_acq_builder.prepare_acquisition_function(data, model, None)
 
     base_acq = base_builder.prepare_acquisition_function(data, model)
@@ -813,7 +817,7 @@ def test_locally_penalized_acquisitions_combine_base_and_penalization_correctly(
     model = QuadraticMeanAndRBFKernel()
     pending_points = tf.zeros([1, 2], dtype=tf.float64)
 
-    acq_builder = LocalPenalization(
+    acq_builder = LocalPenalizationAcquisitionFunction(
         search_space, penalizer=penalizer, base_acquisition_function_builder=base_builder
     )
     acq_builder.prepare_acquisition_function(data, model, None)  # initialize

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -44,7 +44,7 @@ from .function import (
     ExpectedHypervolumeImprovement,
     ExpectedImprovement,
     GreedyAcquisitionFunctionBuilder,
-    LocalPenalization,
+    LocalPenalizationAcquisitionFunction,
     MinValueEntropySearch,
     NegativeLowerConfidenceBound,
     NegativePredictiveMean,

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -44,7 +44,7 @@ from .function import (
     ExpectedHypervolumeImprovement,
     ExpectedImprovement,
     GreedyAcquisitionFunctionBuilder,
-    LocallyPenalizedExpectedImprovement,
+    LocalPenalization,
     MinValueEntropySearch,
     NegativeLowerConfidenceBound,
     NegativePredictiveMean,

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -777,7 +777,7 @@ class LocallyPenalizedExpectedImprovement(SingleModelGreedyAcquisitionBuilder):
         search_space: SearchSpace,
         num_samples: int = 500,
         penalizer: Callable[..., PenalizationFunction] = None,
-        base_acquisition_function_builder: Optional[SingleModelAcquisitionFunctionBuilder] = None,
+        base_acquisition_function_builder: Optional[SingleModelAcquisitionBuilder] = None,
     ):
         """
         :param search_space: The global search space over which the optimisation is defined.
@@ -795,11 +795,15 @@ class LocallyPenalizedExpectedImprovement(SingleModelGreedyAcquisitionBuilder):
 
         self._lipschitz_penalizer = soft_local_penalizer if penalizer is None else penalizer
 
-        self._base_builder = ExpectedImprovement() if base_acquisition_function_builder is None else base_acquisition_function_builder
-        
+        self._base_builder = (
+            ExpectedImprovement()
+            if base_acquisition_function_builder is None
+            else base_acquisition_function_builder
+        )
+
         self._lipschitz_constant = None
         self._eta = None
-        self._base_acquisition_function : Optional[AcquisitionFunction] = None
+        self._base_acquisition_function: Optional[AcquisitionFunction] = None
 
     def prepare_acquisition_function(
         self,


### PR DESCRIPTION
I have added functionality to specify the base acquisition function used by local penalization.

LP assumes a strictly positive acquisition function and so we map all base acquisition functions through a softplus transform (as recommended by the original authors).

