### PR TITLE
Victor/fixkernelconstraints

### DIFF
--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -841,4 +841,4 @@ def test_squeeze_hyperparameters_when_param_at_edge_of_bounds() -> None:
         kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
     squeeze_hyperparameters(kernel, 0.1)
-    npt.assert_array_equal(kernel.lengthscales, [0.1 + 4e-2, 0.5 - 4e-2])
+    npt.assert_array_almost_equal(kernel.lengthscales, [0.1 + 4e-2, 0.5 - 4e-2])

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -513,7 +513,7 @@ def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) 
     model.model.kernel.lengthscales = gpflow.Parameter(
         model.model.kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
-    model.optimize(Dataset(model.model.data[0], model.model.data[1]))
+    model.optimize(Dataset(x, _3x_plus_10(x) * 0.0))
     model.find_best_model_initialization(2)
 
 

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -507,7 +507,7 @@ def test_find_best_model_initialization_improves_likelihood(
 def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) -> None:
 
     x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
-    model = gpr_interface_factory(x, _3x_plus_10(x) * 0.)
+    model = gpr_interface_factory(x, _3x_plus_10(x) * 0.0)
     model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.2])
 
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -404,8 +404,8 @@ def test_gaussian_process_regression_correctly_counts_params_that_can_be_sampled
 def test_find_best_model_initialization_changes_params_with_priors(
     gpr_interface_factory, dim: int
 ) -> None:
-    x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
-    model = gpr_interface_factory(x, _3x_plus_10(x))
+    x = tf.constant(np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float())  # shape: [10, dim]
+    model = gpr_interface_factory(x, _3x_plus_10(x)[:, 0:1])
     model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.2] * dim)
 
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
@@ -428,8 +428,8 @@ def test_find_best_model_initialization_changes_params_with_priors(
 def test_find_best_model_initialization_changes_params_with_sigmoid_bjectors(
     gpr_interface_factory, dim: int
 ) -> None:
-    x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
-    model = gpr_interface_factory(x, _3x_plus_10(x))
+    x = tf.constant(np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float())  # shape: [10, dim]
+    model = gpr_interface_factory(x, _3x_plus_10(x)[:, 0:1])
     model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.2] * dim)
 
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
@@ -455,8 +455,8 @@ def test_find_best_model_initialization_changes_params_with_sigmoid_bjectors(
 def test_find_best_model_initialization_without_priors_improves_training_loss(
     gpr_interface_factory, dim: int
 ) -> None:
-    x = tf.constant(np.arange(1, 10).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
-    model = gpr_interface_factory(x, _3x_plus_10(x))
+    x = tf.constant(np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float())  # shape: [10, dim]
+    model = gpr_interface_factory(x, _3x_plus_10(x)[:, 0:1])
     model.model.kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.2] * dim)
 
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
@@ -480,8 +480,8 @@ def test_find_best_model_initialization_without_priors_improves_training_loss(
 def test_find_best_model_initialization_improves_likelihood(
     gpr_interface_factory, dim: int
 ) -> None:
-    x = tf.constant(np.arange(1, 10).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
-    model = gpr_interface_factory(x, _3x_plus_10(x))
+    x = tf.constant(np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float())  # shape: [10, dim]
+    model = gpr_interface_factory(x, _3x_plus_10(x)[:, 0:1])
     model.model.kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.2] * dim)
 
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
@@ -507,6 +507,10 @@ def test_find_best_model_initialization_improves_likelihood(
 def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) -> None:
     x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [5, 1]
     model = gpr_interface_factory(x, tf.zeros_like(x))
+
+    if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
+        pytest.skip("find_best_model_initialization is only implemented for the GPR models.")
+
     model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.45])
     upper = tf.cast([0.5], dtype=tf.float64)
     lower = upper / 5.0

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -834,11 +834,11 @@ def test_randomize_hyperparameters_samples_different_values_for_multi_dimensiona
 
 @random_seed
 def test_squeeze_hyperparameters_when_param_at_edge_of_bounds() -> None:
