### PR TITLE
trust region refactor

### DIFF
--- a/docs/notebooks/batch_optimization.pct.py
+++ b/docs/notebooks/batch_optimization.pct.py
@@ -87,7 +87,7 @@ from trieste.acquisition.rule import EfficientGlobalOptimization
 batch_ei_acq = BatchMonteCarloExpectedImprovement(sample_size=1000, jitter=1e-5)
 batch_ei_acq_rule = EfficientGlobalOptimization(  # type: ignore
     num_query_points=10, builder=batch_ei_acq)
-points_chosen_by_batch_ei, _ = batch_ei_acq_rule.acquire_single(search_space, initial_data, model)
+points_chosen_by_batch_ei = batch_ei_acq_rule.acquire_single(search_space, initial_data, model)
 
 # %% [markdown]
 # then we do the same with `LocalPenalizationAcquisitionFunction` ...
@@ -98,7 +98,7 @@ from trieste.acquisition import LocalPenalizationAcquisitionFunction
 local_penalization_acq = LocalPenalizationAcquisitionFunction(search_space, num_samples=2000)
 local_penalization_acq_rule = EfficientGlobalOptimization(  # type: ignore
     num_query_points=10, builder=local_penalization_acq)
-points_chosen_by_local_penalization, _ = local_penalization_acq_rule.acquire_single(
+points_chosen_by_local_penalization = local_penalization_acq_rule.acquire_single(
     search_space, initial_data, model)
 
 # %% [markdown]
@@ -110,7 +110,7 @@ from trieste.acquisition import GIBBON
 gibbon_acq = GIBBON(search_space, grid_size = 2000)
 gibbon_acq_rule = EfficientGlobalOptimization(  # type: ignore
     num_query_points=10, builder=gibbon_acq)
-points_chosen_by_gibbon, _ = gibbon_acq_rule.acquire_single(
+points_chosen_by_gibbon = gibbon_acq_rule.acquire_single(
     search_space, initial_data, model)
 
 # %% [markdown]

--- a/docs/notebooks/recovering_from_errors.pct.py
+++ b/docs/notebooks/recovering_from_errors.pct.py
@@ -92,9 +92,9 @@ if result.is_ok:
 # %% [markdown]
 # ## Handling failure
 #
-# If on the other hand, the optimization didn't complete successfully, we can fix our observer, and try again. We can try again by using the data, model and acquisition state from the last successful step, which is the last element of the `history`. Note that we only need to account for the acquisition state because we're using the stateful `TrustRegion` rule. For most rules, we don't need to account for this state.
+# If on the other hand, the optimization didn't complete successfully, we can fix our observer, and try again. We can try again by using the data, model and acquisition state from the last successful step, which is the last element of the `history`. Recall that we only need to account for the acquisition state because we're using the stateful `TrustRegion` rule. For most rules, we don't need to account for this state.
 #
-# We can view any `Result` by printing it. We'll do that here to see what exception was caught.
+# Note can view any `Result` by printing it. We'll do that here to see what exception was caught.
 
 # %%
 if result.is_err:

--- a/docs/notebooks/recovering_from_errors.pct.py
+++ b/docs/notebooks/recovering_from_errors.pct.py
@@ -41,7 +41,7 @@ observer = FaultyBranin()
 
 # %% [markdown]
 # ## Set up the problem
-# We'll use the same set up as before, except for the acquisition rule, where we'll use `TrustRegion`, which (with non-trivial state) will better illustrate how to recover.
+# We'll use the same set up as before, except for the acquisition rule, where we'll use `TrustRegion`. `TrustRegion` is stateful, and we'll need to account for its state to recover, so using this rule gives the reader a more comprehensive overview of how to recover.
 
 # %%
 import gpflow
@@ -92,9 +92,9 @@ if result.is_ok:
 # %% [markdown]
 # ## Handling failure
 #
-# If on the other hand, the optimization didn't complete successfully, we can fix our observer, and try again. We can try again by using the data, model and acquisition state from the last successful step, which is the last element of the `history`.
+# If on the other hand, the optimization didn't complete successfully, we can fix our observer, and try again. We can try again by using the data, model and acquisition state from the last successful step, which is the last element of the `history`. Note that we only need to account for the acquisition state because we're using the stateful `TrustRegion` rule. For most rules, we don't need to account for this state.
 #
-# Note we can view any `Result` by printing it. We'll do that here to see what exception was caught.
+# We can view any `Result` by printing it. We'll do that here to see what exception was caught.
 
 # %%
 if result.is_err:

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+from typing import List, Union, cast
+
 import gpflow
 import numpy.testing as npt
 import pytest
@@ -46,55 +48,65 @@ from trieste.objectives import (
 from trieste.objectives.utils import mk_observer
 from trieste.observer import OBJECTIVE
 from trieste.space import Box, SearchSpace
+from trieste.types import State, TensorType
 
 
 @random_seed
 @pytest.mark.parametrize(
     "num_steps, acquisition_rule",
-    [
-        (20, EfficientGlobalOptimization()),
-        (25, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
-        (
-            15,
-            EfficientGlobalOptimization(
-                MinValueEntropySearch(BRANIN_SEARCH_SPACE, num_fourier_features=1000).using(
-                    OBJECTIVE
-                )
+    cast(
+        List[
+            Union[
+                AcquisitionRule[TensorType, Box],
+                AcquisitionRule[State[TensorType, TrustRegion.State], Box],
+            ]
+        ],
+        [
+            (20, EfficientGlobalOptimization()),
+            (25, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
+            (
+                15,
+                EfficientGlobalOptimization(
+                    MinValueEntropySearch(BRANIN_SEARCH_SPACE, num_fourier_features=1000).using(
+                        OBJECTIVE
+                    )
+                ),
             ),
-        ),
-        (
-            10,
-            EfficientGlobalOptimization(
-                BatchMonteCarloExpectedImprovement(sample_size=500).using(OBJECTIVE),
-                num_query_points=3,
+            (
+                10,
+                EfficientGlobalOptimization(
+                    BatchMonteCarloExpectedImprovement(sample_size=500).using(OBJECTIVE),
+                    num_query_points=3,
+                ),
             ),
-        ),
-        (
-            10,
-            EfficientGlobalOptimization(
-                LocalPenalizationAcquisitionFunction(
-                    BRANIN_SEARCH_SPACE,
-                ).using(OBJECTIVE),
-                num_query_points=3,
+            (
+                10,
+                EfficientGlobalOptimization(
+                    LocalPenalizationAcquisitionFunction(
+                        BRANIN_SEARCH_SPACE,
+                    ).using(OBJECTIVE),
+                    num_query_points=3,
+                ),
             ),
-        ),
-        (
-            10,
-            EfficientGlobalOptimization(
-                GIBBON(
-                    BRANIN_SEARCH_SPACE,
-                ).using(OBJECTIVE),
-                num_query_points=2,
+            (
+                10,
+                EfficientGlobalOptimization(
+                    GIBBON(
+                        BRANIN_SEARCH_SPACE,
+                    ).using(OBJECTIVE),
+                    num_query_points=2,
+                ),
             ),
-        ),
-        (15, TrustRegion()),
-        (10, DiscreteThompsonSampling(500, 3)),
-        (10, DiscreteThompsonSampling(500, 3, num_fourier_features=1000)),
-    ],
+            (15, TrustRegion()),
+            (10, DiscreteThompsonSampling(500, 3)),
+            (10, DiscreteThompsonSampling(500, 3, num_fourier_features=1000)),
+        ],
+    ),
 )
 def test_optimizer_finds_minima_of_the_scaled_branin_function(
     num_steps: int,
-    acquisition_rule: AcquisitionRule[None, SearchSpace] | AcquisitionRule[TrustRegion.State, Box],
+    acquisition_rule: AcquisitionRule[TensorType, SearchSpace]
+    | AcquisitionRule[State[TensorType, TrustRegion.State], Box],
 ) -> None:
     search_space = BRANIN_SEARCH_SPACE
 

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -98,6 +98,16 @@ from trieste.types import State, TensorType
                 ),
             ),
             (15, TrustRegion()),
+            (
+                15,
+                TrustRegion(
+                    EfficientGlobalOptimization(
+                        MinValueEntropySearch(BRANIN_SEARCH_SPACE, num_fourier_features=1000).using(
+                            OBJECTIVE
+                        )
+                    )
+                ),
+            ),
             (10, DiscreteThompsonSampling(500, 3)),
             (10, DiscreteThompsonSampling(500, 3, num_fourier_features=1000)),
         ],

--- a/tests/integration/test_multi_objective_bayesian_optimization.py
+++ b/tests/integration/test_multi_objective_bayesian_optimization.py
@@ -31,6 +31,7 @@ from trieste.objectives.multi_objectives import VLMOP2
 from trieste.objectives.utils import mk_observer
 from trieste.observer import OBJECTIVE
 from trieste.space import Box
+from trieste.types import TensorType
 from trieste.utils.pareto import Pareto, get_reference_point
 
 
@@ -67,7 +68,7 @@ from trieste.utils.pareto import Pareto, get_reference_point
     ],
 )
 def test_multi_objective_optimizer_finds_pareto_front_of_the_VLMOP2_function(
-    num_steps: int, acquisition_rule: AcquisitionRule[None, Box], convergence_threshold: float
+    num_steps: int, acquisition_rule: AcquisitionRule[TensorType, Box], convergence_threshold: float
 ) -> None:
     search_space = Box([-2, -2], [2, 2])
 

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -33,6 +33,7 @@ from trieste.acquisition import (
 )
 from trieste.acquisition.optimizer import AcquisitionOptimizer
 from trieste.acquisition.rule import (
+    AcquisitionRule,
     DiscreteThompsonSampling,
     EfficientGlobalOptimization,
     TrustRegion,
@@ -121,7 +122,7 @@ def test_discrete_thompson_sampling_acquire_returns_correct_shape(
     model.kernel = (
         gpflow.kernels.RBF()
     )  # need a gpflow kernel object for random feature decompositions
-    query_points, _ = ts.acquire_single(search_space, dataset, model)
+    query_points = ts.acquire_single(search_space, dataset, model)
 
     npt.assert_array_equal(query_points.shape, tf.constant([num_query_points, 2]))
 
@@ -157,10 +158,10 @@ def test_efficient_global_optimization(optimizer: AcquisitionOptimizer[Box]) -> 
     search_space = Box([-10], [10])
     ego = EfficientGlobalOptimization(function, optimizer)
     data, model = empty_dataset([1], [1]), QuadraticMeanAndRBFKernel(x_shift=1)
-    query_point, _ = ego.acquire_single(search_space, data, model)
+    query_point = ego.acquire_single(search_space, data, model)
     npt.assert_allclose(query_point, [[1]], rtol=1e-4)
     assert not function._updated
-    query_point, _ = ego.acquire(search_space, {OBJECTIVE: data}, {OBJECTIVE: model})
+    query_point = ego.acquire(search_space, {OBJECTIVE: data}, {OBJECTIVE: model})
     npt.assert_allclose(query_point, [[1]], rtol=1e-4)
     assert function._updated
 
@@ -181,7 +182,7 @@ def test_joint_batch_acquisition_rule_acquire() -> None:
         acq, num_query_points=num_query_points
     )
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
-    query_point, _ = ego.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
+    query_point = ego.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
 
     npt.assert_allclose(query_point, [[0.0, 0.0]] * num_query_points, atol=1e-3)
 
@@ -225,7 +226,7 @@ def test_greedy_batch_acquisition_rule_acquire() -> None:
         acq, num_query_points=num_query_points
     )
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
-    query_point, _ = ego.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
+    query_point = ego.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
     assert acq._update_count == num_query_points - 1
     npt.assert_allclose(query_point, [[0.0, 0.0]] * num_query_points, atol=1e-3)
 
@@ -244,27 +245,56 @@ def test_trust_region_raises_for_missing_datasets_key(
     search_space = Box([-1], [1])
     rule = TrustRegion()
     with pytest.raises(KeyError):
-        rule.acquire(search_space, datasets, models, None)
+        rule.acquire(search_space, datasets, models)
 
 
-def test_trust_region_for_default_state() -> None:
-    tr = TrustRegion(NegativeLowerConfidenceBound(0))
+class _Midpoint(AcquisitionRule[TensorType, Box]):
+    def acquire(
+        self,
+        search_space: Box,
+        datasets: Mapping[str, Dataset],
+        models: Mapping[str, ProbabilisticModel],
+    ) -> TensorType:
+        return (search_space.upper[None] + search_space.lower[None]) / 2
+
+
+@pytest.mark.parametrize(
+    "rule, expected_query_point",
+    [
+        (EfficientGlobalOptimization(NegativeLowerConfidenceBound(0)), [[0.0, 0.0]]),
+        (_Midpoint(), [[-0.45, 1.15]]),
+    ],
+)
+def test_trust_region_for_default_state(
+    rule: AcquisitionRule[TensorType, Box], expected_query_point: TensorType
+) -> None:
+    tr = TrustRegion(rule)
     dataset = Dataset(tf.constant([[0.1, 0.2]]), tf.constant([[0.012]]))
     lower_bound = tf.constant([-2.2, -1.0])
     upper_bound = tf.constant([1.3, 3.3])
     search_space = Box(lower_bound, upper_bound)
 
-    query_point, state = tr.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel(), None)
+    state, query_point = tr.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())(None)
 
-    npt.assert_array_almost_equal(query_point, tf.constant([[0.0, 0.0]]), 5)
+    assert state is not None
+    npt.assert_array_almost_equal(query_point, expected_query_point, 5)
     npt.assert_array_almost_equal(state.acquisition_space.lower, lower_bound)
     npt.assert_array_almost_equal(state.acquisition_space.upper, upper_bound)
     npt.assert_array_almost_equal(state.y_min, [0.012])
     assert state.is_global
 
 
-def test_trust_region_successful_global_to_global_trust_region_unchanged() -> None:
-    tr = TrustRegion(NegativeLowerConfidenceBound(0).using(OBJECTIVE))
+@pytest.mark.parametrize(
+    "rule, expected_query_point",
+    [
+        (EfficientGlobalOptimization(NegativeLowerConfidenceBound(0)), [[0.0, 0.0]]),
+        (_Midpoint(), [[-0.45, 1.15]]),
+    ],
+)
+def test_trust_region_successful_global_to_global_trust_region_unchanged(
+    rule: AcquisitionRule[TensorType, Box], expected_query_point: TensorType
+) -> None:
+    tr = TrustRegion(rule)
     dataset = Dataset(tf.constant([[0.1, 0.2], [-0.1, -0.2]]), tf.constant([[0.4], [0.3]]))
     lower_bound = tf.constant([-2.2, -1.0])
     upper_bound = tf.constant([1.3, 3.3])
@@ -275,19 +305,29 @@ def test_trust_region_successful_global_to_global_trust_region_unchanged() -> No
     is_global = True
     previous_state = TrustRegion.State(search_space, eps, previous_y_min, is_global)
 
-    query_point, current_state = tr.acquire(
-        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}, previous_state
-    )
+    current_state, query_point = tr.acquire(
+        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}
+    )(previous_state)
 
+    assert current_state is not None
     npt.assert_array_almost_equal(current_state.eps, previous_state.eps)
     assert current_state.is_global
-    npt.assert_array_almost_equal(query_point, tf.constant([[0.0, 0.0]]), 5)
+    npt.assert_array_almost_equal(query_point, expected_query_point, 5)
     npt.assert_array_almost_equal(current_state.acquisition_space.lower, lower_bound)
     npt.assert_array_almost_equal(current_state.acquisition_space.upper, upper_bound)
 
 
-def test_trust_region_for_unsuccessful_global_to_local_trust_region_unchanged() -> None:
-    tr = TrustRegion(NegativeLowerConfidenceBound(0).using(OBJECTIVE))
+@pytest.mark.parametrize(
+    "rule",
+    [
+        EfficientGlobalOptimization(NegativeLowerConfidenceBound(0)),
+        _Midpoint(),
+    ],
+)
+def test_trust_region_for_unsuccessful_global_to_local_trust_region_unchanged(
+    rule: AcquisitionRule[TensorType, Box]
+) -> None:
+    tr = TrustRegion(rule)
     dataset = Dataset(tf.constant([[0.1, 0.2], [-0.1, -0.2]]), tf.constant([[0.4], [0.5]]))
     lower_bound = tf.constant([-2.2, -1.0])
     upper_bound = tf.constant([1.3, 3.3])
@@ -299,10 +339,11 @@ def test_trust_region_for_unsuccessful_global_to_local_trust_region_unchanged() 
     acquisition_space = search_space
     previous_state = TrustRegion.State(acquisition_space, eps, previous_y_min, is_global)
 
-    query_point, current_state = tr.acquire(
-        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}, previous_state
-    )
+    current_state, query_point = tr.acquire(
+        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}
+    )(previous_state)
 
