### PR TITLE
GPR kernel initializer

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -41,10 +41,10 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
 @pytest.mark.parametrize(
     "num_steps, acquisition_rule",
     [
-        (25, EfficientGlobalOptimization()),
-        (25, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
+        (20, EfficientGlobalOptimization()),
+        (20, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
         (
-            25,
+            15,
             EfficientGlobalOptimization(
                 MinValueEntropySearch(Box([0, 0], [1, 1]), grid_size=1000, num_samples=10).using(
                     OBJECTIVE
@@ -52,20 +52,20 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
             ),
         ),
         (
-            20,
+            15,
             EfficientGlobalOptimization(
                 BatchMonteCarloExpectedImprovement(sample_size=500).using(OBJECTIVE),
                 num_query_points=2,
             ),
         ),
         (
-            15,
+            10,
             EfficientGlobalOptimization(
                 LocalPenalizationAcquisitionFunction(Box([0, 0], [1, 1])).using(OBJECTIVE),
                 num_query_points=3,
             ),
         ),
-        (20, TrustRegion()),
+        (15, TrustRegion()),
         (17, DiscreteThompsonSampling(500, 3)),
         (20, DiscreteThompsonSampling(1000, 3, num_fourier_features=1000)),
     ],

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -67,7 +67,7 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
         ),
         (15, TrustRegion()),
         (17, DiscreteThompsonSampling(500, 3)),
-        (20, DiscreteThompsonSampling(1000, 3, num_fourier_features=1000)),
+        (15, DiscreteThompsonSampling(1000, 3, num_fourier_features=1000)),
     ],
 )
 def test_optimizer_finds_minima_of_the_branin_function(

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -41,10 +41,10 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
 @pytest.mark.parametrize(
     "num_steps, acquisition_rule",
     [
-        (20, EfficientGlobalOptimization()),
-        (20, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
+        (25, EfficientGlobalOptimization()),
+        (25, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
         (
-            15,
+            25,
             EfficientGlobalOptimization(
                 MinValueEntropySearch(Box([0, 0], [1, 1]), grid_size=1000, num_samples=10).using(
                     OBJECTIVE
@@ -52,21 +52,21 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
             ),
         ),
         (
-            15,
+            20,
             EfficientGlobalOptimization(
                 BatchMonteCarloExpectedImprovement(sample_size=500).using(OBJECTIVE),
                 num_query_points=2,
             ),
         ),
         (
-            10,
+            15,
             EfficientGlobalOptimization(
                 LocalPenalizationAcquisitionFunction(Box([0, 0], [1, 1])).using(OBJECTIVE),
                 num_query_points=3,
             ),
         ),
-        (15, TrustRegion()),
-        (20, DiscreteThompsonSampling(500, 3)),
+        (20, TrustRegion()),
+        (17, DiscreteThompsonSampling(500, 3)),
         (20, DiscreteThompsonSampling(1000, 3, num_fourier_features=1000)),
     ],
 )

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -66,8 +66,8 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
             ),
         ),
         (15, TrustRegion()),
-        (17, DiscreteThompsonSampling(500, 3)),
-        (15, DiscreteThompsonSampling(1000, 3, num_fourier_features=1000)),
+        (20, DiscreteThompsonSampling(500, 3)),
+        (20, DiscreteThompsonSampling(1000, 3, num_fourier_features=1000)),
     ],
 )
 def test_optimizer_finds_minima_of_the_branin_function(

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -24,6 +24,7 @@ trieste model).
 from __future__ import annotations
 
 import copy
+import unittest.mock
 from collections.abc import Callable, Iterable, Sequence
 
 import gpflow
@@ -46,6 +47,7 @@ from trieste.models.model_interfaces import (
     TrainableProbabilisticModel,
     VariationalGaussianProcess,
     module_deepcopy,
+    randomize_kernel_hyperparameters,
 )
 from trieste.models.optimizer import Optimizer, create_optimizer
 from trieste.type import TensorType
@@ -355,6 +357,80 @@ def test_gaussian_process_regression_pairwise_covariance(gpr_interface_factory) 
     np.testing.assert_allclose(expected_covariance, actual_covariance, atol=1e-5)
 
 
+@random_seed
+@unittest.mock.patch(
+    "trieste.models.model_interfaces.GaussianProcessRegression.find_best_kernel_initialization"
+)
+@pytest.mark.parametrize("d", [1, 2])
+def test_gaussian_process_regression_correctly_counts_num_trainable_params_with_priors(
+    mocked_kernel_initializer, d, gpr_interface_factory
+) -> None:
+    x = tf.constant(np.arange(1, 5 * d + 1).reshape(-1, d), dtype=tf.float64)  # shape: [5, d]
+    model = gpr_interface_factory(x, _3x_plus_10(x))
+    model.model.kernel = gpflow.kernels.RBF(lengthscales=tf.ones([d], dtype=tf.float64))
+    model.model.likelihood.variance.assign(1.0)
+
+    model.model.kernel.lengthscales.prior = tfp.distributions.LogNormal(
+        loc=tf.math.log(model.model.kernel.lengthscales), scale=tf.cast(1.0, dtype=tf.float64)
+    )
+    model.model.kernel.variance.prior = tfp.distributions.LogNormal(
+        loc=tf.cast(-2.0, dtype=tf.float64), scale=tf.cast(5.0, dtype=tf.float64)
+    )
+
+    print(model.model.kernel.lengthscales)
+    if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
+        pytest.skip("find_best_kernel_initialization is only implemented for the GPR models.")
+
+    dataset = Dataset(x, tf.cast(_3x_plus_10(x), dtype=tf.float64))
+    model.optimize(dataset)
+
+    mocked_kernel_initializer.assert_called_once()
+    num_samples = mocked_kernel_initializer.call_args[0][0]
+    npt.assert_array_equal(num_samples, tf.minimum(1000, 100 * (d + 1)))
+
+
+def test_find_best_kernel_initialization_only_changes_params_with_priors(
+    gpr_interface_factory,
+) -> None:
+    x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
+    model = gpr_interface_factory(x, _3x_plus_10(x))
+    model.model.kernel = gpflow.kernels.RBF()
+
+    if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
+        pytest.skip("find_best_kernel_initialization is only implemented for the GPR models.")
+
+    model.model.kernel.lengthscales.prior = tfp.distributions.LogNormal(
+        loc=tf.math.log(model.model.kernel.lengthscales), scale=1.0
+    )
+
+    model.find_best_kernel_initialization(2)
+
+    npt.assert_allclose(1.0, model.model.kernel.variance)
+    npt.assert_raises(
+        AssertionError, npt.assert_allclose, [0.2, 0.2], model.model.kernel.lengthscales
+    )
+
+
+@random_seed
+def test_find_best_kernel_initialization_improves_likelihood(gpr_interface_factory) -> None:
+    x = tf.constant(np.arange(1, 10).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
+    model = gpr_interface_factory(x, _3x_plus_10(x))
+    model.model.kernel = gpflow.kernels.RBF()
+
+    if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
+        pytest.skip("find_best_kernel_initialization is only implemented for the GPR models.")
+
+    model.model.kernel.lengthscales.prior = tfp.distributions.LogNormal(
+        loc=tf.math.log(model.model.kernel.lengthscales), scale=1.0
+    )
+
+    pre_init_likelihood = model.model.maximum_log_likelihood_objective()
+    model.find_best_kernel_initialization(10)
+    post_init_likelihood = model.model.maximum_log_likelihood_objective()
+
+    npt.assert_array_less(pre_init_likelihood, post_init_likelihood)
+
+
 def test_gaussian_process_regression_predict_y(gpr_interface_factory) -> None:
     x = tf.constant(np.arange(5).reshape(-1, 1), dtype=gpflow.default_float())
     model = gpr_interface_factory(x, _3x_plus_gaussian_noise(x))
@@ -581,3 +657,16 @@ def test_sparse_variational_optimize(batcher, compile: bool) -> None:
     loss = model.model.training_loss(data)
     model.optimize(dataset)
     assert model.model.training_loss(data) < loss
+
+
+@random_seed
+def test_randomize_kernel_hyperparameters_only_randomize_kernel_parameters_with_priors() -> None:
+    kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.2, 0.2])
+    kernel.lengthscales.prior = tfp.distributions.LogNormal(
+        loc=tf.math.log(kernel.lengthscales), scale=1.0
+    )
+
+    randomize_kernel_hyperparameters(kernel)
+
+    npt.assert_allclose(1.0, kernel.variance)
+    npt.assert_raises(AssertionError, npt.assert_allclose, [0.2, 0.2], kernel.lengthscales)

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -378,9 +378,8 @@ def test_gaussian_process_regression_correctly_counts_num_trainable_params_with_
         loc=tf.cast(-2.0, dtype=tf.float64), scale=tf.cast(5.0, dtype=tf.float64)
     )
 