-    kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.1, 0.5])
+    kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.1 + 1e-3, 0.5 - 1e-3])
     upper = tf.cast([0.5, 0.5], dtype=tf.float64)
     lower = upper / 5.0
     kernel.lengthscales = gpflow.Parameter(
         kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
-    squeeze_hyperparameters(kernel, 1e-2)
-    npt.assert_array_equal(kernel.lengthscales, [0.1 + 4e-3, 0.5 - 4e-3])
+    squeeze_hyperparameters(kernel, 0.1)
+    npt.assert_array_equal(kernel.lengthscales, [0.1 + 4e-2, 0.5 - 4e-2])

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -513,7 +513,7 @@ def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) 
     model.model.kernel.lengthscales = gpflow.Parameter(
         model.model.kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
-    model.optimize(Dataset((model.model.data[0], model.model.data[1])))
+    model.optimize(Dataset(model.model.data[0], model.model.data[1]))
     model.find_best_model_initialization(2)
 
 

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -507,7 +507,7 @@ def test_find_best_model_initialization_improves_likelihood(
 def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) -> None:
     x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [5, 1]
     model = gpr_interface_factory(x, tf.zeros_like(x))
-    model.model.kernel = gpflow.kernels.RBF(lengthscales=0.45)
+    model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.45])
     upper = tf.cast([0.5], dtype=tf.float64)
     lower = upper / 5.0
     model.model.kernel.lengthscales = gpflow.Parameter(

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -404,7 +404,9 @@ def test_gaussian_process_regression_correctly_counts_params_that_can_be_sampled
 def test_find_best_model_initialization_changes_params_with_priors(
     gpr_interface_factory, dim: int
 ) -> None:
-    x = tf.constant(np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float())  # shape: [10, dim]
+    x = tf.constant(
+        np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float()
+    )  # shape: [10, dim]
     model = gpr_interface_factory(x, _3x_plus_10(x)[:, 0:1])
     model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.2] * dim)
 
@@ -428,7 +430,9 @@ def test_find_best_model_initialization_changes_params_with_priors(
 def test_find_best_model_initialization_changes_params_with_sigmoid_bjectors(
     gpr_interface_factory, dim: int
 ) -> None:
-    x = tf.constant(np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float())  # shape: [10, dim]
+    x = tf.constant(
+        np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float()
+    )  # shape: [10, dim]
     model = gpr_interface_factory(x, _3x_plus_10(x)[:, 0:1])
     model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.2] * dim)
 
@@ -455,7 +459,9 @@ def test_find_best_model_initialization_changes_params_with_sigmoid_bjectors(
 def test_find_best_model_initialization_without_priors_improves_training_loss(
     gpr_interface_factory, dim: int
 ) -> None:
-    x = tf.constant(np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float())  # shape: [10, dim]
+    x = tf.constant(
+        np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float()
+    )  # shape: [10, dim]
     model = gpr_interface_factory(x, _3x_plus_10(x)[:, 0:1])
     model.model.kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.2] * dim)
 
@@ -480,7 +486,9 @@ def test_find_best_model_initialization_without_priors_improves_training_loss(
 def test_find_best_model_initialization_improves_likelihood(
     gpr_interface_factory, dim: int
 ) -> None:
-    x = tf.constant(np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float())  # shape: [10, dim]
+    x = tf.constant(
+        np.arange(1, 1 + 10 * dim).reshape(-1, dim), dtype=gpflow.default_float()
+    )  # shape: [10, dim]
     model = gpr_interface_factory(x, _3x_plus_10(x)[:, 0:1])
     model.model.kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.2] * dim)
 

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -752,12 +752,12 @@ def test_sparse_variational_optimize(batcher, compile: bool) -> None:
 
 @random_seed
 @pytest.mark.parametrize("dim", [1, 10])
-def test_randomize_model_hyperparameters_randomize_kernel_parameters_with_priors(dim: int) -> None:
+def test_randomize_hyperparameters_randomize_kernel_parameters_with_priors(dim: int) -> None:
     kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.2] * dim)
     kernel.lengthscales.prior = tfp.distributions.LogNormal(
         loc=tf.math.log(kernel.lengthscales), scale=1.0
     )
-    randomize_model_hyperparameters(kernel)
+    randomize_hyperparameters(kernel)
 
     npt.assert_allclose(1.0, kernel.variance)
     npt.assert_array_equal(dim, kernel.lengthscales.shape)
@@ -774,7 +774,7 @@ def test_randomize_model_hyperparameters_randomizes_constrained_kernel_parameter
         kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
 
