### PR TITLE
Thompson Sampling Overhaul

### DIFF
--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -50,10 +50,10 @@ model_config = {
 # %% [markdown]
 # ## Create the Thompson sampling acquisition rule
 #
-# We achieve Bayesian optimization with Thompson sampling by specifying `ThompsonSampling` as the acquisition rule. Unlike the `EfficientGlobalOptimization` acquisition rule, `ThompsonSampling` does not use an acquisition function. Instead, in each optimization step, the rule samples `num_query_points` samples from the model posterior at `num_search_space_samples` points on the search space. It then returns the `num_query_points` points of those that minimise the model posterior.
+# We achieve Bayesian optimization with Thompson sampling by specifying `DiscreteThompsonSampling` as the acquisition rule. Unlike the `EfficientGlobalOptimization` acquisition rule, `DiscreteThompsonSampling` does not use an acquisition function. Instead, in each optimization step, the rule samples `num_query_points` samples from the model posterior at `num_search_space_samples` points on the search space. It then returns the `num_query_points` points of those that minimise the model posterior.
 
 # %%
-acq_rule = trieste.acquisition.rule.ThompsonSampling(
+acq_rule = trieste.acquisition.rule.DiscreteThompsonSampling(
     num_search_space_samples=1000, num_query_points=10
 )
 

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -26,7 +26,7 @@ from trieste.acquisition.function import (
 from trieste.acquisition.rule import (
     AcquisitionRule,
     EfficientGlobalOptimization,
-    ThompsonSampling,
+    DiscreteThompsonSampling,
     TrustRegion,
 )
 from trieste.bayesian_optimizer import BayesianOptimizer
@@ -66,7 +66,8 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
             ),
         ),
         (15, TrustRegion()),
-        (17, ThompsonSampling(500, 3)),
+        (17, DiscreteThompsonSampling(500, 3)),
+        (15, DiscreteThompsonSampling(1000, 3, num_fourier_features=1000)),
     ],
 )
 def test_optimizer_finds_minima_of_the_branin_function(

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -25,8 +25,8 @@ from trieste.acquisition.function import (
 )
 from trieste.acquisition.rule import (
     AcquisitionRule,
-    EfficientGlobalOptimization,
     DiscreteThompsonSampling,
+    EfficientGlobalOptimization,
     TrustRegion,
 )
 from trieste.bayesian_optimizer import BayesianOptimizer

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -19,6 +19,7 @@ import unittest.mock
 from collections.abc import Mapping
 from typing import Callable
 
+import gpflow
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
@@ -249,33 +250,73 @@ def test_min_value_entropy_search_builder_raises_for_empty_data() -> None:
         builder.prepare_acquisition_function(data, QuadraticMeanAndRBFKernel())
 
 
-def test_min_value_entropy_search_builder_raises_for_invalid_gumbel_sample_sizes() -> None:
+@pytest.mark.parametrize("param", [-2, 0])
+def test_min_value_entropy_search_builder_raises_for_invalid_init_params(param: int) -> None:
     search_space = Box([0, 0], [1, 1])
     with pytest.raises(ValueError):
-        MinValueEntropySearch(search_space, num_samples=-5)
+        MinValueEntropySearch(search_space, num_samples=param)
     with pytest.raises(ValueError):
-        MinValueEntropySearch(search_space, grid_size=-5)
+        MinValueEntropySearch(search_space, grid_size=param)
+    with pytest.raises(ValueError):
+        MinValueEntropySearch(search_space, num_fourier_features=param)
+
+
+def test_min_value_entropy_search_builder_raises_when_given_num_features_and_gumbel() -> None:
+    # cannot do feature-based approx of Gumbel sampler
+    search_space = Box([0, 0], [1, 1])
+    with pytest.raises(ValueError):
+        MinValueEntropySearch(search_space, num_fourier_features=10)
 
 
 @unittest.mock.patch("trieste.acquisition.function.min_value_entropy_search")
-def test_min_value_entropy_search_builder_gumbel_samples(mocked_mves) -> None:
+@pytest.mark.parametrize("use_thompson", [True, False])
+def test_min_value_entropy_search_builder_builds_min_value_samples(
+    mocked_mves, use_thompson
+) -> None:
     dataset = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
     search_space = Box([0, 0], [1, 1])
-    builder = MinValueEntropySearch(search_space)
+    builder = MinValueEntropySearch(search_space, use_thompson=use_thompson)
     model = QuadraticMeanAndRBFKernel()
     builder.prepare_acquisition_function(dataset, model)
     mocked_mves.assert_called_once()
 
     # check that the Gumbel samples look sensible
-    gumbel_samples = mocked_mves.call_args[0][1]
+    min_value_samples = mocked_mves.call_args[0][1]
     query_points = builder._search_space.sample(num_samples=builder._grid_size)
     query_points = tf.concat([dataset.query_points, query_points], 0)
     fmean, _ = model.predict(query_points)
-    assert max(gumbel_samples) < min(fmean)
+    assert max(min_value_samples) < min(fmean)
+
+
+@random_seed
+@unittest.mock.patch("trieste.acquisition.function.min_value_entropy_search")
+def test_min_value_entropy_search_builder_builds_min_value_samples_rff(mocked_mves) -> None:
+    search_space = Box([0.0, 0.0], [1.0, 1.0])
+    model = QuadraticMeanAndRBFKernel(noise_variance=tf.constant(1e-10, dtype=tf.float64))
+    model.kernel = (
+        gpflow.kernels.RBF()
+    )  # need a gpflow kernel object for random feature decompositions
+
+    x_range = tf.linspace(0.0, 1.0, 5)
+    x_range = tf.cast(x_range, dtype=tf.float64)
+    xs = tf.reshape(tf.stack(tf.meshgrid(x_range, x_range, indexing="ij"), axis=-1), (-1, 2))
+    ys = quadratic(xs)
+    dataset = Dataset(xs, ys)
+
+    builder = MinValueEntropySearch(search_space, use_thompson=True, num_fourier_features=100)
+    builder.prepare_acquisition_function(dataset, model)
+    mocked_mves.assert_called_once()
+
+    # check that the Gumbel samples look sensible
+    min_value_samples = mocked_mves.call_args[0][1]
+    query_points = builder._search_space.sample(num_samples=builder._grid_size)
+    query_points = tf.concat([dataset.query_points, query_points], 0)
+    fmean, _ = model.predict(query_points)
+    assert max(min_value_samples) < min(fmean)
 
 
 @pytest.mark.parametrize("samples", [tf.constant([]), tf.constant([[[]]])])
-def test_min_value_entropy_search_raises_for_gumbel_samples_with_invalid_shape(
+def test_min_value_entropy_search_raises_for_min_values_samples_with_invalid_shape(
     samples: TensorType,
 ) -> None:
     with pytest.raises(ValueError):
@@ -292,9 +333,9 @@ def test_min_value_entropy_search_raises_for_invalid_batch_size(at: TensorType) 
 
 def test_min_value_entropy_search_returns_correct_shape() -> None:
     model = QuadraticMeanAndRBFKernel()
-    gumbel_samples = tf.constant([[1.0], [2.0]])
+    min_value_samples = tf.constant([[1.0], [2.0]])
     query_at = tf.linspace([[-10.0]], [[10.0]], 5)
-    evals = min_value_entropy_search(model, gumbel_samples)(query_at)
+    evals = min_value_entropy_search(model, min_value_samples)(query_at)
     npt.assert_array_equal(evals.shape, tf.constant([5, 1]))
 
 
@@ -311,11 +352,11 @@ def test_min_value_entropy_search_chooses_same_as_probability_of_improvement() -
     x_range = tf.cast(x_range, dtype=tf.float64)
     xs = tf.reshape(tf.stack(tf.meshgrid(x_range, x_range, indexing="ij"), axis=-1), (-1, 2))
 
-    gumbel_sample = tf.constant([[1.0]], dtype=tf.float64)
-    mes_evals = min_value_entropy_search(model, gumbel_sample)(xs[..., None, :])
+    min_value_sample = tf.constant([[1.0]], dtype=tf.float64)
+    mes_evals = min_value_entropy_search(model, min_value_sample)(xs[..., None, :])
 
     mean, variance = model.predict(xs)
-    gamma = (tf.cast(gumbel_sample, dtype=mean.dtype) - mean) / tf.sqrt(variance)
+    gamma = (tf.cast(min_value_sample, dtype=mean.dtype) - mean) / tf.sqrt(variance)
     norm = tfp.distributions.Normal(tf.cast(0, dtype=mean.dtype), tf.cast(1, dtype=mean.dtype))
     pi_evals = norm.cdf(gamma)
     npt.assert_array_equal(tf.argmax(mes_evals), tf.argmax(pi_evals))

--- a/tests/unit/acquisition/test_sampler.py
+++ b/tests/unit/acquisition/test_sampler.py
@@ -40,22 +40,14 @@ def test_gumbel_sampler_raises_for_invalid_sample_size(
     sample_size: int,
 ) -> None:
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        GumbelSampler(sample_size, QuadraticMeanAndRBFKernel(), sample_min_value=True)
-
-
-@pytest.mark.parametrize("sample_size", [0, -2])
-def test_gumbel_sampler_raises_when_trying_sample_minimisers(
-    sample_size: int,
-) -> None:
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        GumbelSampler(10, QuadraticMeanAndRBFKernel(), sample_min_value=False)
+        GumbelSampler(sample_size, QuadraticMeanAndRBFKernel())
 
 
 @pytest.mark.parametrize("shape", [[], [1], [2], [1, 2, 3]])
 def test_gumbel_sampler_sample_raises_for_invalid_at_shape(
     shape: ShapeLike,
 ) -> None:
-    sampler = GumbelSampler(1, QuadraticMeanAndRBFKernel(), sample_min_value=True)
+    sampler = GumbelSampler(1, QuadraticMeanAndRBFKernel())
 
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
         sampler.sample(tf.zeros(shape))
@@ -64,7 +56,7 @@ def test_gumbel_sampler_sample_raises_for_invalid_at_shape(
 @pytest.mark.parametrize("sample_size", [10, 100])
 def test_gumbel_sampler_returns_correctly_shaped_samples(sample_size: int) -> None:
     search_space = Box([0, 0], [1, 1])
-    gumbel_sampler = GumbelSampler(sample_size, QuadraticMeanAndRBFKernel(), sample_min_value=True)
+    gumbel_sampler = GumbelSampler(sample_size, QuadraticMeanAndRBFKernel())
     query_points = search_space.sample(5)
     gumbel_samples = gumbel_sampler.sample(query_points)
     tf.debugging.assert_shapes([(gumbel_samples, [sample_size, 1])])
@@ -80,7 +72,7 @@ def test_gumbel_samples_are_minima() -> None:
     dataset = Dataset(xs, ys)
 
     model = QuadraticMeanAndRBFKernel()
-    gumbel_sampler = GumbelSampler(5, model, sample_min_value=True)
+    gumbel_sampler = GumbelSampler(5, model)
 
     query_points = search_space.sample(100)
     query_points = tf.concat([dataset.query_points, query_points], 0)

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -65,6 +65,6 @@ from .sampler import (
     BatchReparametrizationSampler,
     ExactThompsonSampler,
     GumbelSampler,
-    RandomFourierFeatureThompsonSampler,
     IndependentReparametrizationSampler,
+    RandomFourierFeatureThompsonSampler,
 )

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -63,7 +63,8 @@ from .function import (
 )
 from .sampler import (
     BatchReparametrizationSampler,
-    DiscreteThompsonSampler,
+    ExactThompsonSampler,
     GumbelSampler,
+    RandomFourierFeatureThompsonSampler,
     IndependentReparametrizationSampler,
 )

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -32,7 +32,13 @@ from ..space import SearchSpace
 from ..type import TensorType
 from ..utils import DEFAULTS
 from ..utils.pareto import Pareto, get_reference_point
-from .sampler import BatchReparametrizationSampler, GumbelSampler, RandomFourierFeatureThompsonSampler, ExactThompsonSampler
+from .sampler import (
+    BatchReparametrizationSampler,
+    ExactThompsonSampler,
+    GumbelSampler,
+    RandomFourierFeatureThompsonSampler,
+    ThompsonSampler,
+)
 
 AcquisitionFunction = Callable[[TensorType], TensorType]
 """
@@ -246,16 +252,23 @@ class MinValueEntropySearch(SingleModelAcquisitionBuilder):
     :math:`y^*` via a Gumbel sampler. TODO talk about costs of sampling
     """
 
-    def __init__(self, search_space: SearchSpace, num_samples: int = 10, grid_size: int = 5000, use_thompson: bool = False, num_fourier_features: Optional[int]=None):
+    def __init__(
+        self,
+        search_space: SearchSpace,
+        num_samples: int = 10,
+        grid_size: int = 5000,
+        use_thompson: bool = False,
+        num_fourier_features: Optional[int] = None,
+    ):
         """
         :param search_space: The global search space over which the optimisation is defined.
         :param num_samples: Number of samples to draw from the distribution over the minimum of the
             objective function.
         :param grid_size: Size of the grid with which to fit the Gumbel distribution. We recommend
             scaling this with search space dimension.
-        :param use_thompson: If True then use Thompson sampling to sample the objective's 
+        :param use_thompson: If True then use Thompson sampling to sample the objective's
             minimum, else use Gumbel sampling.
-        :param num_fourier_features: Number of fourier features used for approximate Thompson 
+        :param num_fourier_features: Number of fourier features used for approximate Thompson
             sampling. If None, then do exact Thompson sampling.
         """
         self._search_space = search_space
@@ -270,9 +283,16 @@ class MinValueEntropySearch(SingleModelAcquisitionBuilder):
 
         if type(num_fourier_features) is int:
             if not use_thompson:
-                raise ValueError(f"Fourier features approximation can only be applied to thompson sampling however `use_thompson` is {use_thompson}.")
-            if num_fourier_features<=0:
-                raise ValueError(f"num_fourier_features must be positive, got {num_fourier_features}")
+                raise ValueError(
+                    f"""
+                    Fourier features approximation can only be applied to thompson sampling
+                    however `use_thompson` is {use_thompson}.
+                    """
+                )
+            if num_fourier_features <= 0:
+                raise ValueError(
+                    f"num_fourier_features must be positive, got {num_fourier_features}"
+                )
         self._use_thompson = use_thompson
         self._num_fourier_features = num_fourier_features
 
@@ -289,13 +309,21 @@ class MinValueEntropySearch(SingleModelAcquisitionBuilder):
         if len(dataset.query_points) == 0:
             raise ValueError("Dataset must be populated.")
 
-        if not self._use_thompson: # use Gumbel sampler
-            sampler = GumbelSampler(self._num_samples, model, sample_min_value=True)
+        if not self._use_thompson:  # use Gumbel sampler
+            sampler: ThompsonSampler = GumbelSampler(
+                self._num_samples, model, sample_min_value=True
+            )
         else:
-            if type(num_fourier_features) is int: # use approximate Thompson sampler
-                sampler =  RandomFourierFeatureThompsonSampler(self._num_samples, model, dataset, sample_min_value=True, num_features = num_fourier_features)
-            else: # use exact Thompson sampler
-                sampler = ExactThompsonSampler(self._num_samples, model,sample_min_value=True )
+            if type(self._num_fourier_features) is int:  # use approximate Thompson sampler
+                sampler = RandomFourierFeatureThompsonSampler(
+                    self._num_samples,
+                    model,
+                    dataset,
+                    sample_min_value=True,
+                    num_features=self._num_fourier_features,
+                )
+            else:  # use exact Thompson sampler
+                sampler = ExactThompsonSampler(self._num_samples, model, sample_min_value=True)
 
         query_points = self._search_space.sample(num_samples=self._grid_size)
         tf.debugging.assert_same_float_dtype([dataset.query_points, query_points])

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -249,7 +249,10 @@ class MinValueEntropySearch(SingleModelAcquisitionBuilder):
     of the objective minimum that would be gained by evaluating the objective at a given point.
 
     This implementation largely follows :cite:`wang2017max` and samples the objective's minimum
-    :math:`y^*` via a Gumbel sampler. TODO talk about costs of sampling
+    :math:`y^*` across a large set of sampled locations via either a Gumbel sampler, an exact
+    Thompson sampler or an approximate random Fourier feature-based Thompson sampler, with the
+    Gumbel sampler being the cheapest but least accurate.
+
     """
 
     def __init__(

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -213,7 +213,16 @@ class EfficientGlobalOptimization(AcquisitionRule[None, SP_contra]):
 
 
 class DiscreteThompsonSampling(AcquisitionRule[None, SearchSpace]):
-    """Implements Thompson sampling for choosing optimal points. TODO SAY DISCRETE"""
+    r"""
+    Implements Thompson sampling for choosing optimal points over a discrete set of
+    candidate points.
+
+    The model is sampled either exactly (with an :math:`O(N^3)` complexity for a set of `N`
+    candidate points), or sampled approximately through a random Fourier feature decompisition
+    (with an :math:`O(\min(n^3,M^3))` complexity for a model trained on `n` points and
+    using `M` features).
+
+    """
 
     def __init__(
         self,
@@ -224,7 +233,8 @@ class DiscreteThompsonSampling(AcquisitionRule[None, SearchSpace]):
         """
         :param num_search_space_samples: The number of points at which to sample the posterior.
         :param num_query_points: The number of points to acquire.
-        :num_fourier_features: TODO
+        :num_fourier_features: The number of features used to approximate the kernel. We recommend
+            first trying 1000 features, as this typically perfoms well for a wide range of kernels.
         """
         if not num_search_space_samples > 0:
             raise ValueError(f"Search space must be greater than 0, got {num_search_space_samples}")

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -233,8 +233,9 @@ class DiscreteThompsonSampling(AcquisitionRule[None, SearchSpace]):
         """
         :param num_search_space_samples: The number of points at which to sample the posterior.
         :param num_query_points: The number of points to acquire.
-        :num_fourier_features: The number of features used to approximate the kernel. We recommend
-            first trying 1000 features, as this typically perfoms well for a wide range of kernels.
+        :num_fourier_features: The number of features used to approximate the kernel. We
+            recommend first trying 1000 features, as this typically perfoms well for a wide
+            range of kernels. If None, then we perfom exact Thompson sampling.
         """
         if not num_search_space_samples > 0:
             raise ValueError(f"Search space must be greater than 0, got {num_search_space_samples}")
@@ -244,7 +245,7 @@ class DiscreteThompsonSampling(AcquisitionRule[None, SearchSpace]):
                 f"Number of query points must be greater than 0, got {num_query_points}"
             )
 
-        if (type(num_fourier_features) is int) and (num_fourier_features <= 0):
+        if num_fourier_features is not None and num_fourier_features <= 0:
             raise ValueError(
                 f"Number of fourier features must be greater than 0, got {num_query_points}"
             )

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -43,7 +43,7 @@ from .optimizer import (
     batchify,
     optimize_continuous,
 )
-from .sampler import DiscreteThompsonSampler
+from .sampler import ExactThompsonSampler, RandomFourierFeatureThompsonSampler
 
 S = TypeVar("S")
 """ Unbound type variable. """

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -214,13 +214,14 @@ class EfficientGlobalOptimization(AcquisitionRule[None, SP_contra]):
 
 class DiscreteThompsonSampling(AcquisitionRule[None, SearchSpace]):
     r"""
-    Implements Thompson sampling for choosing optimal points over a discrete set of
-    candidate points.
+    Implements Thompson sampling for choosing optimal points.
 
-    The model is sampled either exactly (with an :math:`O(N^3)` complexity for a set of `N`
-    candidate points), or sampled approximately through a random Fourier feature decompisition
-    (with an :math:`O(\min(n^3,M^3))` complexity for a model trained on `n` points and
-    using `M` features).
+    This rule returns the minimizers of functions sampled from our model and evaluated across
+    a discretization of the search space (containing `N` candidate points).
+
+    The model is sampled either exactly (with an :math:`O(N^3)` complexity), or sampled
+    approximately through a random Fourier `M` feature decompisition
+    (with an :math:`O(\min(n^3,M^3))` complexity for a model trained on `n` points).
 
     """
 

--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -61,13 +61,12 @@ class Sampler(ABC):
         """
 
 
-
 class ThompsonSampler(Sampler, ABC):
     r"""
     TODO
     """
 
-    def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value: bool):
+    def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value: bool=False):
         """
         :param sample_size: The desired number of samples.
         :param model: The model to sample from.
@@ -86,39 +85,40 @@ class ThompsonSampler(Sampler, ABC):
         """
 
 
-
-
-
-
-
-
-class DiscreteThompsonSampler(Sampler):
+class ExactThompsonSampler(ThompsonSampler):
     r"""
     This sampler provides approximate Thompson samples of the objective function's
     maximiser :math:`x^*` over a discrete set of input locations.
+
+    TODO SAY OUTPUT and exact (still approx)
     """
 
     def sample(self, at: TensorType) -> TensorType:
         """
-        Return approximate samples from of the objective function's minimser. We return only
-        unique samples.
+        Return exact samples from either the objective function's minimser or its minimal value over the candidate set `at`.
 
         :param at: Where to sample the predictive distribution, with shape `[N, D]`, for points
             of dimension `D`.
-        :return: The samples, of shape `[S, D]`, where `S` is the `sample_size`.
+        :return: The samples, of shape `[S, D]` (where `S` is the `sample_size`) if sampling
+            the function's minimser or shape `[S, 1]` if sampling the function's mimimal value.
         :raise ValueError (or InvalidArgumentError): If ``at`` has an invalid shape.
         """
         tf.debugging.assert_shapes([(at, ["N", None])])
 
-        samples = self._model.sample(at, self._sample_size)  # [self._sample_size, len(at), 1]
-        samples_2d = tf.squeeze(samples, -1)  # [self._sample_size, len(at)]
-        indices = tf.math.argmin(samples_2d, axis=1)
-        unique_indices = tf.unique(indices).y
-        thompson_samples = tf.gather(at, unique_indices)
+        samples = self._model.sample(at, self._sample_size)  # [S, N, 1]
+
+
+        if self._sample_min_value:
+            thompson_samples = tf.reduce_min(samples, axis=1) # [S, 1]
+
+        else:
+            samples_2d = tf.squeeze(samples, -1)  # [S, N]
+            indices = tf.math.argmin(samples_2d, axis=1)
+            thompson_samples = tf.gather(at, indices) # [S, D]
         return thompson_samples
 
 
-class GumbelSampler(Sampler):
+class GumbelSampler(ThompsonSampler):
     r"""
     This sampler follows :cite:`wang2017max` and yields approximate samples of the objective
     minimum value :math:`y^*` via the empirical cdf :math:`\operatorname{Pr}(y^*<y)`. The cdf
@@ -130,7 +130,25 @@ class GumbelSampler(Sampler):
     Samples are obtained via the Gumbel distribution by sampling :math:`r` uniformly from
     :math:`[0, 1]` and applying the inverse probability integral transform
     :math:`y = \mathcal G^{-1}(r; a, b)`.
+
+
+    TODO, only output samples
     """
+
+def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value: bool=False):
+        """
+        :param sample_size: The desired number of samples.
+        :param model: The model to sample from.
+        :sample_min_value: If True then sample from the minimum value of the function,
+            else sample the function's minimiser. TODO only output
+        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
+        """
+        if not sample_min_value:
+            raise ValueError("Gumbel sampler can only provide samples of the minimum value of a function and so requires `sample_min_value` to be True")
+
+        super().__init__(sample_size, sample_min_value)
+
+
 
     def sample(self, at: TensorType) -> TensorType:
         """
@@ -325,44 +343,7 @@ for all queries. This property is known as consistency.
 """
 
 
