### PR TITLE
Allow empty obs in non-dominated space partition

### DIFF
--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -901,9 +901,7 @@ def test_expected_hypervolume_improvement_matches_monte_carlo(
     )
     _pareto = Pareto(existing_observations)
     ref_pt = get_reference_point(_pareto.front)
-    lb_points, ub_points = prepare_default_non_dominated_partition_bounds(
-        _pareto.front, ref_pt, tf.constant([-math.inf] * ref_pt.shape[-1])
-    )
+    lb_points, ub_points = prepare_default_non_dominated_partition_bounds(ref_pt, _pareto.front)
 
     # calc MC approx EHVI
     splus_valid = tf.reduce_all(
@@ -1009,7 +1007,7 @@ def test_batch_monte_carlo_expected_hypervolume_improvement_can_reproduce_ehvi(
     _model_based_pareto = Pareto(mean)
     _reference_pt = get_reference_point(_model_based_pareto.front)
     _partition_bounds = prepare_default_non_dominated_partition_bounds(
-        _model_based_pareto.front, _reference_pt, tf.constant([-1e10] * _reference_pt.shape[-1])
+        _reference_pt, _model_based_pareto.front
     )
 
     qehvi_builder = BatchMonteCarloExpectedHypervolumeImprovement(sample_size=num_samples_per_point)
@@ -1133,9 +1131,7 @@ def test_batch_monte_carlo_expected_hypervolume_improvement_utility_on_specified
             PseudoBatchReparametrizationSampler(obj_samples),
             sampler_jitter=DEFAULTS.JITTER,
             partition_bounds=prepare_default_non_dominated_partition_bounds(
-                Pareto(pareto_front_obs).front,
-                reference_point,
-                tf.constant([-1e10] * obj_samples.shape[-1], dtype=pareto_front_obs.dtype),
+                reference_point, Pareto(pareto_front_obs).front
             ),
         )(test_input),
         expected_output,

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -866,7 +866,7 @@ class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder):
 
         _pf = Pareto(mean)
         _reference_pt = get_reference_point(_pf.front)
-        _partition_bounds = prepare_default_non_dominated_partition_bounds(_pf.front, _reference_pt)
+        _partition_bounds = prepare_default_non_dominated_partition_bounds(_reference_pt, _pf.front)
         function.update(_partition_bounds)  # type: ignore
         return function
 

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -776,7 +776,7 @@ class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder):
         _reference_pt = get_reference_point(_pf.front)
         # prepare the partitioned bounds of non-dominated region for calculating of the
         # hypervolume improvement in this area
-        _partition_bounds = prepare_default_non_dominated_partition_bounds(_pf.front, _reference_pt)
+        _partition_bounds = prepare_default_non_dominated_partition_bounds(_reference_pt, _pf.front)
         return expected_hv_improvement(model, _partition_bounds)
 
 