+    assert current_state is not None
     npt.assert_array_almost_equal(current_state.eps, previous_state.eps)
     assert not current_state.is_global
     npt.assert_array_less(lower_bound, current_state.acquisition_space.lower)
@@ -310,8 +351,17 @@ def test_trust_region_for_unsuccessful_global_to_local_trust_region_unchanged() 
     assert query_point[0] in current_state.acquisition_space
 
 
-def test_trust_region_for_successful_local_to_global_trust_region_increased() -> None:
-    tr = TrustRegion(NegativeLowerConfidenceBound(0).using(OBJECTIVE))
+@pytest.mark.parametrize(
+    "rule",
+    [
+        EfficientGlobalOptimization(NegativeLowerConfidenceBound(0)),
+        _Midpoint(),
+    ],
+)
+def test_trust_region_for_successful_local_to_global_trust_region_increased(
+    rule: AcquisitionRule[TensorType, Box]
+) -> None:
+    tr = TrustRegion(rule)
     dataset = Dataset(tf.constant([[0.1, 0.2], [-0.1, -0.2]]), tf.constant([[0.4], [0.3]]))
     lower_bound = tf.constant([-2.2, -1.0])
     upper_bound = tf.constant([1.3, 3.3])
@@ -323,18 +373,28 @@ def test_trust_region_for_successful_local_to_global_trust_region_increased() ->
     acquisition_space = Box(dataset.query_points[0] - eps, dataset.query_points[0] + eps)
     previous_state = TrustRegion.State(acquisition_space, eps, previous_y_min, is_global)
 
