### PR TITLE
Hopefully fix docs deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 on:
+  workflow_dispatch:
   push:
     tags: v[0-9]+.[0-9]+.[0-9]+*
 
@@ -42,6 +43,7 @@ jobs:
         touch docs/.nojekyll
     - run: |
         git add .
+        git add -f docs/autoapi
         git config --global user.email "none"
         git config --global user.name "github-actions-bot"
         git commit -m "build documentation"


### PR DESCRIPTION
Looks like https://github.com/secondmind-labs/trieste/pull/240 broke the docs deployment script (which is only run at release time) by keeping the autoapi files around when building and (more importantly) adding autoapi to .gitignore to stop them appearing in git status. Unfortunately, the deployment phase tries to add files at that directory when updating the docs.

This change explicitly adds those files with `-f` to override the gitignore. It also allows manually triggering the docs deployment so we don't need to rerelease. Once the docs are fixed I'll remove that ability.