-    randomize_model_hyperparameters(kernel)
+    randomize_hyperparameters(kernel)
 
     npt.assert_allclose(1.0, kernel.variance)
     npt.assert_array_equal(dim, kernel.lengthscales.shape)
@@ -783,7 +783,7 @@ def test_randomize_model_hyperparameters_randomizes_constrained_kernel_parameter
 
 @random_seed
 @pytest.mark.parametrize("dim", [1, 10])
-def test_randomize_model_hyperparameters_randomizes_kernel_parameters_with_constraints_or_priors(
+def test_randomize_hyperparameters_randomizes_kernel_parameters_with_constraints_or_priors(
     dim: int,
 ) -> None:
     kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.2] * dim)
@@ -794,7 +794,7 @@ def test_randomize_model_hyperparameters_randomizes_kernel_parameters_with_const
     )
     kernel.variance.prior = tfp.distributions.LogNormal(loc=np.float64(-2.0), scale=np.float64(1.0))
 
-    randomize_model_hyperparameters(kernel)
+    randomize_hyperparameters(kernel)
 
     npt.assert_raises(AssertionError, npt.assert_allclose, 1.0, kernel.variance)
     npt.assert_array_equal(dim, kernel.lengthscales.shape)
@@ -803,7 +803,7 @@ def test_randomize_model_hyperparameters_randomizes_kernel_parameters_with_const
 
 @random_seed
 @pytest.mark.parametrize("dim", [1, 10])
-def test_randomize_model_hyperparameters_samples_from_constraints_when_given_prior_and_constraint(
+def test_randomize_hyperparameters_samples_from_constraints_when_given_prior_and_constraint(
     dim: int,
 ) -> None:
     kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.2] * dim)
@@ -817,21 +817,21 @@ def test_randomize_model_hyperparameters_samples_from_constraints_when_given_pri
 
     kernel.variance.prior = tfp.distributions.LogNormal(loc=np.float64(-2.0), scale=np.float64(1.0))
 
-    randomize_model_hyperparameters(kernel)
+    randomize_hyperparameters(kernel)
 
     npt.assert_array_less(kernel.lengthscales, [0.5] * dim)
     npt.assert_raises(AssertionError, npt.assert_allclose, [0.2] * dim, kernel.lengthscales)
 
 
 @random_seed
-def test_randomize_model_hyperparameters_samples_different_values_for_multi_dimensional_params() -> None:
+def test_randomize_hyperparameters_samples_different_values_for_multi_dimensional_params() -> None:
     kernel = gpflow.kernels.RBF(variance=1.0, lengthscales=[0.2, 0.2])
     upper = tf.cast([10.0] * 2, dtype=tf.float64)
     lower = upper / 100
     kernel.lengthscales = gpflow.Parameter(
         kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
-    randomize_model_hyperparameters(kernel)
+    randomize_hyperparameters(kernel)
     npt.assert_raises(
         AssertionError, npt.assert_allclose, kernel.lengthscales[0], kernel.lengthscales[1]
     )
@@ -845,5 +845,5 @@ def test_squeeze_hyperparameters_when_param_at_edge_of_bounds() -> None:
     kernel.lengthscales = gpflow.Parameter(
         kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
-    squeeze_model_hyperparameters(kernel, 1e-2)
+    squeeze_hyperparameters(kernel, 1e-2)
     npt.assert_array_equal(kernel.lengthscales, [0.1 + 4e-2, 0.5 - 4e-2])

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -504,11 +504,11 @@ def test_find_best_model_initialization_improves_likelihood(
         model.model.kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
 
-    pre_init_likelihood = -model.model.training_loss()
-    model.find_best_model_initialization(10)
-    post_init_likelihood = -model.model.training_loss()
+    pre_init_loss = model.model.training_loss()
+    model.find_best_model_initialization(100)
+    post_init_loss = model.model.training_loss()
 
-    npt.assert_array_less(pre_init_likelihood, post_init_likelihood)
+    npt.assert_array_less(post_init_loss, pre_init_loss)
 
 
 @random_seed

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -513,7 +513,7 @@ def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) 
     model.model.kernel.lengthscales = gpflow.Parameter(
         model.model.kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
-    model.optimize(Dataset(model.model.X, model.model.Y))
+    model.optimize(Dataset((model.model.data[0], model.model.data[1])))
     model.find_best_model_initialization(2)
 
 
@@ -841,4 +841,4 @@ def test_squeeze_hyperparameters_when_param_at_edge_of_bounds() -> None:
         kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
     squeeze_hyperparameters(kernel, 1e-2)
-    npt.assert_array_equal(kernel.lengthscales, [0.1 + 4e-2, 0.5 - 4e-2])
+    npt.assert_array_equal(kernel.lengthscales, [0.1 + 4e-3, 0.5 - 4e-3])

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -505,15 +505,15 @@ def test_find_best_model_initialization_improves_likelihood(
 
 @random_seed
 def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) -> None:
-    x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
-    model = gpr_interface_factory(x, _3x_plus_10(x) * 0.0)
+    x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [5, 1]
+    model = gpr_interface_factory(x, tf.zeros_like(x))
     model.model.kernel = gpflow.kernels.RBF(lengthscales=0.45)
     upper = tf.cast([0.5], dtype=tf.float64)
     lower = upper / 5.0
     model.model.kernel.lengthscales = gpflow.Parameter(
         model.model.kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
-    model.optimize(Dataset(x, _3x_plus_10(x) * 0.0))
+    model.optimize(Dataset(x, tf.zeros_like(x)))
     model.find_best_model_initialization(2)
 
 

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -519,12 +519,15 @@ def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) 
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
         pytest.skip("find_best_model_initialization is only implemented for the GPR models.")
 
-    model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.45])
+    model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.49])
     upper = tf.cast([0.5], dtype=tf.float64)
     lower = upper / 5.0
     model.model.kernel.lengthscales = gpflow.Parameter(
         model.model.kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
+    gpflow.set_trainable(model.model.kernel.variance, False)
+    gpflow.set_trainable(model.model.likelihood.variance, False)
+
     model.optimize(Dataset(x, tf.zeros_like(x)))
     model.find_best_model_initialization(2)
 

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -507,7 +507,7 @@ def test_find_best_model_initialization_improves_likelihood(
 def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) -> None:
 
     x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
-    model = gpr_interface_factory(x, _3x_plus_10(x))
+    model = gpr_interface_factory(x, _3x_plus_10(x) * 0.)
     model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.2])
 
     if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