-    _, current_state = tr.acquire(
-        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}, previous_state
-    )
+    current_state, _ = tr.acquire(
+        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}
+    )(previous_state)
 
+    assert current_state is not None
     npt.assert_array_less(previous_state.eps, current_state.eps)  # current TR larger than previous
     assert current_state.is_global
     npt.assert_array_almost_equal(current_state.acquisition_space.lower, lower_bound)
     npt.assert_array_almost_equal(current_state.acquisition_space.upper, upper_bound)
 
 
-def test_trust_region_for_unsuccessful_local_to_global_trust_region_reduced() -> None:
-    tr = TrustRegion(NegativeLowerConfidenceBound(0).using(OBJECTIVE))
+@pytest.mark.parametrize(
+    "rule",
+    [
+        EfficientGlobalOptimization(NegativeLowerConfidenceBound(0)),
+        _Midpoint(),
+    ],
+)
+def test_trust_region_for_unsuccessful_local_to_global_trust_region_reduced(
+    rule: AcquisitionRule[TensorType, Box]
+) -> None:
+    tr = TrustRegion(rule)
     dataset = Dataset(tf.constant([[0.1, 0.2], [-0.1, -0.2]]), tf.constant([[0.4], [0.5]]))
     lower_bound = tf.constant([-2.2, -1.0])
     upper_bound = tf.constant([1.3, 3.3])
