### PR TITLE
Allow empty Boxes (copied from 0.6.1)

### DIFF
--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -215,8 +215,20 @@ def test_box_raises_if_bounds_have_invalid_shape(
 ) -> None:
     lower, upper = tf.zeros(lower_shape), tf.ones(upper_shape)
 
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        Box(lower, upper)
+    if lower_shape == upper_shape == (0,):
+        Box(lower, upper)  # empty box is ok
+    else:
+        with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+            Box(lower, upper)
+
+
+def test_box___mul___for_empty_search_space() -> None:
+    empty = Box(tf.zeros(0, dtype=tf.float64), tf.zeros(0, dtype=tf.float64))
+    cube = Box([0, 0, 0], [1, 1, 1])
+    npt.assert_array_equal((cube * empty).lower, cube.lower)
+    npt.assert_array_equal((cube * empty).upper, cube.upper)
+    npt.assert_array_equal((empty * cube).lower, cube.lower)
+    npt.assert_array_equal((empty * cube).upper, cube.upper)
 
 
 @pytest.mark.parametrize(

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -191,8 +191,6 @@ class Box(SearchSpace):
         tf.assert_rank(lower, 1)
         tf.assert_rank(upper, 1)
 
-        tf.debugging.assert_positive(len(lower), message="bounds cannot be empty")
-
         if isinstance(lower, Sequence):
             self._lower = tf.constant(lower, dtype=tf.float64)
             self._upper = tf.constant(upper, dtype=tf.float64)


### PR DESCRIPTION
This restriction was removed in 0.6.1 but was never merged back to develop.