### PR TITLE
Showcase recent PRs

### DIFF
--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -15,13 +15,13 @@ tf.random.set_seed(1793)
 #
 
 # %%
-from trieste.utils.objectives import branin
+from trieste.utils.objectives import scaled_branin, SCALED_BRANIN_MINIMUM
 from util.plotting_plotly import plot_function_plotly
 from trieste.space import Box
 
 search_space = Box([0, 0], [1, 1])
 
-fig = plot_function_plotly(branin, search_space.lower, search_space.upper, grid_density=20)
+fig = plot_function_plotly(scaled_branin, search_space.lower, search_space.upper, grid_density=20)
 fig.update_layout(height=400, width=400)
 fig.show()
 
@@ -30,29 +30,37 @@ fig.show()
 #
 # Sometimes we don't have direct access to the objective function. We only have an observer that indirectly observes it. In _Trieste_, an observer can output a number of datasets. In our case, we only have one dataset, the objective. We can convert a function with `branin`'s signature to a single-output observer using `mk_observer`.
 #
-# The optimization procedure will benefit from having some starting data from the objective function to base its search on. We sample five points from the search space and evaluate them on the observer.
+# The optimization procedure will benefit from having some starting data from the objective function to base its search on. We sample a five point space-filling design from the search space and evaluate it with the observer. For continuous search spaces, Trieste supports random, Sobol and Halton initial designs.
 
 # %%
 import trieste
 
-observer = trieste.utils.objectives.mk_observer(branin)
+observer = trieste.utils.objectives.mk_observer(scaled_branin)
 
 num_initial_points = 5
-initial_query_points = search_space.sample(num_initial_points)
+initial_query_points = search_space.sample_sobol(num_initial_points)
 initial_data = observer(initial_query_points)
 
 # %% [markdown]
 # ## Model the objective function
 #
-# The Bayesian optimization procedure estimates the next best points to query by using a probabilistic model of the objective. We'll use Gaussian process regression for this, provided by GPflow. The model will need to be trained on each step as more points are evaluated, so we'll package it with GPflow's Scipy optimizer.
+# The Bayesian optimization procedure estimates the next best points to query by using a probabilistic model of the objective. We'll use Gaussian Process (GP) regression for this, as provided by GPflow. The model will need to be trained on each step as more points are evaluated, so we'll package it with GPflow's Scipy optimizer.
+#
+# We put priors on the parameters of our GP model's kernel in order to stabilize model fitting. We found the priors below to be highly effective for objective functions defined over the unit hypercube and with an ouput standardized to have zero mean and unit variance. For objective functions with different scaling, other priors will likely be more appropriate. Our fitted model uses the maximum a posteriori estiamte of these kernel parameters, as found by optimizing the kernel parameters starting from the best of random sample from the kernel parameter priors.  
+#
+# If we do not specify kernel priors, then Trieste returns the maximum likelihood estimate of the kernel parameters.
 
 # %%
 import gpflow
+import tensorflow_probability as tfp
 
 
 def build_model(data):
     variance = tf.math.reduce_variance(data.observations)
     kernel = gpflow.kernels.Matern52(variance=variance, lengthscales=[0.2, 0.2])
+    prior_scale = tf.cast(1.0, dtype=tf.float64)
+    kernel.variance.prior = tfp.distributions.LogNormal(tf.cast(-2.0, dtype=tf.float64), prior_scale)
+    kernel.lengthscales.prior = tfp.distributions.LogNormal(tf.math.log(kernel.lengthscales), prior_scale)
     gpr = gpflow.models.GPR(data.astuple(), kernel, noise_variance=1e-5)
     gpflow.set_trainable(gpr.likelihood, False)
 
@@ -104,9 +112,11 @@ print(f"observation: {observations[arg_min_idx, :]}")
 from util.plotting import plot_bo_points, plot_function_2d
 
 _, ax = plot_function_2d(
-    branin, search_space.lower, search_space.upper, grid_density=30, contour=True
+    scaled_branin, search_space.lower, search_space.upper, grid_density=30, contour=True
 )
 plot_bo_points(query_points, ax[0, 0], num_initial_points, arg_min_idx)
