### PR TITLE
mask infeasible points before prediction in eci

### DIFF
--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -607,9 +607,9 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
         if not tf.reduce_any(is_feasible):
             return constraint_fn
 
-        feasible_query_points = tf.boolean_mask(objective_dataset.query_points, axis=0)
+        feasible_query_points = tf.boolean_mask(objective_dataset.query_points)
         feasible_mean, _ = objective_model.predict(feasible_query_points)
-        eta = tf.reduce_min(feasible_mean)
+        eta = tf.reduce_min(feasible_mean, axis=0)
 
         return lambda at: expected_improvement(objective_model, eta)(at) * constraint_fn(at)
 

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -607,8 +607,9 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
         if not tf.reduce_any(is_feasible):
             return constraint_fn
 
-        mean, _ = objective_model.predict(objective_dataset.query_points)
-        eta = tf.reduce_min(tf.boolean_mask(mean, is_feasible), axis=0)
+        feasible_query_points = tf.boolean_mask(objective_dataset.query_points, axis=0)
+        feasible_mean, _ = objective_model.predict(feasible_query_points)
+        eta = tf.reduce_min(feasible_mean)
 
         return lambda at: expected_improvement(objective_model, eta)(at) * constraint_fn(at)
 

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -602,7 +602,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
 
         constraint_fn = self._constraint_builder.prepare_acquisition_function(datasets, models)
         pof = constraint_fn(objective_dataset.query_points[:, None, ...])
-        is_feasible = pof >= self._min_feasibility_probability
+        is_feasible = tf.squeeze(pof >= self._min_feasibility_probability, axis=-1)
 
         if not tf.reduce_any(is_feasible):
             return constraint_fn

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -607,7 +607,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
         if not tf.reduce_any(is_feasible):
             return constraint_fn
 
-        feasible_query_points = tf.boolean_mask(objective_dataset.query_points)
+        feasible_query_points = tf.boolean_mask(objective_dataset.query_points, is_feasible)
         feasible_mean, _ = objective_model.predict(feasible_query_points)
         eta = tf.reduce_min(feasible_mean, axis=0)
 


### PR DESCRIPTION
In expected constrained improvement, all the query points are used for predictions, then they're masked out with the constraint mask. This is inefficient as it's making predictions then potentially throwing some away. I've changed it so it throws the query points away first, then makes predictions