@@ -346,10 +406,11 @@ def test_trust_region_for_unsuccessful_local_to_global_trust_region_reduced() ->
     acquisition_space = Box(dataset.query_points[0] - eps, dataset.query_points[0] + eps)
     previous_state = TrustRegion.State(acquisition_space, eps, previous_y_min, is_global)
 
-    _, current_state = tr.acquire(
-        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}, previous_state
-    )
+    current_state, _ = tr.acquire(
+        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}
+    )(previous_state)
 
+    assert current_state is not None
     npt.assert_array_less(current_state.eps, previous_state.eps)  # current TR smaller than previous
     assert current_state.is_global
     npt.assert_array_almost_equal(current_state.acquisition_space.lower, lower_bound)

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -230,7 +230,7 @@ def test_greedy_batch_acquisition_rule_acquire() -> None:
     assert acq._update_count == num_query_points - 1
     npt.assert_allclose(query_point, [[0.0, 0.0]] * num_query_points, atol=1e-3)
 
-    query_point, _ = ego.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
+    query_point = ego.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
     npt.assert_allclose(query_point, [[0.0, 0.0]] * num_query_points, atol=1e-3)
     assert acq._update_count == 2 * num_query_points - 1
 

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import NoReturn
+from typing import NoReturn, Optional
 
 import numpy.testing as npt
 import pytest
@@ -39,7 +39,7 @@ from trieste.data import Dataset
 from trieste.models import ProbabilisticModel, TrainableProbabilisticModel
 from trieste.observer import OBJECTIVE, Observer
 from trieste.space import Box, SearchSpace
-from trieste.types import TensorType
+from trieste.types import State, TensorType
 from trieste.utils import Err, Ok
 
 
@@ -198,7 +198,7 @@ def test_bayesian_optimizer_uses_specified_acquisition_state(
     expected_states_received: list[int | None],
     final_acquisition_state: int | None,
 ) -> None:
-    class Rule(AcquisitionRule[int, Box]):
+    class Rule(AcquisitionRule[State[Optional[int], TensorType], Box]):
         def __init__(self) -> None:
             self.states_received: list[int | None] = []
 
@@ -207,14 +207,16 @@ def test_bayesian_optimizer_uses_specified_acquisition_state(
             search_space: Box,
             datasets: Mapping[str, Dataset],
             models: Mapping[str, ProbabilisticModel],
-            state: int | None = None,
-        ) -> tuple[TensorType, int]:
-            self.states_received.append(state)
+        ) -> State[int | None, TensorType]:
+            def go(state: int | None) -> tuple[int | None, TensorType]:
+                self.states_received.append(state)
 
-            if state is None:
-                state = 0
+                if state is None:
+                    state = 0
 
-            return tf.constant([[0.0]], tf.float64), state + 1
+                return state + 1, tf.constant([[0.0]], tf.float64)
+
+            return go
 
     rule = Rule()
 
@@ -271,13 +273,12 @@ class _BrokenModel(_PseudoTrainableQuadratic):
         raise _Whoops
 
 
-class _BrokenRule(AcquisitionRule[None, SearchSpace]):
+class _BrokenRule(AcquisitionRule[NoReturn, SearchSpace]):
     def acquire(
         self,
         search_space: SearchSpace,
         datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
-        state: None = None,
     ) -> NoReturn:
         raise _Whoops
 
@@ -329,13 +330,12 @@ def test_bayesian_optimizer_optimize_is_noop_for_zero_steps() -> None:
         def optimize(self, dataset: Dataset) -> NoReturn:
             assert False
 
-    class _UnusableRule(AcquisitionRule[None, Box]):
+    class _UnusableRule(AcquisitionRule[NoReturn, Box]):
         def acquire(
             self,
             search_space: Box,
             datasets: Mapping[str, Dataset],
             models: Mapping[str, ProbabilisticModel],
-            state: None = None,
         ) -> NoReturn:
             assert False
 
@@ -366,27 +366,29 @@ def test_bayesian_optimizer_can_use_two_gprs_for_objective_defined_by_two_dimens
     LINEAR = "linear"
     EXPONENTIAL = "exponential"
 
-    class AdditionRule(AcquisitionRule[int, Box]):
+    class AdditionRule(AcquisitionRule[State[Optional[int], TensorType], Box]):
         def acquire(
             self,
             search_space: Box,
             datasets: Mapping[str, Dataset],
             models: Mapping[str, ProbabilisticModel],
-            previous_state: int | None = None,
-        ) -> tuple[TensorType, int]:
-            if previous_state is None:
-                previous_state = 1
+        ) -> State[int | None, TensorType]:
+            def go(previous_state: int | None) -> tuple[int | None, TensorType]:
+                if previous_state is None:
+                    previous_state = 1
 