-
-class ContinuousSampler(ABC):
-    r"""
-    An :class:`ContinuousSampler` samples a specific quantity according
-    to an underlying :class:`ProbabilisticModel`.
-    Unlike our :class:`Sampler`, :class:`ContinuousSampler` returns a
-    queryable function (a trajectory) that provides the sample's value at a query location.
-    """
-
-    def __init__(self, dataset: Dataset, model: ProbabilisticModel):
-        """
-        :param dataset: The data from the observer. Must be populated.
-        :param model: The model to sample from.
-        :raise ValueError: If ``dataset`` is empty.
-        """
-
-        if len(dataset.query_points) == 0:
-            raise ValueError("Dataset must be populated.")
-
-        self._dataset = dataset
-        self._model = model
-
-    def __repr__(self) -> str:
-        """"""
-        return f"{self.__class__.__name__}({self._model!r}, {self._dataset!r})"
-
-    @abstractmethod
-    def get_trajectory(self) -> TrajectoryFunction:
-        """
-        Return a trajectory function that evaluates a particular sample at a set of `N` query
-        points (each of dimension `D`) i.e. takes input of shape `[N, D]` and returns
-        shape `[N, 1]`.
-
-        :return: Queryable function representing a sample.
-        """
-
-
-class RandomFourierFeatureThompsonSampler(ContinuousSampler):
+class RandomFourierFeatureThompsonSampler(ThompsonSampler):
     r"""
     This class builds functions that approximate a trajectory sampled from an underlying Gaussian
     process model. For tractibility, the Gaussian process is approximated with a Bayesian
@@ -370,7 +351,7 @@ class RandomFourierFeatureThompsonSampler(ContinuousSampler):
     the model's kernel. See :cite:`hernandez2014predictive` for details.
 
     Achieving consistency (ensuring that the same sample draw for all evalutions of a particular
-    trajectry function) for exact sample draws from a  GP is prohibitively costly because it scales
+    trajectory function) for exact sample draws from a GP is prohibitively costly because it scales
     cubically with the number of query points. However, finite feature representations can be
     evaluated with constant cost regardless of the required number of queries.
 
@@ -398,16 +379,29 @@ class RandomFourierFeatureThompsonSampler(ContinuousSampler):
     of m (as required to approximate very flexible kernels).
     """
 
