### PR TITLE
Decomposition of model-specific optimizer functions

### DIFF
--- a/trieste/models/gpflow/__init__.py
+++ b/trieste/models/gpflow/__init__.py
@@ -21,3 +21,4 @@ from .config import GPflowModelConfig
 from .interface import GPflowPredictor
 from .models import GaussianProcessRegression, SparseVariational, VariationalGaussianProcess
 from .utils import M, assert_data_is_compatible, randomize_hyperparameters, squeeze_hyperparameters
+from .optimizer import _create_loss_function_internal, _create_loss_function_external

--- a/trieste/models/gpflow/__init__.py
+++ b/trieste/models/gpflow/__init__.py
@@ -20,5 +20,5 @@ number of :class:`TrainableProbabilisticModel` wrappers for GPflow-based models.
 from .config import GPflowModelConfig
 from .interface import GPflowPredictor
 from .models import GaussianProcessRegression, SparseVariational, VariationalGaussianProcess
+from .optimizer import _create_loss_function_external, _create_loss_function_internal
 from .utils import M, assert_data_is_compatible, randomize_hyperparameters, squeeze_hyperparameters
-from .optimizer import _create_loss_function_internal, _create_loss_function_external

--- a/trieste/models/gpflow/__init__.py
+++ b/trieste/models/gpflow/__init__.py
@@ -20,5 +20,9 @@ number of :class:`TrainableProbabilisticModel` wrappers for GPflow-based models.
 from .config import GPflowModelConfig
 from .interface import GPflowPredictor
 from .models import GaussianProcessRegression, SparseVariational, VariationalGaussianProcess
-from .optimizer import _create_loss_function_external, _create_loss_function_internal
+from .optimizer import (
+    _create_loss_function_external,
+    _create_loss_function_internal,
+    _create_scipy_optimizer,
+)
 from .utils import M, assert_data_is_compatible, randomize_hyperparameters, squeeze_hyperparameters

--- a/trieste/models/gpflow/optimizer.py
+++ b/trieste/models/gpflow/optimizer.py
@@ -14,11 +14,12 @@
 
 from __future__ import annotations
 
-from gpflow.models import ExternalDataTrainingLossMixin, InternalDataTrainingLossMixin
-import gpflow
-from typing import Dict, Any
+from typing import Any, Dict
 
-from ..optimizer import LossClosure, TrainingData, create_loss_function, create_optimizer, Optimizer
+import gpflow
+from gpflow.models import ExternalDataTrainingLossMixin, InternalDataTrainingLossMixin
+
+from ..optimizer import LossClosure, Optimizer, TrainingData, create_loss_function, create_optimizer
 
 
 @create_optimizer.register

--- a/trieste/models/gpflow/optimizer.py
+++ b/trieste/models/gpflow/optimizer.py
@@ -1,0 +1,47 @@
+# Copyright 2021 The Trieste Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from gpflow.models import ExternalDataTrainingLossMixin, InternalDataTrainingLossMixin
+import gpflow
+from typing import Dict, Any
+
+from ..optimizer import LossClosure, TrainingData, create_loss_function, create_optimizer, Optimizer
+
+
+@create_optimizer.register
+def _create_scipy_optimizer(
+    optimizer: gpflow.optimizers.Scipy,
+    optimizer_args: Dict[str, Any],
+) -> Optimizer:
+    return Optimizer(optimizer, **optimizer_args)
+
+
+@create_loss_function.register
+def _create_loss_function_internal(
+    model: InternalDataTrainingLossMixin,
+    data: TrainingData,
+    compile: bool = False,
+) -> LossClosure:
+    return model.training_loss_closure(compile=compile)
+
+
+@create_loss_function.register
+def _create_loss_function_external(
+    model: ExternalDataTrainingLossMixin,
+    data: TrainingData,
+    compile: bool = False,
+) -> LossClosure:
+    return model.training_loss_closure(data, compile=compile)

--- a/trieste/models/optimizer.py
+++ b/trieste/models/optimizer.py
@@ -162,7 +162,7 @@ def _create_tf_optimizer(
 
 @singledispatch
 def create_loss_function(
-    model: gpflow.models.GPModel, dataset: TrainingData, compile: bool = False
+    model: tf.Module, dataset: TrainingData, compile: bool = False
 ) -> LossClosure:
     """
     Generic function for building a loss function for a specified `model` and `dataset`.

--- a/trieste/models/optimizer.py
+++ b/trieste/models/optimizer.py
@@ -21,7 +21,6 @@ from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
 import gpflow
 import scipy
 import tensorflow as tf
-from gpflow.models import ExternalDataTrainingLossMixin, InternalDataTrainingLossMixin
 
 from ..data import Dataset
 from ..types import TensorType
@@ -161,14 +160,6 @@ def _create_tf_optimizer(
     return TFOptimizer(optimizer, **optimizer_args)
 
 
-@create_optimizer.register
-def _create_scipy_optimizer(
-    optimizer: gpflow.optimizers.Scipy,
-    optimizer_args: Dict[str, Any],
-) -> Optimizer:
-    return Optimizer(optimizer, **optimizer_args)
-
-
 @singledispatch
 def create_loss_function(
     model: gpflow.models.GPModel, dataset: TrainingData, compile: bool = False
@@ -183,21 +174,3 @@ def create_loss_function(
     :return: The loss function.
     """
     raise NotImplementedError(f"Unknown model {model} passed for loss function extraction")
-
-
-@create_loss_function.register
-def _create_loss_function_internal(
-    model: InternalDataTrainingLossMixin,
-    data: TrainingData,
-    compile: bool = False,
-) -> LossClosure:
-    return model.training_loss_closure(compile=compile)
-
-
-@create_loss_function.register
-def _create_loss_function_external(
-    model: ExternalDataTrainingLossMixin,
-    data: TrainingData,
-    compile: bool = False,
-) -> LossClosure:
-    return model.training_loss_closure(data, compile=compile)


### PR DESCRIPTION
Following #272 it would be good to decompose model-specific optimizer functions into their own files corresponding to each model. 