### PR TITLE
Better continuous optimizers

### DIFF
--- a/docs/notebooks/batch_optimization.pct.py
+++ b/docs/notebooks/batch_optimization.pct.py
@@ -74,7 +74,7 @@ model = create_model(model_spec)
 from trieste.acquisition import BatchMonteCarloExpectedImprovement
 from trieste.acquisition.rule import EfficientGlobalOptimization
 
-batch_ei_acq = BatchMonteCarloExpectedImprovement(sample_size=1000)
+batch_ei_acq = BatchMonteCarloExpectedImprovement(sample_size=1000, jitter=1e-5)
 batch_ei_acq_rule = EfficientGlobalOptimization(  # type: ignore
     num_query_points=10, builder=batch_ei_acq)
 points_chosen_by_batch_ei, _ = batch_ei_acq_rule.acquire_single(search_space, initial_data, model)

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -15,6 +15,7 @@ import gpflow
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from tests.util.misc import random_seed
 from trieste.acquisition.function import (
@@ -41,31 +42,31 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
 @pytest.mark.parametrize(
     "num_steps, acquisition_rule",
     [
-        (20, EfficientGlobalOptimization()),
-        (20, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
+        (25, EfficientGlobalOptimization()),
+        (25, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
         (
-            15,
+            25,
             EfficientGlobalOptimization(
-                MinValueEntropySearch(Box([0, 0], [1, 1]), grid_size=1000, num_samples=10).using(
+                MinValueEntropySearch(Box([0, 0], [1, 1]), grid_size=1000, num_samples=5).using(
                     OBJECTIVE
                 )
             ),
         ),
         (
-            15,
+            20,
             EfficientGlobalOptimization(
                 BatchMonteCarloExpectedImprovement(sample_size=500).using(OBJECTIVE),
                 num_query_points=2,
             ),
         ),
         (
-            10,
+            15,
             EfficientGlobalOptimization(
                 LocalPenalizationAcquisitionFunction(Box([0, 0], [1, 1])).using(OBJECTIVE),
                 num_query_points=3,
             ),
         ),
-        (15, TrustRegion()),
+        (20, TrustRegion()),
         (17, DiscreteThompsonSampling(500, 3)),
         (15, DiscreteThompsonSampling(1000, 3, num_fourier_features=1000)),
     ],
@@ -78,11 +79,18 @@ def test_optimizer_finds_minima_of_the_branin_function(
     def build_model(data: Dataset) -> GaussianProcessRegression:
         variance = tf.math.reduce_variance(data.observations)
         kernel = gpflow.kernels.Matern52(variance, tf.constant([0.2, 0.2], tf.float64))
+        scale = tf.constant(1.0, dtype=tf.float64)
+        kernel.variance.prior = tfp.distributions.LogNormal(
+            tf.constant(-2.0, dtype=tf.float64), scale
+        )
+        kernel.lengthscales.prior = tfp.distributions.LogNormal(
+            tf.math.log(kernel.lengthscales), scale
+        )
         gpr = gpflow.models.GPR((data.query_points, data.observations), kernel, noise_variance=1e-5)
         gpflow.utilities.set_trainable(gpr.likelihood, False)
         return GaussianProcessRegression(gpr)
 
-    initial_query_points = search_space.sample(5)
+    initial_query_points = search_space.sample(10)
     observer = mk_observer(branin)
     initial_data = observer(initial_query_points)
     model = build_model(initial_data)

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -23,8 +23,8 @@ from trieste.acquisition.optimizer import (
     AcquisitionOptimizer,
     automatic_optimizer_selector,
     batchify,
+    generate_continuous_optimizer,
     generate_random_search_optimizer,
-    optimize_continuous,
     optimize_discrete,
 )
 from trieste.space import Box, DiscreteSearchSpace
@@ -33,6 +33,11 @@ from trieste.type import TensorType
 
 def _quadratic_sum(shift: list[float]) -> AcquisitionFunction:
     return lambda x: tf.reduce_sum(0.5 - quadratic(x - shift), axis=-2)
+
+
+def test_generate_random_search_optimizer_raises_with_invalid_sample_size() -> None:
+    with pytest.raises(ValueError):
+        generate_random_search_optimizer(num_samples=-5)
 
 
 @random_seed
@@ -55,29 +60,23 @@ def _quadratic_sum(shift: list[float]) -> AcquisitionFunction:
             Box([-1], [2]),
             [1.0],
             [[1.0]],
-            [optimize_continuous, generate_random_search_optimizer(10_000)],
+            [generate_random_search_optimizer(10_000)],
         ),  # 1D
         (
             Box([-1, -2], [1.5, 2.5]),
             [0.3, -0.4],
             [[0.3, -0.4]],
-            [optimize_continuous, generate_random_search_optimizer(10_000)],
+            [generate_random_search_optimizer(10_000)],
         ),  # 2D
         (
             Box([-1, -2], [1.5, 2.5]),
             [1.0, 4],
             [[1.0, 2.5]],
-            [optimize_continuous, generate_random_search_optimizer(10_000)],
+            [generate_random_search_optimizer(10_000)],
         ),  # 2D with maximum outside search space
-        (
-            Box([-1, -2, 1], [1.5, 2.5, 1.5]),
-            [0.3, -0.4, 0.5],
-            [[0.3, -0.4, 1.0]],
-            [optimize_continuous, generate_random_search_optimizer(100_000)],
-        ),  # 3D
     ],
 )
-def test_optimizer(
+def test_discrete_and_random_optimizer(
     search_space: DiscreteSearchSpace,
     shift: list[float],
     expected_maximizer: list[list[float]],
@@ -85,16 +84,69 @@ def test_optimizer(
 ) -> None:
     for optimizer in optimizers:
         maximizer = optimizer(search_space, _quadratic_sum(shift))
-        if optimizer is optimize_continuous:
-            npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-3)
-        elif optimizer is optimize_discrete:
+        if optimizer is optimize_discrete:
             npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-4)
         else:
             npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-1)
 
 
+def test_generate_continuous_optimizer_raises_with_invalid_init_params() -> None:
+    with pytest.raises(ValueError):
+        generate_continuous_optimizer(num_samples=-5)
+    with pytest.raises(ValueError):
+        generate_continuous_optimizer(num_restarts=-5)
+    with pytest.raises(NotImplementedError):
+        generate_continuous_optimizer(sigmoid=False, num_restarts=5)
+
+
+@random_seed
+@pytest.mark.parametrize(
+    "search_space, shift, expected_maximizer",
+    [
+        (
+            Box([-1], [2]),
+            [1.0],
+            [[1.0]],
+        ),  # 1D
+        (
+            Box([-1, -2], [1.5, 2.5]),
+            [0.3, -0.4],
+            [[0.3, -0.4]],
+        ),  # 2D
+        (
+            Box([-1, -2], [1.5, 2.5]),
+            [1.0, 4],
+            [[1.0, 2.5]],
+        ),  # 2D with maximum outside search space
+        (
+            Box([-1, -2, 1], [1.5, 2.5, 1.5]),
+            [0.3, -0.4, 0.5],
+            [[0.3, -0.4, 1.0]],
+        ),  # 3D
+    ],
+)
+@pytest.mark.parametrize(
+    "optimizer",
+    [
+        generate_continuous_optimizer(),
+        generate_continuous_optimizer(sigmoid=True),
+        generate_continuous_optimizer(sigmoid=True, num_restarts=10),
+        generate_continuous_optimizer(sigmoid=False, num_restarts=3),
+    ],
+)
+def test_continuous_optimizer(
+    search_space: DiscreteSearchSpace,
+    shift: list[float],
+    expected_maximizer: list[list[float]],
+    optimizer: AcquisitionOptimizer,
+) -> None:
+
+    maximizer = optimizer(search_space, _quadratic_sum(shift))
+    npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-4)
+
+
 def test_optimize_batch_raises_with_invalid_batch_size() -> None:
-    batch_size_one_optimizer = optimize_continuous
+    batch_size_one_optimizer = generate_continuous_optimizer()
     with pytest.raises(ValueError):
         batchify(batch_size_one_optimizer, -5)
 
@@ -111,7 +163,7 @@ def test_optimize_batch_raises_with_invalid_batch_size() -> None:
 def test_optimize_batch(
     search_space: Box, acquisition: AcquisitionFunction, maximizer: TensorType, batch_size: int
 ) -> None:
-    batch_size_one_optimizer = optimize_continuous
+    batch_size_one_optimizer = generate_continuous_optimizer()
     batch_optimizer = batchify(batch_size_one_optimizer, batch_size)
     points = batch_optimizer(search_space, acquisition)
     assert points.shape == [batch_size] + search_space.lower.shape
@@ -141,8 +193,3 @@ def test_automatic_optimizer_selector(
     optimizer = automatic_optimizer_selector
     point = optimizer(search_space, acquisition)
     npt.assert_allclose(point, maximizer, rtol=2e-4)
-
-
-def test_generate_random_search_optimizer_raises_with_invalid_sample_size() -> None:
-    with pytest.raises(ValueError):
-        generate_random_search_optimizer(num_samples=-5)

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -92,7 +92,7 @@ def test_discrete_and_random_optimizer(
 
 def test_generate_continuous_optimizer_raises_with_invalid_init_params() -> None:
     with pytest.raises(ValueError):
-        generate_continuous_optimizer(num_samples=-5)
+        generate_continuous_optimizer(num_initial_samples=-5)
     with pytest.raises(ValueError):
         generate_continuous_optimizer(num_restarts=-5)
 

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -131,7 +131,6 @@ def test_generate_continuous_optimizer_raises_with_invalid_init_params() -> None
         generate_continuous_optimizer(),
         generate_continuous_optimizer(sigmoid=True),
         generate_continuous_optimizer(sigmoid=True, num_restarts=10),
-        generate_continuous_optimizer(sigmoid=False, num_restarts=3),
     ],
 )
 def test_continuous_optimizer(

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -95,8 +95,6 @@ def test_generate_continuous_optimizer_raises_with_invalid_init_params() -> None
         generate_continuous_optimizer(num_samples=-5)
     with pytest.raises(ValueError):
         generate_continuous_optimizer(num_restarts=-5)
-    with pytest.raises(NotImplementedError):
-        generate_continuous_optimizer(sigmoid=False, num_restarts=5)
 
 
 @random_seed
@@ -129,8 +127,9 @@ def test_generate_continuous_optimizer_raises_with_invalid_init_params() -> None
     "optimizer",
     [
         generate_continuous_optimizer(),
+        generate_continuous_optimizer(num_restarts=3),
         generate_continuous_optimizer(sigmoid=True),
-        generate_continuous_optimizer(sigmoid=True, num_restarts=10),
+        generate_continuous_optimizer(sigmoid=True, num_restarts=3),
     ],
 )
 def test_continuous_optimizer(
@@ -141,7 +140,7 @@ def test_continuous_optimizer(
 ) -> None:
 
     maximizer = optimizer(search_space, _quadratic_sum(shift))
-    npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-4)
+    npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-3)
 
 
 def test_optimize_batch_raises_with_invalid_batch_size() -> None:

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -184,7 +184,9 @@ class _GreedyBatchModelMinusMeanMaximumSingleBuilder(SingleModelGreedyAcquisitio
             return lambda at: -tf.reduce_max(model.predict(at)[0], axis=-2)
         else:
             best_pending_score = tf.reduce_max(model.predict(pending_points)[0])
-            return lambda at: -tf.math.maximum(model.predict(at)[0][0], best_pending_score)
+            return lambda at: -tf.math.maximum(
+                tf.reduce_max(model.predict(at)[0], axis=-2), best_pending_score
+            )
 
 
 @random_seed

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -127,7 +127,7 @@ def generate_continuous_optimizer(
     if not sigmoid and num_restarts > 1:
         raise NotImplementedError(
             """
-            Must have  `sigmoid=True` for `num_resarts>1`, as L-BFGS-B does not
+            Must have  `sigmoid=True` for `num_restarts>1`, as L-BFGS-B does not
             yet support parallel evaluations."
             """
         )

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -93,7 +93,7 @@ def optimize_discrete(space: DiscreteSearchSpace, target_func: AcquisitionFuncti
 
 
 def generate_continuous_optimizer(
-    num_samples: int = 1000, sigmoid: bool = False, num_restarts: int = 1
+    num_samples: int = 1000, sigmoid: bool = True, num_restarts: int = 10
 ) -> AcquisitionOptimizer[Box]:
     """
     Generate a gradient-based acquisition optimizer for :class:'Box' spaces and batches

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -93,12 +93,12 @@ def optimize_discrete(space: DiscreteSearchSpace, target_func: AcquisitionFuncti
 
 
 def generate_continuous_optimizer(
-    num_samples: int = 1000, sigmoid: bool = False, num_restarts: int = 1
+    num_initial_samples: int = 1000, sigmoid: bool = False, num_restarts: int = 1
 ) -> AcquisitionOptimizer[Box]:
     """
     Generate a gradient-based acquisition optimizer for :class:'Box' spaces and batches
     of size of 1. We perfom gradient-based optimization starting from the best location
-    across a sample of `num_samples` random points.
+    across a sample of `num_initial_samples` random points.
 
     This optimizer supports Scipy's L-BFGS-B and LBFGS optimizers. We
     constrain L-BFGS's search with a sigmoid bijector that maps an unconstrained space into
@@ -111,14 +111,14 @@ def generate_continuous_optimizer(
     The default behaviour of this method is to return a L-BFGS-B optimizer that perfoms
     a single optimization.
 
-    :param num_samples: The size of the random sample used to find the starting point(s) of
+    :param num_initial_samples: The size of the random sample used to find the starting point(s) of
         the optimization.
     :param sigmoid: If True then use L-BFGS, otherwise use L-BFGS-B.
-    :param num_restarts: The number of optimizations ran in parallel.
+    :param num_restarts: The number of separate optimizations to run.
     :return: The acquisition optimizer.
     """
-    if num_samples <= 0:
-        raise ValueError(f"num_samples must be positive, got {num_samples}")
+    if num_initial_samples <= 0:
+        raise ValueError(f"num_initial_samples must be positive, got {num_initial_samples}")
 
     if num_restarts <= 0:
         raise ValueError(f"num_parallel must be positive, got {num_restarts}")
@@ -134,7 +134,7 @@ def generate_continuous_optimizer(
         :return: The **one** point in ``space`` that maximises ``target_func``, with shape [1, D].
         """
 
-        trial_search_space = space.sample(num_samples)  # [num_samples, D]
+        trial_search_space = space.sample(num_initial_samples)  # [num_initial_samples, D]
         target_func_values = target_func(trial_search_space[:, None, :])  # [num_samples, 1]
         _, top_k_indicies = tf.math.top_k(
             tf.squeeze(target_func_values), k=num_restarts

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -112,10 +112,11 @@ def generate_continuous_optimizer(
     The default behaviour of this method is to return a L-BFGS optimizer that perfoms
     10 optimizations in parallel.
 
-    :param num_samples: The number of random points to sample. TODO
+    :param num_samples: The size of the random sample used to find the starting point(s) of
+        the optimization.
     :param sigmoid: If True then use Tensorflow's L-BFGS optimizer, otherwise use
         Scipy's L-BFGS-B optimizer.
-    :param num_restarts: TODO
+    :param num_restarts: The number of optimizations ran in parallel.
     :return: The acquisition optimizer.
     """
     if num_samples <= 0:

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -41,7 +41,7 @@ from .optimizer import (
     AcquisitionOptimizer,
     automatic_optimizer_selector,
     batchify,
-    optimize_continuous,
+    generate_continuous_optimizer,
 )
 from .sampler import ExactThompsonSampler, RandomFourierFeatureThompsonSampler, ThompsonSampler
 
@@ -366,7 +366,7 @@ class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):
             builder = builder.using(OBJECTIVE)
 
         if optimizer is None:
-            optimizer = optimize_continuous
+            optimizer = generate_continuous_optimizer()
 
         self._builder = builder
         self._beta = beta


### PR DESCRIPTION
We now have

-  2 different continuous optimizers: Scipy's L-BGS-B and L-BFGS (through a sigmoid mapping), each supporting multiple restarts
- a continuous acquisition optimiser builder to allow user to choose which continuous optimizer to use (define this when specifying your rule)

The default behaviour is to use  L-BFGS for 1 restarts.