-    def __init__(self, dataset: Dataset, model: ProbabilisticModel, num_features: int = 1000):
+    def __init__(self, model: ProbabilisticModel, dataset: Dataset, sample_min_value: bool=False, num_features: int = 1000):
         """
-        :param dataset: The data from the observer. Must be populated.
+        TODO, to initilzie we calculate the posterior distributions for
+        the feature weights.
+
         :param model: The model to sample from.
+        :param dataset: The data from the observer. Must be populated.
+        :sample_min_value: If True then sample from the minimum value of the function,
+            else sample the function's minimiser.
         :param num_features: The number of features used to approximate the kernel. We use a default
             of 1000 as it typically perfoms well for a wide range of kernel. Note that very smooth
             kernels (e.g. RBF) can be well-approximated with fewer features.
         :raise ValueError: If ``dataset`` is empty.
         """
-        super().__init__(dataset, model)
+
+        super().__init__(model, dataset, sample_min_value)
+
+        if len(dataset.query_points) == 0:
+            raise ValueError("Dataset must be populated.")
+
+        self._dataset = dataset
+        self._model = model
+
 
         tf.debugging.assert_positive(num_features)
         self._num_features = num_features  # m
@@ -423,6 +417,20 @@ class RandomFourierFeatureThompsonSampler(ContinuousSampler):
             with a Gaussian likelihood and an accessible kernel attribute.
             """
             )
+
+
+        self._feature_functions = RandomFourierFeatures(
+                self._kernel, self._num_features, dtype=self._dataset.query_points.dtype
+            ) # prep feature functions at data
+
+        if (
+            self._num_features < self._num_data
+        ):  # if m < n  then calculate posterior in design space (an m*m matrix inversion)
+            self._theta_posterior = self._prepare_theta_posterior_in_design_space()
+        else:  # if n <= m  then calculate posterior in gram space (an n*n matrix inversion)
+            self._theta_posterior = self._prepare_theta_posterior_in_gram_space()
+
+
 
         self._pre_calc = False  # Flag so we only calculate the posterior for the weights once.
 
@@ -500,26 +508,9 @@ class RandomFourierFeatureThompsonSampler(ContinuousSampler):
         Generate an approximate function draw (trajectory) by sampling weights
         and evaluating the feature functions.
 
-        If this is the first call, then we calculate the posterior distributions for
-        the feature weights.
-
         :return: A trajectory function representing an approximate trajectory from the Gaussian
             process, taking an input of shape `[N, D]` and returning shape `[N, 1]`
         """
