### PR TITLE
Remove workflow_dispatch for deploy.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 on:
-  workflow_dispatch:
   push:
     tags: v[0-9]+.[0-9]+.[0-9]+*
 


### PR DESCRIPTION
Revert the ability to manually deploy documentation added in https://github.com/secondmind-labs/trieste/pull/263 as there should be a safer, more restrictive way to do this.