-            candidate_query_points = search_space.sample(previous_state)
-            linear_predictions, _ = models[LINEAR].predict(candidate_query_points)
-            exponential_predictions, _ = models[EXPONENTIAL].predict(candidate_query_points)
+                candidate_query_points = search_space.sample(previous_state)
+                linear_predictions, _ = models[LINEAR].predict(candidate_query_points)
+                exponential_predictions, _ = models[EXPONENTIAL].predict(candidate_query_points)
 
-            target = linear_predictions + exponential_predictions
+                target = linear_predictions + exponential_predictions
 
-            optimum_idx = tf.argmin(target, axis=0)[0]
-            next_query_points = tf.expand_dims(candidate_query_points[optimum_idx, ...], axis=0)
+                optimum_idx = tf.argmin(target, axis=0)[0]
+                next_query_points = tf.expand_dims(candidate_query_points[optimum_idx, ...], axis=0)
 
-            return next_query_points, previous_state * 2
+                return previous_state * 2, next_query_points
+
+            return go
 
     def linear_and_exponential(query_points: tf.Tensor) -> dict[str, Dataset]:
         return {
@@ -430,16 +432,18 @@ def test_bayesian_optimizer_optimize_doesnt_track_state_if_told_not_to() -> None
 
 
 def test_bayesian_optimizer_optimize_tracked_state() -> None:
-    class _CountingRule(AcquisitionRule[int, Box]):
+    class _CountingRule(AcquisitionRule[State[Optional[int], TensorType], Box]):
         def acquire(
             self,
             search_space: Box,
             datasets: Mapping[str, Dataset],
             models: Mapping[str, ProbabilisticModel],
-            state: int | None = None,
-        ) -> tuple[TensorType, int]:
-            new_state = 0 if state is None else state + 1
-            return tf.constant([[10.0]], tf.float64) + new_state, new_state
+        ) -> State[int | None, TensorType]:
+            def go(state: int | None) -> tuple[int | None, TensorType]:
+                new_state = 0 if state is None else state + 1
+                return new_state, tf.constant([[10.0]], tf.float64) + new_state
+
+            return go
 
     class _DecreasingVarianceModel(QuadraticMeanAndRBFKernel, TrainableProbabilisticModel):
         def __init__(self, data: Dataset):

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -113,7 +113,7 @@ def quadratic(x: tf.Tensor) -> tf.Tensor:
     return tf.reduce_sum(x ** 2, axis=-1, keepdims=True)
 
 
-class FixedAcquisitionRule(AcquisitionRule[None, SearchSpace]):
+class FixedAcquisitionRule(AcquisitionRule[TensorType, SearchSpace]):
     """An acquisition rule that returns the same fixed value on every step."""
 
     def __init__(self, query_points: SequenceN[Sequence[float]]):
@@ -131,16 +131,14 @@ class FixedAcquisitionRule(AcquisitionRule[None, SearchSpace]):
         search_space: SearchSpace,
         datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
-        state: None = None,
-    ) -> tuple[TensorType, None]:
+    ) -> TensorType:
         """
         :param search_space: Unused.
         :param datasets: Unused.
         :param models: Unused.
-        :param state: Unused.
-        :return: The fixed value specified on initialisation, and `None`.
+        :return: The fixed value specified on initialisation.
         """