-
-        if not self._pre_calc:
-            self._feature_functions = RandomFourierFeatures(
-                self._kernel, self._num_features, dtype=self._dataset.query_points.dtype
-            )
-
-            if (
-                self._num_features < self._num_data
-            ):  # if m < n  then calculate posterior in design space (an m*m matrix inversion)
-                self._theta_posterior = self._prepare_theta_posterior_in_design_space()
-            else:  # if n <= m  then calculate posterior in gram space (an n*n matrix inversion)
-                self._theta_posterior = self._prepare_theta_posterior_in_gram_space()
-
-            self._pre_calc = True
 
         theta_sample = self._theta_posterior.sample(1)  # [1, m]
 
@@ -528,3 +519,35 @@ class RandomFourierFeatureThompsonSampler(ContinuousSampler):
             return tf.matmul(feature_evaluations, theta_sample, transpose_b=True)  # [N,1]
 
         return trajectory
+
+
+
+    def sample(self, at: TensorType) -> TensorType:
+        """
+        Return approximate samples from either the objective function's minimser or its minimal value over the candidate set `at`.
+
+        :param at: Where to sample the predictive distribution, with shape `[N, D]`, for points
+            of dimension `D`.
+        :return: The samples, of shape `[S, D]` (where `S` is the `sample_size`) if sampling
+            the function's minimser or shape `[S, 1]` if sampling the function's mimimal value.
+        :raise ValueError (or InvalidArgumentError): If ``at`` has an invalid shape.
+        """
+        tf.debugging.assert_shapes([(at, ["N", None])])
+
+
+        if self._sample_min_value:
+            thompson_samples = tf.zeros([0,1]) # [0,1]
+        else:
+            thompson_samples = tf.zeros([0,tf.shape(at)[1]]) # [0,D]
+
+        for _ in tf.range(self._sample_size): 
+            sampled_trajectory = self.trajectory()
+            evaluated_trajectory = sampled_trajectory(at) # [N, 1]
+            if self._sample_min_value:
+                sample = tf.reduce_min(evaluated_trajectory) # [1, 1]
+            else:
+                sample = tf.gather(at, tf.math.argmin(evaluated_trajectory)) # [1, D]
+
+            thompson_samples = tf.concat([thompson_samples, sample], axis=0)
+
+        return thompson_samples # [S, D] or [S, 1]

