### PR TITLE
Add mechanism to mark slow running tests

### DIFF
--- a/.github/workflows/develop-checks.yaml
+++ b/.github/workflows/develop-checks.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 The Trieste Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: develop
+    tags: v[0-9]+.[0-9]+.[0-9]+*
+
+jobs:
+  alltests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - run: pip install tox
+    - run: tox -e alltests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,11 @@ Run tests with
 $ tox -e tests
 ```
 
+To save time, some slower tests are not run by default. Run these with:
+```bash
+$ tox -e alltests
+```
+
 #### Code formatting
 
 We format all Python code, other than the notebooks, with [black](https://black.readthedocs.io/en/stable/), [flake8](https://flake8.pycqa.org/en/latest/), and [isort](https://pycqa.github.io/isort/). You may need to run these before pushing changes, with (in the repository root)
@@ -89,8 +94,10 @@ pip install -r common_build/taskipy/requirements.txt -c common_build/taskipy/con
 
 You can then use `task` to run various common tasks:
 
-- `task tests` to run all the tests (including type checking);
+- `task tests` to run all the normal tests (including type checking);
 - `task quicktests` to run just the unit tests (starting with the last failure and exiting immediately on any error);
+- `task alltests` to run all the tests including the slow ones;
+- `task slowtests` to run just the slow tests;
 - `task mypy` to run just the type checks;
 - `task format` to reformat the code using black, flake8 and isort;
 - `task check_format` to check whether the code is correctly formatted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,9 +94,9 @@ pip install -r common_build/taskipy/requirements.txt -c common_build/taskipy/con
 
 You can then use `task` to run various common tasks:
 
-- `task tests` to run all the normal tests (including type checking);
+- `task tests` to run all the tests (including type checking, but excluding slow tests);
 - `task quicktests` to run just the unit tests (starting with the last failure and exiting immediately on any error);
-- `task alltests` to run all the tests including the slow ones;
+- `task alltests` to run all the tests including the slow tests;
 - `task slowtests` to run just the slow tests;
 - `task mypy` to run just the type checks;
 - `task format` to reformat the code using black, flake8 and isort;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,9 @@ skip_glob = "docs/notebooks"
 line_length = 100
 
 [tool.taskipy.tasks]
-tests = "pytest --mypy --cov trieste --cov-report html:htmlcov"
+tests = "pytest --mypy --cov trieste --cov-report html:htmlcov --durations 6"
+alltests = "pytest --mypy --durations 6 --runslow yes"
+slowtests = "pytest --mypy --durations 6 --runslow only"
 quicktests = "pytest -x --ff -rN -Wignore --ignore-glob=tests/integration/*"
 mypy = "pytest --mypy --cache-clear -m mypy -v"
 pylint = "pytest --pylint --cache-clear -m pylint -v trieste"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+# Copyright 2021 The Trieste Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store", default="no", choices=("yes","no","only"), help="whether to run slow tests"
+    )
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow") == "no":
+        skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
+    elif config.getoption("--runslow") == "only":
+        skip_fast = pytest.mark.skip(reason="--skipfast option set")
+        for item in items:
+            if "slow" not in item.keywords:
+                item.add_marker(skip_fast)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,13 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--runslow", action="store", default="no", choices=("yes","no","only"), help="whether to run slow tests"
+        "--runslow",
+        action="store",
+        default="no",
+        choices=("yes", "no", "only"),
+        help="whether to run slow tests",
     )
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,8 @@ commands =
     format: isort --check .
     tests: pip install . -r tests/requirements.txt -c tests/constraints.txt
     tests: pytest
+    alltests: pip install . -r tests/requirements.txt -c tests/constraints.txt
+    alltests: pytest --runslow yes
     notebooks: pip install . -r notebooks/requirements.txt -c notebooks/constraints.txt
     notebooks: bash -c "res=0; for f in notebooks/*.py; do python "$f" || res=$?; done; $(exit $res)"
     docs: pip install . -r notebooks/requirements.txt -c notebooks/constraints.txt -r docs/requirements.txt -c docs/constraints.txt

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -150,8 +150,12 @@ def batchify(
 
 
 def generate_random_search_optimizer(num_samples: int = 1000) -> AcquisitionOptimizer[SP]:
-    # Generate an acquistion optimizer that samples `num_samples` random points across the space.
+    """
+    Generate an acquisition optimizer that samples `num_samples` random points across the space.
 
+    :param num_samples: The number of random points to sample.
+    :return: The acquisition optimizer.
+    """
     if num_samples <= 0:
         raise ValueError(f"num_samples must be positive, got {num_samples}")
 

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -200,7 +200,7 @@ class EfficientGlobalOptimization(AcquisitionRule[None, SP_contra]):
         points = self._optimizer(search_space, acquisition_function)
 
         if isinstance(self._builder, GreedyAcquisitionFunctionBuilder):
-            for i in range(
+            for _ in range(
                 self._num_query_points - 1
             ):  # greedily allocate remaining batch elements
                 greedy_acquisition_function = self._builder.prepare_acquisition_function(


### PR DESCRIPTION
After this PR:

- you can now mark slow running tests with `@pytest.mark.slow`.
- these tests will be skipped by default, but can be run with `pytest --runslow yes`, `tox -e alltests` or `task alltests`
- (alternatively you can use `pytest --runslow only` or `task slowtests` to run just the slow tests)
- running tests via `task` now also shows the slowest running tests
- there is a github workflow to run all the tests (including the slow ones) after a merge to develop or release

TODO

- figure out how failures can be reported (email/status/badge/?). This may require merging first.
- figure out what to do for slow running notebooks. This should probably be in a different PR.