@@ -518,6 +518,7 @@ def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) 
     model.model.kernel.lengthscales = gpflow.Parameter(
         model.model.kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
+    model.optimize(Dataset(model.model.X, model.model.Y))
     model.model.kernel.lengthscales.assign(0.5)
     model.find_best_model_initialization(2)
 

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -505,21 +505,15 @@ def test_find_best_model_initialization_improves_likelihood(
 
 @random_seed
 def test_find_best_model_initialization_avoids_inf_error(gpr_interface_factory) -> None:
-
     x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
     model = gpr_interface_factory(x, _3x_plus_10(x) * 0.0)
-    model.model.kernel = gpflow.kernels.RBF(lengthscales=[0.2])
-
-    if isinstance(model, (VariationalGaussianProcess, SparseVariational)):
-        pytest.skip("find_best_model_initialization is only implemented for the GPR models.")
-
+    model.model.kernel = gpflow.kernels.RBF(lengthscales=0.45)
     upper = tf.cast([0.5], dtype=tf.float64)
     lower = upper / 5.0
     model.model.kernel.lengthscales = gpflow.Parameter(
         model.model.kernel.lengthscales, transform=tfp.bijectors.Sigmoid(low=lower, high=upper)
     )
     model.optimize(Dataset(model.model.X, model.model.Y))
-    model.model.kernel.lengthscales.assign(0.5)
     model.find_best_model_initialization(2)
 
 

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -471,7 +471,7 @@ def test_find_best_model_initialization_improves_likelihood(
     )
 
     pre_init_likelihood = -model.model.training_loss()
-    model.find_best_model_initialization(10)
+    model.find_best_model_initialization(100)
     post_init_likelihood = -model.model.training_loss()
 
     npt.assert_array_less(pre_init_likelihood, post_init_likelihood)

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -47,8 +47,8 @@ from trieste.models.model_interfaces import (
     TrainableProbabilisticModel,
     VariationalGaussianProcess,
     module_deepcopy,
-    randomize_model_hyperparameters,
-    squeeze_model_hyperparameters,
+    randomize_hyperparameters,
+    squeeze_hyperparameters,
 )
 from trieste.models.optimizer import Optimizer, create_optimizer
 from trieste.type import TensorType

--- a/tests/unit/models/test_model_interfaces.py
+++ b/tests/unit/models/test_model_interfaces.py
@@ -471,7 +471,7 @@ def test_find_best_model_initialization_improves_likelihood(
     )
 
     pre_init_likelihood = -model.model.training_loss()
-    model.find_best_model_initialization(100)
+    model.find_best_model_initialization(10)
     post_init_likelihood = -model.model.training_loss()
 
     npt.assert_array_less(pre_init_likelihood, post_init_likelihood)

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -476,7 +476,6 @@ class GaussianProcessRegression(GPflowPredictor, TrainableProbabilisticModel):
         current_best_parameters = read_values(self.model)
         min_loss = self.model.training_loss()
 
-        found_better = False
         for _ in tf.range(num_kernel_samples):
             try:
                 train_loss = evaluate_loss_of_model_parameters()
@@ -486,10 +485,8 @@ class GaussianProcessRegression(GPflowPredictor, TrainableProbabilisticModel):
             if train_loss < min_loss:  # only keep best kernel params
                 min_loss = train_loss
                 current_best_parameters = read_values(self.model)
-                found_better = True
 
-        if found_better:  # trick to avoid issues with Sigmoid
-            multiple_assign(self.model, current_best_parameters)
+        multiple_assign(self.model, current_best_parameters)
 
 
 class SparseVariational(GPflowPredictor, TrainableProbabilisticModel):

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -623,7 +623,8 @@ def randomize_model_hyperparameters(model: gpflow.models.GPModel) -> None:
         elif param.prior is not None:
             param.assign(param.prior.sample())
 
-def squeeze_hyperparameters(model: gpflow.models.GPModel, epsilon: float=1e-8) -> None:
+
+def squeeze_hyperparameters(model: gpflow.models.GPModel, epsilon: float = 1e-8) -> None:
     for param in model.trainable_parameters:
         if isinstance(param.bijector, tfp.bijectors.Sigmoid):
             squeezed_param = tf.math.minimum(param, param.bijector.high - epsilon)

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -627,7 +627,7 @@ def randomize_hyperparameters(object: gpflow.Module) -> None:
 def squeeze_hyperparameters(object: gpflow.Module, alpha: float = 1e-2) -> None:
     """
     Squeezes the parameters to be strictly inside their range defined by the Sigmoid.
-    This avoids having NaN of Inf unconstrained values when the parameters are exactly at the boundary.
+    This avoids having Inf unconstrained values when the parameters are exactly at the boundary.
 
     :param object: Any gpflow Module.
     :param alpha: the proportion of the range with which to squeeze
@@ -635,7 +635,7 @@ def squeeze_hyperparameters(object: gpflow.Module, alpha: float = 1e-2) -> None:
     """
 
     if not (0 < alpha < 1):
-        raise ValueError(f"squeeze factor alpha must be in (0, 1)")
+        raise ValueError(f"squeeze factor alpha must be in (0, 1), given value is {alpha}")
 
     for param in object.trainable_parameters:
         if isinstance(param.bijector, tfp.bijectors.Sigmoid):

--- a/trieste/models/model_interfaces.py
+++ b/trieste/models/model_interfaces.py
@@ -626,8 +626,8 @@ def randomize_hyperparameters(object: gpflow.Module) -> None:
 
 def squeeze_hyperparameters(object: gpflow.Module, alpha: float = 1e-2) -> None:
     """
-    Sets hyperparameters to random samples from their constrained domains or (if not constraints
-    are available) their prior distributions.
+    Squeezes the parameters to be strictly inside their range defined by the Sigmoid.
+    This avoids having NaN of Inf unconstrained values when the parameters are exactly at the boundary.
 
     :param object: Any gpflow Module.
     :param alpha: the proportion of the range with which to squeeze


### PR DESCRIPTION
This PR fixes 3 things:

- in `find_best_model_initialization` we now use the training loss so that it also works if we don't use any prior
- we "squeeze" the hyperparameters by an epsilon before searching for new ones. This avoids the following bug: say at the previous BO iteration, the optimal lengthscale reached its upper bound; if `find_best_model_initialization` doesn't find any better set of hyperparameters, you would re-assign the upper bound to the hyperparameters, then the untransformed value is +Inf and you get an error message.
- the previous sampling would return a single value for all lengthscales. They are now all different.