--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -64,7 +64,7 @@ class Sampler(ABC):
 class ThompsonSampler(Sampler, ABC):
     r"""
     A :class:`ThompsonSampler` samples either the minimum values or minimisers of a function
-    modelled by an underlying :class:`ProbabilisticModel` across a  discrete set of points.
+    modeled by an underlying :class:`ProbabilisticModel` across a  discrete set of points.
 
     """
 
@@ -85,13 +85,6 @@ class ThompsonSampler(Sampler, ABC):
         {self._sample_size!r},
         {self._model!r},
         {self._sample_min_value})
-        """
-
-    @abstractmethod
-    def sample(self, at: TensorType) -> TensorType:
-        """
-        :param at: Input points that define the sampler.
-        :return: Samples.
         """
 
 
@@ -123,11 +116,11 @@ class ExactThompsonSampler(ThompsonSampler):
 
         if self._sample_min_value:
             thompson_samples = tf.reduce_min(samples, axis=1)  # [S, 1]
-
         else:
             samples_2d = tf.squeeze(samples, -1)  # [S, N]
             indices = tf.math.argmin(samples_2d, axis=1)
             thompson_samples = tf.gather(at, indices)  # [S, D]
+
         return thompson_samples
 
 
@@ -144,29 +137,17 @@ class GumbelSampler(ThompsonSampler):
     :math:`[0, 1]` and applying the inverse probability integral transform
     :math:`y = \mathcal G^{-1}(r; a, b)`.
 
-
     Note that the :class:`GumbelSampler` can only sample a function's minimal value and not
     its minimiser.
     """
 