-    print(model.model.kernel.lengthscales)
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
-        pytest.skip("find_best_kernel_initialization is only implemented for the GPR models.")
+        pytest.skip("find_best_model_initialization is only implemented for the GPR models.")
 
     dataset = Dataset(x, tf.cast(_3x_plus_10(x), dtype=tf.float64))
     model.optimize(dataset)
@@ -398,7 +397,7 @@ def test_find_best_model_initialization_only_changes_params_with_priors(
     model.model.kernel = gpflow.kernels.RBF()
 
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
-        pytest.skip("find_best_kernel_initialization is only implemented for the GPR models.")
+        pytest.skip("find_best_model_initialization is only implemented for the GPR models.")
 
     model.model.kernel.lengthscales.prior = tfp.distributions.LogNormal(
         loc=tf.math.log(model.model.kernel.lengthscales), scale=1.0
@@ -419,7 +418,7 @@ def test_find_best_model_initialization_improves_likelihood(gpr_interface_factor
     model.model.kernel = gpflow.kernels.RBF()
 
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
-        pytest.skip("find_best_kernel_initialization is only implemented for the GPR models.")
+        pytest.skip("find_best_model_initialization is only implemented for the GPR models.")
 
     model.model.kernel.lengthscales.prior = tfp.distributions.LogNormal(
         loc=tf.math.log(model.model.kernel.lengthscales), scale=1.0

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -28,13 +28,6 @@ from ..type import TensorType
 from ..utils import DEFAULTS
 from .optimizer import Optimizer
 
-RANDOM_INIT_SUPPORTED_KERNELS = (
-    gpflow.kernels.SquaredExponential,
-    gpflow.kernels.Matern12,
-    gpflow.kernels.Matern32,
-    gpflow.kernels.Matern52,
-)
-
 
 class ProbabilisticModel(ABC):
     """A probabilistic model."""

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -460,12 +460,12 @@ class GaussianProcessRegression(GPflowPredictor, TrainableProbabilisticModel):
         for _ in tf.range(num_prior_samples):
             randomize_model_hyperparameters(self.model)
             try:
-                likelihood = evaluate_likelihood_of_model_parameters()
+                log_likelihood = evaluate_likelihood_of_model_parameters()
             except tf.errors.InvalidArgumentError:  # allow badly specified priors
-                likelihood = -1e100
+                log_likelihood = -1e100
 
-            if likelihood > max_log_likelihood:  # only keep best kernel params
-                max_log_likelihood = likelihood
+            if log_likelihood > max_log_likelihood:  # only keep best kernel params
+                max_log_likelihood = log_likelihood
                 current_best_parameters = read_values(self.model)
 
         multiple_assign(self.model, current_best_parameters)

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -432,10 +432,10 @@ class GaussianProcessRegression(GPflowPredictor, TrainableProbabilisticModel):
         """
 
         num_trainable_params_with_priors = tf.reduce_sum(
-            [tf.size(param) for param in self.model.kernel.trainable_parameters]
+            [tf.size(param) for param in self.model.kernel.trainable_parameters if param.prior]
         )
 
-        if num_trainable_params_with_priors > 1:  # Find a promising kernel initialization
+        if num_trainable_params_with_priors >= 1:  # Find a promising kernel initialization
             num_random_samples = tf.minimum(1000, 100 * num_trainable_params_with_priors)
             self.find_best_kernel_initialization(num_random_samples)
 

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -432,7 +432,11 @@ class GaussianProcessRegression(GPflowPredictor, TrainableProbabilisticModel):
         """
 
         num_trainable_params_with_priors = tf.reduce_sum(
-            [tf.size(param) for param in self.model.kernel.trainable_parameters if param.prior]
+            [
+                tf.size(param)
+                for param in self.model.kernel.trainable_parameters
+                if param.prior is not None
+            ]
         )
 
         if num_trainable_params_with_priors >= 1:  # Find a promising kernel initialization

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -452,13 +452,13 @@ class GaussianProcessRegression(GPflowPredictor, TrainableProbabilisticModel):
 
         @tf.function
         def evaluate_likelihood_of_model_parameters() -> tf.Tensor:
+            randomize_model_hyperparameters(self.model)
             return self.model.maximum_log_likelihood_objective()
 
         current_best_parameters = read_values(self.model)
-        max_log_likelihood = evaluate_likelihood_of_model_parameters()
+        max_log_likelihood = self.model.maximum_log_likelihood_objective()
 
         for _ in tf.range(num_prior_samples):
-            randomize_model_hyperparameters(self.model)
             try:
                 log_likelihood = evaluate_likelihood_of_model_parameters()
             except tf.errors.InvalidArgumentError:  # allow badly specified priors


### PR DESCRIPTION
If any of our GPR kernel's trainable parameters have priors, then we begin model optimization from the best configuration across a random sample from these parameters' priors.

For trainable parameters without priors, we begin optimization from their initial values.

The sample size is max(1000, 100*d) where d is the number of trainable kernel params with priors.