### PR TITLE
Use extend-exclude for flake8 and black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ testpaths = [
 line-length = 100
 target-version = ['py37']
 include = '\.py$'
-exclude = '\.pct.py$'
+extend-exclude = '\.pct.py$'
 
 [tool.isort]
 profile = "black"
@@ -59,7 +59,7 @@ quicktests = "pytest -x --ff -rN -Wignore --ignore-glob=tests/integration/*"
 mypy = "mypy"
 pylint = "pytest --pylint --cache-clear -m pylint -v trieste"
 check_format = "pytest -v --black --flake8 --isort -m 'black or flake8 or isort'"
-format = "black . --extend-exclude .tox && flake8 . && isort ."
+format = "black . && flake8 . && isort ."
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
     types: pip install -r common_build/types/requirements.txt -c common_build/types/constraints.txt
     types: mypy
     format: pip install -r common_build/format/requirements.txt -c common_build/format/constraints.txt
-    format: black --check . --extend-exclude .tox
+    format: black --check .
     format: flake8 --count .
     format: isort --check .
     tests: pip install . -r tests/requirements.txt -c tests/constraints.txt

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ skipsdist = true
 max-line-length = 100
 extend-ignore = E203, W503
 per-file-ignores = __init__.py: F401
-extend-exclude = docs/notebooks/
+extend-exclude = docs/notebooks/,.venv
 
 [testenv]
 basepython = python3.7


### PR DESCRIPTION
This PR makes a bit more extensive use of `extend-exclude` option, pun intended.

I've hit a couple of issues running all format checks because in my dev setup `.venv` lives in the project root. So both tools would validated files inside this `.venv`.

Black by default can respect .gitignore file, which covers .venv, .tox and many more. But if you use `exclude` option, this default behavior is overriden. So for black we simply use `extend-exclude` instead of `exclude`, and then clean up in other places.

flake8 doesn't respect .gitignore at all, but it has sensbile defaults that cover .tox. Thus for flake8 we only need to add `.venv` to the list of excludes, with the same `extend-exclude` option.

While this is wasn't an issue in Trieste development so far, I argue it would very contributor-friendly to support .venv in project root,  as this setup is [quite](https://github.com/python-poetry/poetry/issues/108) [popular](https://github.com/pypa/pipenv/issues/259).