-    def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value: bool = False):
+    def __init__(self, sample_size: int, model: ProbabilisticModel):
         """
         :param sample_size: The desired number of samples.
         :param model: The model to sample from.
-        :sample_min_value: If True then sample from the minimum value of the function,
-            else sample the function's minimiser.
-        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive or
-            if ``sample_min_value`` is False.
+        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
         """
-        if not sample_min_value:
-            raise ValueError(
-                f"""
-                Gumbel sampler only provides samples of the minimum value of a function,
-                however, `sample_min_value` is {sample_min_value}
-                """
-            )
-
-        super().__init__(sample_size, model, sample_min_value)
+        super().__init__(sample_size, model, True)
 
     def sample(self, at: TensorType) -> TensorType:
         """

--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -34,7 +34,7 @@ from ..utils import DEFAULTS
 
 class Sampler(ABC):
     r"""
-    An :class:`Sampler` samples a specific quantity across a discrete set of points
+    A :class:`Sampler` samples a specific quantity across a discrete set of points
     according to an underlying :class:`ProbabilisticModel`.
     """
 
@@ -63,7 +63,9 @@ class Sampler(ABC):
 
 class ThompsonSampler(Sampler, ABC):
     r"""
-    TODO
+    A :class:`ThompsonSampler` samples either the minimum values or minimisers of a function
+    modelled by an underlying :class:`ProbabilisticModel` across a  discrete set of points.
+
     """
 
     def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value: bool = False):
@@ -95,10 +97,13 @@ class ThompsonSampler(Sampler, ABC):
 
 class ExactThompsonSampler(ThompsonSampler):
     r"""