+ax[0, 0].set_xlabel(r'$x_1$')
+ax[0, 0].set_xlabel(r'$x_2$')
 
 # %% [markdown]
 # ... or as a three-dimensional plot
@@ -114,7 +124,7 @@ plot_bo_points(query_points, ax[0, 0], num_initial_points, arg_min_idx)
 # %%
 from util.plotting_plotly import add_bo_points_plotly
 
-fig = plot_function_plotly(branin, search_space.lower, search_space.upper, grid_density=20)
+fig = plot_function_plotly(scaled_branin, search_space.lower, search_space.upper, grid_density=20)
 fig.update_layout(height=500, width=500)
 
 fig = add_bo_points_plotly(
@@ -136,9 +146,15 @@ fig.show()
 import matplotlib.pyplot as plt
 from util.plotting import plot_regret
 
+suboptimality = observations - SCALED_BRANIN_MINIMUM.numpy()
 _, ax = plt.subplots(1, 2)
-plot_regret(observations, ax[0], num_init=num_initial_points, idx_best=arg_min_idx)
+plot_regret(suboptimality, ax[0], num_init=num_initial_points, idx_best=arg_min_idx)
 plot_bo_points(query_points, ax[1], num_init=num_initial_points, idx_best=arg_min_idx)
+
+ax[0].set_yscale("log")
+ax[0].set_ylabel("Regret")
+ax[0].set_ylim(0.001, 100)
+ax[0].set_xlabel("# evaluations")
 
 # %% [markdown]
 # We can visualise the model over the objective function by plotting the mean and 95% confidence intervals of its predictive distribution. Like with the data before, we can get the model with `.try_get_final_model()`.
@@ -163,7 +179,6 @@ fig = add_bo_points_plotly(
     figrow=1,
     figcol=1,
 )
-
 fig.show()
 
 # %% [markdown]
@@ -174,14 +189,31 @@ gpflow.utilities.print_summary(
     result.try_get_final_model().model  # type: ignore
 )
 
+variance_list = [
+    step.model.model.kernel.variance.numpy()  # type: ignore
+    for step in result.history + [result.final_result.unwrap()]
+]
+
 ls_list = [
     step.model.model.kernel.lengthscales.numpy()  # type: ignore
     for step in result.history + [result.final_result.unwrap()]
 ]
 
+variance = np.array(variance_list)
 ls = np.array(ls_list)
-plt.plot(ls[:, 0])
-plt.plot(ls[:, 1])
+
+fig, ax = plt.subplots(1, 2)
+ax[0].plot(variance, label="Kernel variance")
+ax[0].legend(loc="upper left")
+ax[0].set_xlabel("# Evaluations")
+ax[0].set_xlabel("Parameter Value")
+
+ax[1].plot(ls[:, 0], label="Kernel lengthscale 1")
+ax[1].plot(ls[:, 1], label="Kernel lengthscale 2")
+ax[1].legend(loc="upper left")
+ax[1].set_xlabel("# Evaluations")
+
+fig.tight_layout()
 
 # %% [markdown]
 # ## Run the optimizer for more steps
@@ -194,7 +226,7 @@ dataset = result.try_get_final_dataset()
 
 arg_min_idx = tf.squeeze(tf.argmin(dataset.observations, axis=0))
 _, ax = plot_function_2d(
-    branin, search_space.lower, search_space.upper, grid_density=40, contour=True
+    scaled_branin, search_space.lower, search_space.upper, grid_density=40, contour=True
 )
 
 plot_bo_points(
@@ -203,6 +235,9 @@ plot_bo_points(
     num_init=len(dataset.query_points),
     idx_best=arg_min_idx,
 )
+
+ax[0, 0].set_xlabel(r'$x_1$')
+ax[0, 0].set_xlabel(r'$x_2$')
 
 # %% [markdown]
 # ## LICENSE

--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -4,6 +4,7 @@
 # %%
 import numpy as np
 import tensorflow as tf
+import matplotlib.pyplot as plt
 
 np.random.seed(1793)
 tf.random.set_seed(1793)
@@ -17,7 +18,7 @@ tf.random.set_seed(1793)
 
 # %%
 import trieste
-from trieste.utils.objectives import branin
+from trieste.utils.objectives import branin, BRANIN_MINIMUM
 
 search_space = trieste.space.Box([0, 0], [1, 1])
 

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -35,17 +35,22 @@ from trieste.data import Dataset
 from trieste.models import GaussianProcessRegression
 from trieste.observer import OBJECTIVE
 from trieste.space import Box
-from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, mk_observer
+from trieste.utils.objectives import (
+    BRANIN_MINIMIZERS,
+    SCALED_BRANIN_MINIMUM,
+    mk_observer,
+    scaled_branin,
+)
 
 
 @random_seed
 @pytest.mark.parametrize(
     "num_steps, acquisition_rule",
     [
-        (25, EfficientGlobalOptimization()),
-        (25, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
+        (7, EfficientGlobalOptimization()),
+        (15, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
         (
-            25,
+            14,
             EfficientGlobalOptimization(
                 MinValueEntropySearch(Box([0, 0], [1, 1]), grid_size=1000, num_samples=5).using(
                     OBJECTIVE
@@ -53,25 +58,25 @@ from trieste.utils.objectives import BRANIN_MINIMIZERS, BRANIN_MINIMUM, branin, 
             ),
         ),
         (
-            20,
+            6,
             EfficientGlobalOptimization(
                 BatchMonteCarloExpectedImprovement(sample_size=500).using(OBJECTIVE),
                 num_query_points=2,
             ),
         ),
         (
-            15,
+            4,
             EfficientGlobalOptimization(
                 LocalPenalizationAcquisitionFunction(Box([0, 0], [1, 1])).using(OBJECTIVE),
                 num_query_points=3,
             ),
         ),
-        (20, TrustRegion()),
-        (17, DiscreteThompsonSampling(500, 3)),
-        (15, DiscreteThompsonSampling(1000, 3, num_fourier_features=1000)),
+        (7, TrustRegion()),
+        (7, DiscreteThompsonSampling(500, 3)),
+        (8, DiscreteThompsonSampling(500, 3, num_fourier_features=1000)),
     ],
 )
-def test_optimizer_finds_minima_of_the_branin_function(
+def test_optimizer_finds_minima_of_the_scaled_branin_function(
     num_steps: int, acquisition_rule: AcquisitionRule
 ) -> None:
     search_space = Box([0, 0], [1, 1])
@@ -90,8 +95,8 @@ def test_optimizer_finds_minima_of_the_branin_function(
         gpflow.utilities.set_trainable(gpr.likelihood, False)
         return GaussianProcessRegression(gpr)
 
-    initial_query_points = search_space.sample(10)
-    observer = mk_observer(branin)
+    initial_query_points = search_space.sample_sobol(5)
+    observer = mk_observer(scaled_branin)
     initial_data = observer(initial_query_points)
     model = build_model(initial_data)
 
@@ -109,5 +114,5 @@ def test_optimizer_finds_minima_of_the_branin_function(
     relative_minimizer_err = tf.abs((best_x - BRANIN_MINIMIZERS) / BRANIN_MINIMIZERS)
     # these accuracies are the current best for the given number of optimization steps, which makes
     # this is a regression test
-    assert tf.reduce_any(tf.reduce_all(relative_minimizer_err < 0.03, axis=-1), axis=0)
-    npt.assert_allclose(best_y, BRANIN_MINIMUM, rtol=0.03)
+    assert tf.reduce_any(tf.reduce_all(relative_minimizer_err < 0.05, axis=-1), axis=0)
+    npt.assert_allclose(best_y, SCALED_BRANIN_MINIMUM, rtol=0.005)

--- a/tests/integration/test_constrained_bayesian_optimization.py
+++ b/tests/integration/test_constrained_bayesian_optimization.py
@@ -96,5 +96,6 @@ def test_optimizer_finds_minima_of_Gardners_Simulation_1(
     relative_minimizer_err = tf.abs(best_x - MINIMIZER)
     # these accuracies are the current best for the given number of optimization steps, which makes
     # this is a regression test
+
     assert tf.reduce_all(relative_minimizer_err < 0.03, axis=-1)
-    npt.assert_allclose(best_y, MINIMUM, rtol=0.03)
+    npt.assert_allclose(best_y, MINIMUM, rtol=0.005)

--- a/tests/unit/utils/test_objectives.py
+++ b/tests/unit/utils/test_objectives.py
@@ -34,6 +34,7 @@ from trieste.utils.objectives import (
     LOGARITHMIC_GOLDSTEIN_PRICE_MINIMUM,
     ROSENBROCK_4_MINIMIZER,
     ROSENBROCK_4_MINIMUM,
+    SCALED_BRANIN_MINIMUM,
     SHEKEL_4_MINIMIZER,
     SHEKEL_4_MINIMUM,
     ackley_5,
@@ -44,6 +45,7 @@ from trieste.utils.objectives import (
     logarithmic_goldstein_price,
     mk_observer,
     rosenbrock_4,
+    scaled_branin,
     shekel_4,
 )
 
@@ -52,6 +54,7 @@ from trieste.utils.objectives import (
     "objective, minimizers, minimum",
     [
         (branin, BRANIN_MINIMIZERS, BRANIN_MINIMUM),
+        (scaled_branin, BRANIN_MINIMIZERS, SCALED_BRANIN_MINIMUM),
         (gramacy_lee, GRAMACY_LEE_MINIMIZER, GRAMACY_LEE_MINIMUM),
         (
             logarithmic_goldstein_price,
@@ -77,6 +80,7 @@ def test_objective_maps_minimizers_to_minimum(
     "objective, space, minimum",
     [
         (branin, Box([0.0, 0.0], [1.0, 1.0]), BRANIN_MINIMUM),
+        (scaled_branin, Box([0.0, 0.0], [1.0, 1.0]), SCALED_BRANIN_MINIMUM),
         (gramacy_lee, Box([0.5], [2.5]), GRAMACY_LEE_MINIMUM),
         (
             logarithmic_goldstein_price,

--- a/trieste/utils/objectives.py
+++ b/trieste/utils/objectives.py
@@ -29,7 +29,7 @@ from ..observer import MultiObserver, Observer, SingleObserver
 from ..type import TensorType
 
 
-def branin_internals(x: TensorType, scale: TensorType, translate: TensorType) -> TensorType:
+def _branin_internals(x: TensorType, scale: TensorType, translate: TensorType) -> TensorType:
     x0 = x[..., :1] * 15.0 - 5.0
     x1 = x[..., 1:] * 15.0
 
@@ -44,7 +44,7 @@ def branin_internals(x: TensorType, scale: TensorType, translate: TensorType) ->
 
 def branin(x: TensorType) -> TensorType:
     """
-    The Branin-Hoo function, rescaled to have zero mean and unit variance over :math:`[0, 1]^2`. See
+    The Branin-Hoo function over :math:`[0, 1]^2`. See
     :cite:`Picheny2013` for details.
 
     :param x: The points at which to evaluate the function, with shape [..., 2].
@@ -53,7 +53,7 @@ def branin(x: TensorType) -> TensorType:
     """
     tf.debugging.assert_shapes([(x, (..., 2))])
 
-    return branin_internals(x, 1, 10)
+    return _branin_internals(x, 1, 10)
 
 
 def scaled_branin(x: TensorType) -> TensorType:
@@ -67,7 +67,7 @@ def scaled_branin(x: TensorType) -> TensorType:
     """
     tf.debugging.assert_shapes([(x, (..., 2))])
 
-    return branin_internals(x, 1 / 51.95, -44.81)
+    return _branin_internals(x, 1 / 51.95, -44.81)
 
 
 _ORIGINAL_BRANIN_MINIMIZERS = tf.constant(

--- a/trieste/utils/objectives.py
+++ b/trieste/utils/objectives.py
@@ -29,6 +29,19 @@ from ..observer import MultiObserver, Observer, SingleObserver
 from ..type import TensorType
 
 
+def branin_internals(x: TensorType, scale: TensorType, translate: TensorType) -> TensorType:
+    x0 = x[..., :1] * 15.0 - 5.0
+    x1 = x[..., 1:] * 15.0
+
+    b = 5.1 / (4 * math.pi ** 2)
+    c = 5 / math.pi
+    r = 6
+    s = 10
+    t = 1 / (8 * math.pi)
+
+    return scale * ((x1 - b * x0 ** 2 + c * x0 - r) ** 2 + s * (1 - t) * tf.cos(x0) + translate)
+
+
 def branin(x: TensorType) -> TensorType:
     """
     The Branin-Hoo function, rescaled to have zero mean and unit variance over :math:`[0, 1]^2`. See
@@ -40,17 +53,21 @@ def branin(x: TensorType) -> TensorType:
     """
     tf.debugging.assert_shapes([(x, (..., 2))])
 
-    x0 = x[..., :1] * 15.0 - 5.0
-    x1 = x[..., 1:] * 15.0
+    return branin_internals(x, 1, 10)
 
-    a = 1
-    b = 5.1 / (4 * math.pi ** 2)
-    c = 5 / math.pi
-    r = 6
-    s = 10
-    t = 1 / (8 * math.pi)
 
-    return a * (x1 - b * x0 ** 2 + c * x0 - r) ** 2 + s * (1 - t) * tf.cos(x0) + s
+def scaled_branin(x: TensorType) -> TensorType:
+    """
+    The Branin-Hoo function, rescaled to have zero mean and unit variance over :math:`[0, 1]^2`. See
+    :cite:`Picheny2013` for details.
+
+    :param x: The points at which to evaluate the function, with shape [..., 2].
+    :return: The function values at ``x``, with shape [..., 1].
+    :raise ValueError (or InvalidArgumentError): If ``x`` has an invalid shape.
+    """
+    tf.debugging.assert_shapes([(x, (..., 2))])
+
+    return branin_internals(x, 1 / 51.95, -44.81)
 
 
 _ORIGINAL_BRANIN_MINIMIZERS = tf.constant(
@@ -63,7 +80,12 @@ The three global minimizers of the :func:`branin` function over :math:`[0, 1]^2`
 and dtype float64.
 """
 
+
 BRANIN_MINIMUM = tf.constant([0.397887], tf.float64)
+""" The global minimum of the :func:`branin` function, with shape [1] and dtype float64. """
+
+
+SCALED_BRANIN_MINIMUM = tf.constant([-1.047393], tf.float64)
 """ The global minimum of the :func:`branin` function, with shape [1] and dtype float64. """
 
 


### PR DESCRIPTION
I have added some of our recently added functionality into our PRs and integration tests.

- Added kernel priors in EI and batch EI notebooks and explained how they are used by Trieste
- Added demo of our new space-filling design in EI notebook
- Added lables on some notebook plots
- Added kernel priors/space-filling design to integration tests to reduce the number of steps required to converge (i.e fast tests).
- Slightly changed the convergence criterion of the integration test to better test BO, i.e. a harsher regret criterion but less harsh relative difference criterion (which didnt actually test convergence properly due to the rescaling)
- Added a rescaled branin function to use with kernel priors (used in EI and batch EI notebooks and the integration tests)