-        return self._qp, None
+        return self._qp
 
 
 ShapeLike = Union[tf.TensorShape, Sequence[int]]

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -337,17 +337,20 @@ class TrustRegion(AcquisitionRule[types.State[Optional["TrustRegion.State"], Ten
 
     def __init__(
         self,
-        rule: AcquisitionRule[TensorType, Box] = EfficientGlobalOptimization(),
+        rule: AcquisitionRule[TensorType, Box] | None = None,
         beta: float = 0.7,
         kappa: float = 1e-4,
     ):
         """
         :param rule: The acquisition rule that defines how to search for a new query point in a
-            given search space.
+            given search space. Defaults to :class:`EfficientGlobalOptimization` with default arguments.
         :param beta: The inverse of the trust region contraction factor.
         :param kappa: Scales the threshold for the minimal improvement required for a step to be
             considered a success.
         """
+        if rule is None:
+            rule = EfficientGlobalOptimization()
+
         self._rule = rule
         self._beta = beta
         self._kappa = kappa

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -25,6 +25,7 @@ from typing import Generic, Optional, TypeVar, Union
 
 import tensorflow as tf
 
+from .. import types
 from ..data import Dataset
 from ..models import ProbabilisticModel
 from ..observer import OBJECTIVE
@@ -38,23 +39,27 @@ from .function import (
     SingleModelAcquisitionBuilder,
     SingleModelGreedyAcquisitionBuilder,
 )
-from .optimizer import (
-    AcquisitionOptimizer,
-    automatic_optimizer_selector,
-    batchify,
-    generate_continuous_optimizer,
-)
+from .optimizer import AcquisitionOptimizer, automatic_optimizer_selector, batchify
 from .sampler import ExactThompsonSampler, RandomFourierFeatureThompsonSampler, ThompsonSampler
 
-S = TypeVar("S")
-""" Unbound type variable. """
+T_co = TypeVar("T_co", covariant=True)
+""" Unbound covariant type variable. """
 
 SP_contra = TypeVar("SP_contra", bound=SearchSpace, contravariant=True)
 """ Contravariant type variable bound to :class:`~trieste.space.SearchSpace`. """
 
 
-class AcquisitionRule(ABC, Generic[S, SP_contra]):
-    """The central component of the acquisition API."""
+class AcquisitionRule(ABC, Generic[T_co, SP_contra]):
+    """
+    The central component of the acquisition API.
+
+    An :class:`AcquisitionRule` can produce any value from the search space for this step, and the
+    historic data and models. This value is typically a set of query points, either on its own as
+    a `TensorType` (see e.g. :class:`EfficientGlobalOptimization`), or within some context
+    (see e.g. :class:`TrustRegion`). Indeed, to use an :class:`AcquisitionRule` in the main
+    :class:`~trieste.bayesian_optimizer.BayesianOptimizer` Bayesian optimization loop, the rule
+    must return either a `TensorType` or `State`-ful `TensorType`.
+    """
 
     @abstractmethod
     def acquire(
@@ -62,30 +67,21 @@ class AcquisitionRule(ABC, Generic[S, SP_contra]):
         search_space: SP_contra,
         datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
-        state: S | None = None,
-    ) -> tuple[TensorType, S]:
+    ) -> T_co:
         """
-        Return the optimal points within the specified ``search_space``, where optimality is defined
-        by the acquisition rule.
-
+        Return a value of type `T_co`. Typically this will be a set of query points, either on its
+        own as a `TensorType` (see e.g. :class:`EfficientGlobalOptimization`), or within some
+        context (see e.g. :class:`TrustRegion`).
 
         **Type hints:**
-          - The global search space must be a :class:`~trieste.space.SearchSpace`. The exact type
-            of :class:`~trieste.space.SearchSpace` depends on the specific
-            :class:`AcquisitionRule`.
-          - Each :class:`AcquisitionRule` must define the type of its corresponding acquisition
-            state (if the rule is stateless, this type can be `None`). The ``state`` passed
-            to this method, and the state returned, must both be of that type.
+          - The search space must be a :class:`~trieste.space.SearchSpace`. The exact type of
+            :class:`~trieste.space.SearchSpace` depends on the specific :class:`AcquisitionRule`.
 
-
-        :param search_space: The global search space over which the optimization problem
-            is defined.
+        :param search_space: The local acquisition search space for *this step*.
         :param datasets: The known observer query points and observations for each tag.
         :param models: The model to use for each :class:`~trieste.data.Dataset` in ``datasets``
             (matched by tag).
-        :param state: The acquisition state from the previous step, if there was a previous step,
-            else `None`.
-        :return: The optimal points and the acquisition state for this step.
+        :return: A value of type `T_co`.
         """
 
     def acquire_single(
@@ -93,31 +89,25 @@ class AcquisitionRule(ABC, Generic[S, SP_contra]):
         search_space: SP_contra,
         dataset: Dataset,
         model: ProbabilisticModel,
-        state: S | None = None,
-    ) -> tuple[TensorType, S]:
+    ) -> T_co:
         """
         A convenience wrapper for :meth:`acquire` that uses only one model, dataset pair.
-
-        Return the optimal points within the specified ``search_space``, where optimality is defined
-        by the acquisition rule.
 
         :param search_space: The global search space over which the optimization problem
             is defined.
         :param dataset: The known observer query points and observations.
-        :param models: The model to use for the dataset.
-        :param state: The acquisition state from the previous step, if there was a previous step,
-            else `None`.
-        :return: The optimal points and the acquisition state for this step.
+        :param model: The model to use for the dataset.
+        :return: A value of type `T_co`.
         """
         if isinstance(dataset, dict) or isinstance(model, dict):
             raise ValueError(
                 "AcquisitionRule.acquire_single method does not support multiple datasets "
                 "or models: use acquire instead"
             )
-        return self.acquire(search_space, {OBJECTIVE: dataset}, {OBJECTIVE: model}, state)
+        return self.acquire(search_space, {OBJECTIVE: dataset}, {OBJECTIVE: model})
 
 
-class EfficientGlobalOptimization(AcquisitionRule[None, SP_contra]):
+class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
     """Implements the Efficient Global Optimization, or EGO, algorithm."""
 
     def __init__(
@@ -184,18 +174,15 @@ class EfficientGlobalOptimization(AcquisitionRule[None, SP_contra]):
         search_space: SP_contra,
         datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
-        state: None = None,
-    ) -> tuple[TensorType, None]:
+    ) -> TensorType:
         """
-        Return the query point that optimizes the acquisition function produced by ``builder`` (see
-        :meth:`__init__`).
+        Return the query point(s) that optimizes the acquisition function produced by ``builder``
+        (see :meth:`__init__`).
 
-        :param search_space: The global :class:`~trieste.space.SearchSpace` over which the
-            optimization problem is defined.
+        :param search_space: The local acquisition search space for *this step*.
         :param datasets: The known observer query points and observations.
         :param models: The models of the specified ``datasets``.
-        :param state: Unused.
-        :return: The single (or batch of) points to query, and `None`.
+        :return: The single (or batch of) points to query.
         """
         if self._acquisition_function is None:
             self._acquisition_function = self._builder.prepare_acquisition_function(
@@ -218,10 +205,10 @@ class EfficientGlobalOptimization(AcquisitionRule[None, SP_contra]):
                 chosen_point = self._optimizer(search_space, self._acquisition_function)
                 points = tf.concat([points, chosen_point], axis=0)
 
-        return points, None
+        return points
 
 
-class DiscreteThompsonSampling(AcquisitionRule[None, SearchSpace]):
+class DiscreteThompsonSampling(AcquisitionRule[TensorType, SearchSpace]):
     r"""
     Implements Thompson sampling for choosing optimal points.
 
@@ -276,19 +263,16 @@ class DiscreteThompsonSampling(AcquisitionRule[None, SearchSpace]):
         search_space: SearchSpace,
         datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
-        state: None = None,
-    ) -> tuple[TensorType, None]:
+    ) -> TensorType:
         """
         Sample `num_search_space_samples` (see :meth:`__init__`) points from the
         ``search_space``. Of those points, return the `num_query_points` points at which
         random samples yield the **minima** of the model posterior.
 
-        :param search_space: The global :class:`~trieste.space.SearchSpace` over which the
-            optimization problem is defined.
+        :param search_space: The local acquisition search space for *this step*.
         :param datasets: Unused.
         :param models: The model of the known data. Uses the single key `OBJECTIVE`.
-        :param state: Unused.
-        :return: The `num_query_points` points to query, and `None`.
+        :return: The ``num_query_points`` points to query.
         :raise ValueError: If ``models`` do not contain the key `OBJECTIVE`, or it contains any
             other key.
         """
@@ -320,10 +304,10 @@ class DiscreteThompsonSampling(AcquisitionRule[None, SearchSpace]):
         query_points = search_space.sample(self._num_search_space_samples)
         thompson_samples = thompson_sampler.sample(query_points)
 
-        return thompson_samples, None
+        return thompson_samples
 
 
-class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):
+class TrustRegion(AcquisitionRule[types.State[Optional["TrustRegion.State"], TensorType], Box]):
     """Implements the *trust region* acquisition algorithm."""
 
     @dataclass(frozen=True)
@@ -353,53 +337,39 @@ class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):
 
     def __init__(
         self,
-        builder: Optional[AcquisitionFunctionBuilder | SingleModelAcquisitionBuilder] = None,
+        rule: AcquisitionRule[TensorType, Box] = EfficientGlobalOptimization(),
         beta: float = 0.7,
         kappa: float = 1e-4,
-        optimizer: AcquisitionOptimizer[Box] | None = None,
     ):
         """
-        :param builder: The acquisition function builder to use. :class:`TrustRegion` will attempt
-            to **maximise** the corresponding acquisition function. Defaults to
-            :class:`~trieste.acquisition.ExpectedImprovement` with tag `OBJECTIVE`.
+        :param rule: The acquisition rule that defines how to search for a new query point in a
+            given search space.
         :param beta: The inverse of the trust region contraction factor.
         :param kappa: Scales the threshold for the minimal improvement required for a step to be
             considered a success.
-        :param optimizer: The optimizer with which to optimize the acquisition function built by
-            ``builder``. This must be able optimize over a :class:`Box`.
         """
-        if builder is None:
-            builder = ExpectedImprovement()
-
-        if isinstance(builder, SingleModelAcquisitionBuilder):
-            builder = builder.using(OBJECTIVE)
-
-        if optimizer is None:
-            optimizer = generate_continuous_optimizer()
-
-        self._builder = builder
+        self._rule = rule
         self._beta = beta
         self._kappa = kappa
-        self._optimizer = optimizer
-        self._acquisition_function: Optional[AcquisitionFunction] = None
 
     def __repr__(self) -> str:
         """"""
-        return f"TrustRegion({self._builder!r}, {self._beta!r}, {self._kappa!r})"
+        return f"TrustRegion({self._rule!r}, {self._beta!r}, {self._kappa!r})"
 
     def acquire(
         self,
         search_space: Box,
         datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
-        state: State | None = None,
-    ) -> tuple[TensorType, State]:
+    ) -> types.State[State | None, TensorType]:
         """
-        Acquire one new query point according the trust region algorithm. Return the new query point
-        along with the final acquisition state from this step.
+        Construct a local search space from ``search_space`` according the trust region algorithm,
+        and use that with the ``rule`` specified at :meth:`~TrustRegion.__init__` to find new
+        query points. Return a function that constructs these points given a previous trust region
+        state.
 
-        If no ``state`` is specified (it is `None`), ``search_space`` is used as
-        the search space for this step.
+        If no ``state`` is specified (it is `None`), ``search_space`` is used as the search space
+        for this step.
 
         If a ``state`` is specified, and the new optimum improves over the previous optimum
         by some threshold (that scales linearly with ``kappa``), the previous acquisition is
@@ -418,14 +388,12 @@ class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):
         ``search_space``. For a local search, the actual search space will be the
         intersection of the trust region and ``search_space``.
 