-    This sampler provides approximate Thompson samples of the objective function's
+    This sampler provides exact Thompson samples of the objective function's
     maximiser :math:`x^*` over a discrete set of input locations.
 
-    TODO SAY OUTPUT and exact (still approx)
+    Although exact Thompson sampling is costly (incuring with an :math:`O(N^3)` complexity to
+    sample over a set of `N` locations), this method can be used for any probabilistic model
+    with a sampling method.
+
     """
 
     def sample(self, at: TensorType) -> TensorType:
@@ -140,7 +145,8 @@ class GumbelSampler(ThompsonSampler):
     :math:`y = \mathcal G^{-1}(r; a, b)`.
 
 
-    TODO, only output samples
+    Note that the :class:`GumbelSampler` can only sample a function's minimal value and not
+    its minimiser.
     """
 
     def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value: bool = False):
@@ -148,8 +154,9 @@ class GumbelSampler(ThompsonSampler):
         :param sample_size: The desired number of samples.
         :param model: The model to sample from.
         :sample_min_value: If True then sample from the minimum value of the function,
-            else sample the function's minimiser. TODO only output
-        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
+            else sample the function's minimiser.
+        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive or
+            if ``sample_min_value`` is False.
         """
         if not sample_min_value:
             raise ValueError(
@@ -399,16 +406,13 @@ class RandomFourierFeatureThompsonSampler(ThompsonSampler):
         num_features: int = 1000,
     ):
         """
-        TODO, to initilzie we calculate the posterior distributions for
-        the feature weights.
-
         :param sample_size: The desired number of samples.
         :param model: The model to sample from.
         :param dataset: The data from the observer. Must be populated.
         :sample_min_value: If True then sample from the minimum value of the function,
             else sample the function's minimiser.
         :param num_features: The number of features used to approximate the kernel. We use a default
-            of 1000 as it typically perfoms well for a wide range of kernel. Note that very smooth
+            of 1000 as it typically perfoms well for a wide range of kernels. Note that very smooth
             kernels (e.g. RBF) can be well-approximated with fewer features.
         :raise ValueError: If ``dataset`` is empty.
         """

--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -135,7 +135,7 @@ class GumbelSampler(ThompsonSampler):
     TODO, only output samples
     """
 
-def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value: bool=False):
+    def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value: bool=False):
         """
         :param sample_size: The desired number of samples.
         :param model: The model to sample from.
@@ -144,10 +144,9 @@ def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value
         :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
         """
         if not sample_min_value:
-            raise ValueError("Gumbel sampler can only provide samples of the minimum value of a function and so requires `sample_min_value` to be True")
+            raise ValueError(f"Gumbel sampler only provides samples of the minimum value of a function, however, `sample_min_value` is {sample_min_value}")
 
-        super().__init__(sample_size, sample_min_value)
-
+        super().__init__(sample_size, model, sample_min_value)
 
 
     def sample(self, at: TensorType) -> TensorType:
