### PR TITLE
Suppress tf logging in notebooks

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 on:
+  workflow_dispatch:
   push:
     tags: v[0-9]+.[0-9]+.[0-9]+*
 

--- a/docs/constraints.txt
+++ b/docs/constraints.txt
@@ -54,7 +54,7 @@ requests==2.26.0
 six==1.16.0
 snowballstemmer==2.1.0
 soupsieve==2.2.1
-Sphinx==4.1.2
+Sphinx==3.5.4
 sphinx-autoapi==1.8.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.3.0

--- a/docs/notebooks/batch_optimization.pct.py
+++ b/docs/notebooks/batch_optimization.pct.py
@@ -12,6 +12,7 @@ from util.plotting_plotly import plot_function_plotly
 import matplotlib.pyplot as plt
 import trieste
 
+tf.get_logger().setLevel('INFO')
 np.random.seed(1234)
 tf.random.set_seed(1234)
 

--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -5,6 +5,7 @@
 import numpy as np
 import tensorflow as tf
 
+tf.get_logger().setLevel('INFO')
 np.random.seed(1793)
 tf.random.set_seed(1793)
 

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import numpy as np
 import tensorflow as tf
 
+tf.get_logger().setLevel('INFO')
 np.random.seed(1234)
 tf.random.set_seed(1234)
 

--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -5,6 +5,7 @@
 import numpy as np
 import tensorflow as tf
 
+tf.get_logger().setLevel('INFO')
 np.random.seed(1793)
 tf.random.set_seed(1793)
 

--- a/docs/notebooks/multi_objective_ehvi.pct.py
+++ b/docs/notebooks/multi_objective_ehvi.pct.py
@@ -27,6 +27,7 @@ from trieste.space import Box
 from trieste.objectives.multi_objectives import VLMOP2
 from trieste.utils.pareto import Pareto, get_reference_point
 
+tf.get_logger().setLevel('INFO')
 np.random.seed(1793)
 tf.random.set_seed(1793)
 

--- a/docs/notebooks/recovering_from_errors.pct.py
+++ b/docs/notebooks/recovering_from_errors.pct.py
@@ -6,6 +6,7 @@ import numpy as np
 import tensorflow as tf
 import random
 
+tf.get_logger().setLevel('INFO')
 np.random.seed(1793)
 tf.random.set_seed(1793)
 random.seed(3)

--- a/docs/notebooks/thompson_sampling.pct.py
+++ b/docs/notebooks/thompson_sampling.pct.py
@@ -6,6 +6,7 @@ import numpy as np
 import tensorflow as tf
 import matplotlib.pyplot as plt
 
+tf.get_logger().setLevel('INFO')
 np.random.seed(1793)
 tf.random.set_seed(1793)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sphinx
+# ping sphinx to 3.5 for now to work around https://github.com/plotly/plotly.js/issues/4563
+# setting mathjax_path in docs/confg.py to https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML
+# SHOULD fix this, but it doesn't seem to quite
+sphinx~=3.5.4
 sphinx-autoapi
 pydata-sphinx-theme
 ipython


### PR DESCRIPTION
This PR should fix the 0.6.0 docs issues:

* remove the superfluous tensorflow logging
* fix the plotly graph issues
* temporarily add a way to redeploy the docs without cutting a new release (a future PR will remove this again)