-        :param search_space: The global  :class:`~trieste.space.SearchSpace` for the optimization
-            problem.
+        :param search_space: The local acquisition search space for *this step*.
         :param datasets: The known observer query points and observations. Uses the data for key
             `OBJECTIVE` to calculate the new trust region.
         :param models: The models of the specified ``datasets``.
-        :param state: The acquisition state from the previous step, if there was a previous step,
-            else `None`.
-        :return: A 2-tuple of the query point and the acquisition state for this step.
+        :return: A function that constructs the next acquisition state and the recommended query
+            points from the previous acquisition state.
         :raise KeyError: If ``datasets`` does not contain the key `OBJECTIVE`.
         """
         dataset = datasets[OBJECTIVE]
@@ -435,43 +403,39 @@ class TrustRegion(AcquisitionRule["TrustRegion.State", Box]):
 
         y_min = tf.reduce_min(dataset.observations, axis=0)
 
-        if state is None:
-            eps = 0.5 * (global_upper - global_lower) / (5.0 ** (1.0 / global_lower.shape[-1]))
-            is_global = True
-        else:
-            tr_volume = tf.reduce_prod(
-                state.acquisition_space.upper - state.acquisition_space.lower
-            )
-            step_is_success = y_min < state.y_min - self._kappa * tr_volume
+        def go(state: TrustRegion.State | None) -> tuple[TrustRegion.State | None, TensorType]:
 
-            eps = (
-                state.eps
-                if state.is_global
-                else state.eps / self._beta
-                if step_is_success
-                else state.eps * self._beta
-            )
+            if state is None:
+                eps = 0.5 * (global_upper - global_lower) / (5.0 ** (1.0 / global_lower.shape[-1]))
+                is_global = True
+            else:
+                tr_volume = tf.reduce_prod(
+                    state.acquisition_space.upper - state.acquisition_space.lower
+                )
+                step_is_success = y_min < state.y_min - self._kappa * tr_volume
 
-            is_global = step_is_success or not state.is_global
+                eps = (
+                    state.eps
+                    if state.is_global
+                    else state.eps / self._beta
+                    if step_is_success
+                    else state.eps * self._beta
+                )
 
-        if is_global:
-            acquisition_space = search_space
-        else:
-            xmin = dataset.query_points[tf.argmin(dataset.observations)[0], :]
-            acquisition_space = Box(
-                tf.reduce_max([global_lower, xmin - eps], axis=0),
-                tf.reduce_min([global_upper, xmin + eps], axis=0),
-            )
+                is_global = step_is_success or not state.is_global
 
-        if self._acquisition_function is None:
-            self._acquisition_function = self._builder.prepare_acquisition_function(
-                datasets, models
-            )
-        else:
-            self._acquisition_function = self._builder.update_acquisition_function(
-                self._acquisition_function, datasets, models
-            )
-        point = self._optimizer(acquisition_space, self._acquisition_function)
-        state_ = TrustRegion.State(acquisition_space, eps, y_min, is_global)
+            if is_global:
+                acquisition_space = search_space
+            else:
+                xmin = dataset.query_points[tf.argmin(dataset.observations)[0], :]
+                acquisition_space = Box(
+                    tf.reduce_max([global_lower, xmin - eps], axis=0),
+                    tf.reduce_min([global_upper, xmin + eps], axis=0),
+                )
 
-        return point, state_
+            points = self._rule.acquire(acquisition_space, datasets, models)
+            state_ = TrustRegion.State(acquisition_space, eps, y_min, is_global)
+
+            return state_, points
+
+        return go

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -343,7 +343,8 @@ class TrustRegion(AcquisitionRule[types.State[Optional["TrustRegion.State"], Ten
     ):
         """
         :param rule: The acquisition rule that defines how to search for a new query point in a