@@ -379,11 +378,12 @@ class RandomFourierFeatureThompsonSampler(ThompsonSampler):
     of m (as required to approximate very flexible kernels).
     """
 
-    def __init__(self, model: ProbabilisticModel, dataset: Dataset, sample_min_value: bool=False, num_features: int = 1000):
+    def __init__(self, sample_size: int, model: ProbabilisticModel, dataset: Dataset, sample_min_value: bool=False, num_features: int = 1000):
         """
         TODO, to initilzie we calculate the posterior distributions for
         the feature weights.
 
+        :param sample_size: The desired number of samples.
         :param model: The model to sample from.
         :param dataset: The data from the observer. Must be populated.
         :sample_min_value: If True then sample from the minimum value of the function,
@@ -394,7 +394,7 @@ class RandomFourierFeatureThompsonSampler(ThompsonSampler):
         :raise ValueError: If ``dataset`` is empty.
         """
 
-        super().__init__(model, dataset, sample_min_value)
+        super().__init__(sample_size, model, sample_min_value)
 
         if len(dataset.query_points) == 0:
             raise ValueError("Dataset must be populated.")

--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -32,9 +32,9 @@ from ..type import TensorType
 from ..utils import DEFAULTS
 
 
-class DiscreteSampler(ABC):
+class Sampler(ABC):
     r"""
-    An :class:`DiscreteSampler` samples a specific quantity across a discrete set of points
+    An :class:`Sampler` samples a specific quantity across a discrete set of points
     according to an underlying :class:`ProbabilisticModel`.
     """
 
@@ -61,7 +61,38 @@ class DiscreteSampler(ABC):
         """
 
 
-class DiscreteThompsonSampler(DiscreteSampler):
+
+class ThompsonSampler(Sampler, ABC):
+    r"""
+    TODO
+    """
+
+    def __init__(self, sample_size: int, model: ProbabilisticModel, sample_min_value: bool):
+        """
+        :param sample_size: The desired number of samples.
+        :param model: The model to sample from.
+        :sample_min_value: If True then sample from the minimum value of the function,
+            else sample the function's minimiser.
+        :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
+        """
+        super().__init__(sample_size, model)
+        self._sample_min_value = sample_min_value
+
+    @abstractmethod
+    def sample(self, at: TensorType) -> TensorType:
+        """
+        :param at: Input points that define the sampler.
+        :return: Samples.
+        """
+
+
+
+
+
+
+
+
+class DiscreteThompsonSampler(Sampler):
     r"""
     This sampler provides approximate Thompson samples of the objective function's
     maximiser :math:`x^*` over a discrete set of input locations.
@@ -87,7 +118,7 @@ class DiscreteThompsonSampler(DiscreteSampler):
         return thompson_samples
 
 
-class GumbelSampler(DiscreteSampler):
+class GumbelSampler(Sampler):
     r"""
     This sampler follows :cite:`wang2017max` and yields approximate samples of the objective
     minimum value :math:`y^*` via the empirical cdf :math:`\operatorname{Pr}(y^*<y)`. The cdf
@@ -146,7 +177,7 @@ class GumbelSampler(DiscreteSampler):
         return gumbel_samples
 
 
-class IndependentReparametrizationSampler(DiscreteSampler):
+class IndependentReparametrizationSampler(Sampler):
     r"""
     This sampler employs the *reparameterization trick* to approximate samples from a
     :class:`ProbabilisticModel`\ 's predictive distribution as
@@ -195,7 +226,7 @@ class IndependentReparametrizationSampler(DiscreteSampler):
         return mean + tf.sqrt(var) * tf.cast(self._eps[:, None, :], var.dtype)  # [..., S, 1, L]
 
 
-class BatchReparametrizationSampler(DiscreteSampler):
+class BatchReparametrizationSampler(Sampler):
     r"""
     This sampler employs the *reparameterization trick* to approximate batches of samples from a
     :class:`ProbabilisticModel`\ 's predictive joint distribution as
@@ -294,11 +325,12 @@ for all queries. This property is known as consistency.
 """
 
 
+
 class ContinuousSampler(ABC):
     r"""
     An :class:`ContinuousSampler` samples a specific quantity according
     to an underlying :class:`ProbabilisticModel`.
-    Unlike our :class:`DiscreteSampler`, :class:`ContinuousSampler` returns a
+    Unlike our :class:`Sampler`, :class:`ContinuousSampler` returns a
     queryable function (a trajectory) that provides the sample's value at a query location.
     """
 


### PR DESCRIPTION
I have overhauled our Thompson sampling functionality to support Fourier feature decompositions and have a more consistent sampling interface. 

Significant changes are as follows:

- we no longer have separate discrete and continuous sampler classes. We now have a general Sampler class and a ThompsonSampler subclass. The ThompsonSampler class differs from Sampler as it has an additional input to determine if we return samples of the function's minimal value (as required for entropy search) or its minimiser (as required for Thompson sampling).
- The RandomFourierFeatureThompsonSampler no longer has a prebuild logic as this turned out to be unnecessary.  This class also now has a sample method (over a discrete set of locations) to match the other ThompsonSampler classes. We can still access the full sampled trajectory, which will be required for a future continuous Thompson sampler PR.
- The ThompsonSampling rule is now more appropriately named DiscreteThompsonSampling and now supports exact or approximate (feature-based) Thompson sampling over a discrete candidate set.
- The MinValueEntropySearch acquisition function can now get its min value samples using Gumbel, exact (discrete) Thompson sampling or approximate (feature-based) Thompson sampling.