@@ -928,7 +928,7 @@ class BatchMonteCarloExpectedHypervolumeImprovement(SingleModelAcquisitionBuilde
         _reference_pt = get_reference_point(_pf.front)
         # prepare the partitioned bounds of non-dominated region for calculating of the
         # hypervolume improvement in this area
-        _partition_bounds = prepare_default_non_dominated_partition_bounds(_pf.front, _reference_pt)
+        _partition_bounds = prepare_default_non_dominated_partition_bounds(_reference_pt, _pf.front)
 
         sampler = BatchReparametrizationSampler(self._sample_size, model)
 
@@ -1053,8 +1053,8 @@ class ExpectedConstrainedHypervolumeImprovement(ExpectedConstrainedImprovement):
         # prepare the partitioned bounds of non-dominated region for calculating of the
         # hypervolume improvement in this area
         _partition_bounds = prepare_default_non_dominated_partition_bounds(
-            _pf.front,
             _reference_pt,
+            _pf.front,
         )
         ehvi = expected_hv_improvement(objective_model, _partition_bounds)
         return lambda at: ehvi(at) * constraint_fn(at)

--- a/trieste/acquisition/multi_objective/pareto.py
+++ b/trieste/acquisition/multi_objective/pareto.py
@@ -65,7 +65,7 @@ class Pareto:
             shape=1, dtype=self.front.dtype
         )
         lower, upper = prepare_default_non_dominated_partition_bounds(
-            self.front, reference, helper_anti_reference
+            reference, self.front, helper_anti_reference
         )
         non_dominated_hypervolume = tf.reduce_sum(tf.reduce_prod(upper - lower, 1))
         hypervolume_indicator = (

--- a/trieste/acquisition/multi_objective/partition.py
+++ b/trieste/acquisition/multi_objective/partition.py
@@ -63,7 +63,7 @@ def prepare_default_non_dominated_partition_bounds(
         tf.debugging.assert_greater_equal(
             ref,
             anti_ref,
-            message="reference point containing dimensionality below default "
+            message=f"reference point: {ref} containing at least one value below default "
             "anti-reference point ([-1e10, ..., -1e10]), try specify a lower "
             "anti-reference point.",
         )
@@ -71,23 +71,24 @@ def prepare_default_non_dominated_partition_bounds(
             tf.debugging.assert_greater_equal(
                 obs,
                 anti_ref,
-                message="observations containing points below default "
+                message=f"observations: {obs} containing at least one value below default "
                 "anti-reference point ([-1e10, ..., -1e10]), try specify a lower "
                 "anti-reference point.",
             )
         return anti_ref
 
     tf.debugging.assert_shapes([(reference, ["D"])])
-    if (  # prepare default anti_reference point if not specified
-        anti_reference is None
-    ):  # if anti_reference point is not specified, use a -1e10 as default (act as -inf)
+    if anti_reference is None:
+        # if anti_reference point is not specified, use a -1e10 as default (act as -inf)
         anti_reference = specify_default_anti_reference_point(reference, observations)
-    else:  # anti_reference point is specified
+    else:
+        # anti_reference point is specified
         tf.debugging.assert_shapes([(anti_reference, ["D"])])
 
     if is_empty_obs(observations):  # if no valid observations
         assert tf.reduce_all(tf.less_equal(anti_reference, reference)), ValueError(
-            "anti_reference point contains at least one value larger than reference point"
+            f"anti_reference point: {anti_reference} contains at least one value larger "
+            f"than reference point: {reference}"
         )
         return tf.expand_dims(anti_reference, 0), tf.expand_dims(reference, 0)
     elif tf.shape(observations)[-1] > 2:

--- a/trieste/acquisition/multi_objective/partition.py
+++ b/trieste/acquisition/multi_objective/partition.py
@@ -38,7 +38,7 @@ def prepare_default_non_dominated_partition_bounds(
 
     :param observations: The observations for all objectives, with shape [N, D], if not specified
         or is an empty Tensor, a single non-dominated partition bounds constructed by reference
-        and anti_reference point.
+        and anti_reference point will be returned.
     :param anti_reference: a worst point to use with shape [D].
         Defines the lower bound of the hypercell. If not specified, will use a default value:
         -[1e10] * D.
@@ -53,10 +53,12 @@ def prepare_default_non_dominated_partition_bounds(
         shape.
     """
 
-    def not_valid_obs(obs: TensorType) -> bool:
+    def not_valid_obs(obs: Optional[TensorType]) -> bool:
         return obs is None or tf.equal(tf.size(observations), 0)
 
-    def specify_default_anti_reference_point(ref: TensorType, obs: TensorType) -> TensorType:
+    def specify_default_anti_reference_point(
+        ref: TensorType, obs: Optional[TensorType]
+    ) -> TensorType:
         anti_ref = -1e10 * tf.ones(shape=(tf.shape(reference)), dtype=reference.dtype)
         tf.debugging.assert_greater_equal(
             ref,
@@ -65,7 +67,7 @@ def prepare_default_non_dominated_partition_bounds(
             "anti-reference point ([-1e10, ..., -1e10]), try specify a lower "
             "anti-reference point.",
         )
-        if not not_valid_obs(obs):
+        if not not_valid_obs(obs):  # make sure given (valid) observations are larger than -1e10
             tf.debugging.assert_greater_equal(
                 obs,
                 anti_ref,
@@ -79,9 +81,8 @@ def prepare_default_non_dominated_partition_bounds(
     if (  # prepare default anti_reference point if not specified
         anti_reference is None
     ):  # if anti_reference point is not specified, use a -1e10 as default (act as -inf)
-        # make sure given observations are larger than -1e10
         anti_reference = specify_default_anti_reference_point(reference, observations)
-    else:  # a anti_reference point is specified
+    else:  # anti_reference point is specified
         tf.debugging.assert_shapes([(anti_reference, ["D"])])
 
     if not_valid_obs(observations):  # if no valid observations

--- a/trieste/acquisition/multi_objective/partition.py
+++ b/trieste/acquisition/multi_objective/partition.py
@@ -53,7 +53,7 @@ def prepare_default_non_dominated_partition_bounds(
         shape.
     """
 
-    def not_valid_obs(obs: Optional[TensorType]) -> bool:
+    def is_empty_obs(obs: Optional[TensorType]) -> bool:
         return obs is None or tf.equal(tf.size(observations), 0)
 
     def specify_default_anti_reference_point(
@@ -67,7 +67,7 @@ def prepare_default_non_dominated_partition_bounds(
             "anti-reference point ([-1e10, ..., -1e10]), try specify a lower "
             "anti-reference point.",
         )
-        if not not_valid_obs(obs):  # make sure given (valid) observations are larger than -1e10
+        if not is_empty_obs(obs):  # make sure given (valid) observations are larger than -1e10
             tf.debugging.assert_greater_equal(
                 obs,
                 anti_ref,
@@ -85,9 +85,9 @@ def prepare_default_non_dominated_partition_bounds(
     else:  # anti_reference point is specified
         tf.debugging.assert_shapes([(anti_reference, ["D"])])
 
-    if not_valid_obs(observations):  # if no valid observations
+    if is_empty_obs(observations):  # if no valid observations
         assert tf.reduce_all(tf.less_equal(anti_reference, reference)), ValueError(
-            "anti_reference points contains dimension bigger than reference point"
+            "anti_reference point contains at least one value larger than reference point"
         )
         return tf.expand_dims(anti_reference, 0), tf.expand_dims(reference, 0)
     elif tf.shape(observations)[-1] > 2:


### PR DESCRIPTION
This is a PR for allowing empty/None observation specified for non-dominated partition. In some cases, there maybe no observations below a specified reference point. In this scenario, this functionality will just return a hyper-cell (bounds) that has been constructed by anti_reference and reference point, driving greedy acquisition function search within this region. 

**Main Modifications**
- change `observations` to optional arg
- change the order of args of `prepare_default_non_dominated_partition_bounds`
- Add return case when `observations` is not specified (or empty)

This PR is the 1st step of tackling #353 (option 1).

**Note**: we leave the responsibility of screening observations below reference point within `prepare_acquisition_function`.