-            given search space. Defaults to :class:`EfficientGlobalOptimization` with default arguments.
+            given search space. Defaults to :class:`EfficientGlobalOptimization` with default
+            arguments.
         :param beta: The inverse of the trust region contraction factor.
         :param kappa: Scales the threshold for the minimal improvement required for a step to be
             considered a success.

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -30,6 +30,7 @@ from .data import Dataset
 from .models import ModelSpec, TrainableProbabilisticModel, create_model
 from .observer import OBJECTIVE, Observer
 from .space import SearchSpace
+from .types import State, TensorType
 from .utils import Err, Ok, Result, map_values
 
 S = TypeVar("S")
@@ -182,7 +183,23 @@ class BayesianOptimizer(Generic[SP]):
         num_steps: int,
         datasets: Mapping[str, Dataset],
         model_specs: Mapping[str, ModelSpec],
-        acquisition_rule: AcquisitionRule[S, SP],
+        acquisition_rule: AcquisitionRule[TensorType, SP],
+        *,
+        track_state: bool = True,
+        fit_initial_model: bool = True,
+        # this should really be OptimizationResult[None], but tf.Tensor is untyped so the type
+        # checker can't differentiate between TensorType and State[S | None, TensorType], and
+        # the return types clash. object is close enough to None that object will do.
+    ) -> OptimizationResult[object]:
+        ...
+
+    @overload
+    def optimize(
+        self,
+        num_steps: int,
+        datasets: Mapping[str, Dataset],
+        model_specs: Mapping[str, ModelSpec],
+        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP],
         acquisition_state: S | None = None,
         *,
         track_state: bool = True,
@@ -208,7 +225,20 @@ class BayesianOptimizer(Generic[SP]):
         num_steps: int,
         datasets: Dataset,
         model_specs: ModelSpec,
-        acquisition_rule: AcquisitionRule[S, SP],
+        acquisition_rule: AcquisitionRule[TensorType, SP],
+        *,
+        track_state: bool = True,
+        fit_initial_model: bool = True,
+    ) -> OptimizationResult[object]:
+        ...
+
+    @overload
+    def optimize(
+        self,
+        num_steps: int,
+        datasets: Dataset,
+        model_specs: ModelSpec,
+        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP],
         acquisition_state: S | None = None,
         *,
         track_state: bool = True,
@@ -221,7 +251,8 @@ class BayesianOptimizer(Generic[SP]):
         num_steps: int,
         datasets: Mapping[str, Dataset] | Dataset,
         model_specs: Mapping[str, ModelSpec] | ModelSpec,
-        acquisition_rule: AcquisitionRule[S, SP] | None = None,
+        acquisition_rule: AcquisitionRule[TensorType | State[S | None, TensorType], SP]
+        | None = None,
         acquisition_state: S | None = None,
         *,
         track_state: bool = True,
@@ -312,7 +343,7 @@ class BayesianOptimizer(Generic[SP]):
                     f" {OBJECTIVE!r}, got keys {datasets.keys()}"
                 )
 
-            acquisition_rule = cast(AcquisitionRule[S, SP], EfficientGlobalOptimization())
+            acquisition_rule = cast(AcquisitionRule[TensorType, SP], EfficientGlobalOptimization())
 
         models = map_values(create_model, model_specs)
         history: list[Record[S]] = []
@@ -330,9 +361,12 @@ class BayesianOptimizer(Generic[SP]):
                         model.update(dataset)
                         model.optimize(dataset)
 
-                query_points, acquisition_state = acquisition_rule.acquire(
-                    self._search_space, datasets, models, acquisition_state
-                )
+                points_or_stateful = acquisition_rule.acquire(self._search_space, datasets, models)
+
+                if callable(points_or_stateful):
+                    acquisition_state, query_points = points_or_stateful(acquisition_state)
+                else:
+                    query_points = points_or_stateful
 
                 observer_output = self._observer(query_points)
 

--- a/trieste/types.py
+++ b/trieste/types.py
@@ -12,10 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This module contains type aliases."""
-from typing import Union
+from typing import Callable, Tuple, TypeVar, Union
 
 import numpy as np
 import tensorflow as tf
 
 TensorType = Union[np.ndarray, tf.Tensor]
 """Type alias for tensor-like types."""
+
+S = TypeVar("S")
+"""Unbound type variable."""
+
+T = TypeVar("T")
+"""Unbound type variable."""
+
+State = Callable[[S], Tuple[S, T]]
+"""
+A `State` produces a value of type `T`, given a state of type `S`, and in doing so can update the
+state. If the state is updated, it is not updated in-place. Instead, a new state is created. This
+is a referentially transparent alternative to mutable state.
+"""


### PR DESCRIPTION
This is a much simpler alternative to #286 . While that PR special-cases trust region itself, this PR special-cases only stateful acquisition rules

It's kind of two PRs, and I can split them up if you prefer. The first curries the `acquire` method on `TrustRegion`, moving the state parameter to the return type. This means we can then parametrize over the return type, now `T_co`. In the second, we let users choose which rule to use with `TrustRegion`.