### PR TITLE
fixing reference point etc.

### DIFF
--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -1060,7 +1060,7 @@ class ExpectedConstrainedHypervolumeImprovement(ExpectedConstrainedImprovement):
         feasible_mean, _ = objective_model.predict(feasible_query_points)
 
         _pf = Pareto(feasible_mean)
-        _reference_pt = get_reference_point(_pf.front)
+        _reference_pt = get_reference_point(feasible_mean)
         ehvi = expected_hv_improvement(objective_model, _pf, _reference_pt)
         return lambda at: ehvi(at) * constraint_fn(at)
 

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -352,6 +352,7 @@ class BayesianOptimizer(Generic[SP]):
         history: list[Record[S]] = []
 
         for step in range(num_steps):
+            print(step)
             try:
                 if track_state:
                     models_copy = copy.deepcopy(models)


### PR DESCRIPTION
In CEHVI, the reference point is now based on the feasible set of points rather than the optimal ones only.

In the plotting code, a bug is fixed so that the Pareto front excludes infeasible points according to the constraint.