### PR TITLE
BayesianOptimizer can fit initial model

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -48,10 +48,10 @@ from trieste.utils.objectives import (
 @pytest.mark.parametrize(
     "num_steps, acquisition_rule",
     [
-        (7, EfficientGlobalOptimization()),
-        (15, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
+        (20, EfficientGlobalOptimization()),
+        (25, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
         (
-            7,
+            15,
             EfficientGlobalOptimization(
                 MinValueEntropySearch(Box([0, 0], [1, 1]), num_fourier_features=1000).using(
                     OBJECTIVE
@@ -59,14 +59,14 @@ from trieste.utils.objectives import (
             ),
         ),
         (
-            6,
+            10,
             EfficientGlobalOptimization(
                 BatchMonteCarloExpectedImprovement(sample_size=500).using(OBJECTIVE),
-                num_query_points=2,
+                num_query_points=3,
             ),
         ),
         (
-            4,
+            10,
             EfficientGlobalOptimization(
                 LocalPenalizationAcquisitionFunction(
                     Box([0, 0], [1, 1]),
@@ -75,17 +75,17 @@ from trieste.utils.objectives import (
             ),
         ),
         (
-            5,
+            10,
             EfficientGlobalOptimization(
                 GIBBON(
                     Box([0, 0], [1, 1]),
                 ).using(OBJECTIVE),
-                num_query_points=3,
+                num_query_points=2,
             ),
         ),
-        (7, TrustRegion()),
-        (7, DiscreteThompsonSampling(500, 3)),
-        (8, DiscreteThompsonSampling(500, 3, num_fourier_features=1000)),
+        (15, TrustRegion()),
+        (10, DiscreteThompsonSampling(500, 3)),
+        (10, DiscreteThompsonSampling(500, 3, num_fourier_features=1000)),
     ],
 )
 def test_optimizer_finds_minima_of_the_scaled_branin_function(
@@ -107,7 +107,7 @@ def test_optimizer_finds_minima_of_the_scaled_branin_function(
         gpflow.utilities.set_trainable(gpr.likelihood, False)
         return GaussianProcessRegression(gpr)
 
-    initial_query_points = search_space.sample_sobol(5)
+    initial_query_points = search_space.sample(5)
     observer = mk_observer(scaled_branin)
     initial_data = observer(initial_query_points)
     model = build_model(initial_data)

--- a/tests/integration/test_constrained_bayesian_optimization.py
+++ b/tests/integration/test_constrained_bayesian_optimization.py
@@ -66,7 +66,7 @@ def test_optimizer_finds_minima_of_Gardners_Simulation_1(
             CONSTRAINT: Dataset(query_points, constraint(query_points)),
         }
 
-    num_initial_points = 5
+    num_initial_points = 6
     initial_data = observer(search_space.sample(num_initial_points))
 
     def build_model(data):

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -155,9 +155,9 @@ def test_bayesian_optimizer_optimizes_initial_model(fit_intial_model: bool) -> N
     final_model = final_opt_state.unwrap().model
 
     if fit_intial_model:  # optimized at start and end of first BO step
-        assert final_model._optimize_count == 2
+        assert final_model._optimize_count == 2  # type: ignore
     else:  # optimized just at end of first BO step
-        assert final_model._optimize_count == 1
+        assert final_model._optimize_count == 1  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -130,6 +130,36 @@ def test_bayesian_optimizer_calls_observer_once_per_iteration(steps: int) -> Non
     assert observer.call_count == steps
 
 
+@pytest.mark.parametrize("fit_intial_model", [True, False])
+def test_bayesian_optimizer_optimizes_initial_model(fit_intial_model: bool) -> None:
+    class _CountingOptimizerModel(_PseudoTrainableQuadratic):
+        _optimize_count = 0
+
+        def optimize(self, dataset: Dataset) -> None:
+            self._optimize_count += 1
+
+    rule = FixedAcquisitionRule([[0.0]])
+    model = _CountingOptimizerModel()
+
+    final_opt_state, _ = (
+        BayesianOptimizer(_quadratic_observer, Box([0], [1]))
+        .optimize(
+            1,
+            {"": mk_dataset([[0.0]], [[0.0]])},
+            {"": model},
+            rule,
+            fit_intial_model=fit_intial_model,
+        )
+        .astuple()
+    )
+    final_model = final_opt_state.unwrap().model
+
+    if fit_intial_model:  # optimized at start and end of first BO step
+        assert final_model._optimize_count == 2
+    else:  # optimized just at end of first BO step
+        assert final_model._optimize_count == 1
+
+
 @pytest.mark.parametrize(
     "datasets, models",
     [
@@ -216,7 +246,13 @@ def test_bayesian_optimizer_optimize_for_uncopyable_model() -> None:
     rule = FixedAcquisitionRule([[0.0]])
     result, history = (
         BayesianOptimizer(_quadratic_observer, Box([0], [1]))
-        .optimize(10, {"": mk_dataset([[0.0]], [[0.0]])}, {"": _UncopyableModel()}, rule)
+        .optimize(
+            10,
+            {"": mk_dataset([[0.0]], [[0.0]])},
+            {"": _UncopyableModel()},
+            rule,
+            fit_intial_model=False,
+        )
         .astuple()
     )
 

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -172,6 +172,7 @@ class BayesianOptimizer(Generic[SP]):
         model_specs: Mapping[str, ModelSpec],
         *,
         track_state: bool = True,
+        fit_intial_model: bool = True,
     ) -> OptimizationResult[None]:
         ...
 
@@ -185,6 +186,7 @@ class BayesianOptimizer(Generic[SP]):
         acquisition_state: S | None = None,
         *,
         track_state: bool = True,
+        fit_intial_model: bool = True,
     ) -> OptimizationResult[S]:
         ...
 
@@ -196,6 +198,7 @@ class BayesianOptimizer(Generic[SP]):
         model_specs: ModelSpec,
         *,
         track_state: bool = True,
+        fit_intial_model: bool = True,
     ) -> OptimizationResult[None]:
         ...
 
@@ -209,6 +212,7 @@ class BayesianOptimizer(Generic[SP]):
         acquisition_state: S | None = None,
         *,
         track_state: bool = True,
+        fit_intial_model: bool = True,
     ) -> OptimizationResult[S]:
         ...
 

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -226,7 +226,7 @@ class BayesianOptimizer(Generic[SP]):
         *,
         track_state: bool = True,
         fit_intial_model: bool = True,
-    ) -> OptimizationResult[S]:
+    ) -> OptimizationResult[S] | OptimizationResult[None]:
         """
         Attempt to find the minimizer of the ``observer`` in the ``search_space`` (both specified at
         :meth:`__init__`). This is the central implementation of the Bayesian optimization loop.


### PR DESCRIPTION
At the moment, we assume that the model given to BayesianOptimizer is already optimized to the initial_data and so it is not optimized in our BO loop until after choosing the first BO point.

I have changed it so that we optimize the model before choosing the first point, with an optional choice to revert back to our current behaviour 