### PR TITLE
including prior density in kernel param init 

### DIFF
--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -453,7 +453,7 @@ class GaussianProcessRegression(GPflowPredictor, TrainableProbabilisticModel):
         @tf.function
         def evaluate_likelihood_of_model_parameters() -> tf.Tensor:
             randomize_model_hyperparameters(self.model)
-            return self.model.maximum_log_likelihood_objective()
+            return self.model.maximum_log_likelihood_objective() + self.model.log_prior_density()
 
         current_best_parameters = read_values(self.model)
         max_log_likelihood = self.model.maximum_log_likelihood_objective()


### PR DESCRIPTION
Including kernel prior term in the likelihood when choosing kernel params