### PR TITLE
Reduce RAM usage in integration tests

### DIFF
--- a/tests/integration/test_multi_objective_bayesian_optimization.py
+++ b/tests/integration/test_multi_objective_bayesian_optimization.py
@@ -21,6 +21,7 @@ from trieste.acquisition.function import (
     BatchMonteCarloExpectedHypervolumeImprovement,
     ExpectedHypervolumeImprovement,
 )
+from trieste.acquisition.optimizer import generate_continuous_optimizer
 from trieste.acquisition.rule import AcquisitionRule, EfficientGlobalOptimization
 from trieste.bayesian_optimizer import BayesianOptimizer
 from trieste.data import Dataset
@@ -44,17 +45,21 @@ from trieste.utils.pareto import Pareto, get_reference_point
             id="ehvi_vlmop2",
         ),
         pytest.param(
-            10,
+            15,
             EfficientGlobalOptimization(
-                BatchMonteCarloExpectedHypervolumeImprovement().using(OBJECTIVE), num_query_points=2
+                BatchMonteCarloExpectedHypervolumeImprovement(sample_size=500).using(OBJECTIVE),
+                num_query_points=2,
+                optimizer=generate_continuous_optimizer(num_initial_samples=500),
             ),
             -3.44,
             id="qehvi_vlmop2_q_2",
         ),
         pytest.param(
-            5,
+            10,
             EfficientGlobalOptimization(
-                BatchMonteCarloExpectedHypervolumeImprovement().using(OBJECTIVE), num_query_points=4
+                BatchMonteCarloExpectedHypervolumeImprovement(sample_size=250).using(OBJECTIVE),
+                num_query_points=4,
+                optimizer=generate_continuous_optimizer(num_initial_samples=500),
             ),
             -3.2095,
             id="qehvi_vlmop2_q_4",

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -921,7 +921,9 @@ def test_qehvi_builder_raises_for_empty_data() -> None:
     model = QuadraticMeanAndRBFKernel()
 
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        BatchMonteCarloExpectedHypervolumeImprovement().prepare_acquisition_function(dataset, model)
+        BatchMonteCarloExpectedHypervolumeImprovement(sample_size=100).prepare_acquisition_function(
+            dataset, model
+        )
 
 
 @pytest.mark.parametrize("sample_size", [-2, 0])

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -899,7 +899,7 @@ class BatchMonteCarloExpectedHypervolumeImprovement(SingleModelAcquisitionBuilde
     follows :cite:`daulton2020differentiable`
     """
 
-    def __init__(self, sample_size: int = 512, *, jitter: float = DEFAULTS.JITTER):
+    def __init__(self, sample_size: int, *, jitter: float = DEFAULTS.JITTER):
         """
         :param sample_size: The number of samples from model predicted distribution for
             each batch of points.


### PR DESCRIPTION
Our MO integration tests previously had a massive matrix multiplication that required >10GB of RAM. I've now changed some of the parameters in the tests (e.g. num MC samples) to avoid such a large calculation.

The resulting tests will now run on any machine.

We also now force the user to specify the number of MC samples when defining a BatchMonteCarloExpectedHypervolumeImprovement acquisition function, just like we do for BatchMonteCarloExpectedImprovement. This will avoid future similar accidental memory explosions.