### PR TITLE
Fix cts acquisition optimizer

### DIFF
--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -132,6 +132,7 @@ def test_generate_continuous_optimizer_raises_with_invalid_init_params() -> None
         generate_continuous_optimizer(num_restarts=3),
         generate_continuous_optimizer(sigmoid=True),
         generate_continuous_optimizer(sigmoid=True, num_restarts=3),
+        generate_continuous_optimizer(sigmoid=True, num_restarts=1, num_initial_samples=1),
     ],
 )
 def test_continuous_optimizer(
@@ -168,7 +169,6 @@ def test_optimize_batch(
     points = batch_optimizer(search_space, acquisition)
     assert points.shape == [batch_size] + search_space.lower.shape
     for point in points:
-        print(point)
         npt.assert_allclose(tf.expand_dims(point, 0), maximizer, rtol=2e-4)
 
 

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -95,6 +95,8 @@ def test_generate_continuous_optimizer_raises_with_invalid_init_params() -> None
         generate_continuous_optimizer(num_initial_samples=-5)
     with pytest.raises(ValueError):
         generate_continuous_optimizer(num_restarts=-5)
+    with pytest.raises(ValueError):
+        generate_continuous_optimizer(num_restarts=5, num_initial_samples=4)
 
 
 @random_seed

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -145,7 +145,7 @@ def generate_continuous_optimizer(
         trial_search_space = space.sample(num_initial_samples)  # [num_initial_samples, D]
         target_func_values = target_func(trial_search_space[:, None, :])  # [num_samples, 1]
         _, top_k_indicies = tf.math.top_k(
-            tf.squeeze(target_func_values), k=num_restarts
+            target_func_values[:, 0], k=num_restarts
         )  # [num_restarts]
         initial_points = tf.gather(trial_search_space, top_k_indicies)  # [num_restarts, D]
 

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -121,7 +121,7 @@ def generate_continuous_optimizer(
         raise ValueError(f"num_initial_samples must be positive, got {num_initial_samples}")
 
     if num_restarts <= 0:
-        raise ValueError(f"num_parallel must be positive, got {num_restarts}")
+        raise ValueError(f"num_restarts must be positive, got {num_restarts}")
 
     if num_initial_samples < num_restarts:
         raise ValueError(

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -123,6 +123,14 @@ def generate_continuous_optimizer(
     if num_restarts <= 0:
         raise ValueError(f"num_parallel must be positive, got {num_restarts}")
 
+    if num_initial_samples < num_restarts:
+        raise ValueError(
+            f"""
+            num_initial_samples {num_initial_samples} must be at
+            least num_restarts {num_restarts}
+            """
+        )
+
     def optimize_continuous(space: Box, target_func: AcquisitionFunction) -> TensorType:
         """
         A gradient-based :const:`AcquisitionOptimizer` for :class:'Box' spaces and batches


### PR DESCRIPTION
We now raise error (rather than crash) if we try to optimize our acq function with more restarts than initial samples.

I have also added a unit test to check this.