### PR TITLE
Actually using pending points in prepare

### DIFF
--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -91,7 +91,7 @@ class _ArbitrarySingleBuilder(SingleModelAcquisitionBuilder):
 
 
 class _ArbitraryGreedySingleBuilder(SingleModelGreedyAcquisitionBuilder):
-    def prepare_acquisition_function(
+    def update_acquisition_function(
         self, dataset: Dataset, model: ProbabilisticModel, pending_points: TensorType = None
     ) -> AcquisitionFunction:
         return raise_exc
@@ -1329,21 +1329,11 @@ def test_locally_penalized_expected_improvement_builder_raises_for_invalid_pendi
     data = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
     space = Box([0, 0], [1, 1])
     builder = LocalPenalizationAcquisitionFunction(search_space=space)
-    builder.prepare_acquisition_function(
+    lp_acq = builder.prepare_acquisition_function(
         data, QuadraticMeanAndRBFKernel(), None
     )  # first initialize
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.prepare_acquisition_function(data, QuadraticMeanAndRBFKernel(), pending_points)
-
-
-def test_locally_penalized_expected_improvement_raises_when_called_before_initialization() -> None:
-    data = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
-    search_space = Box([0, 0], [1, 1])
-    pending_points = tf.zeros([1, 2])
-    with pytest.raises(tf.errors.InvalidArgumentError):
-        LocalPenalizationAcquisitionFunction(search_space).prepare_acquisition_function(
-            data, QuadraticMeanAndRBFKernel(), pending_points
-        )
+        builder.update_acquisition_function(lp_acq, data, QuadraticMeanAndRBFKernel(), pending_points)
 
 
 @random_seed
@@ -1561,21 +1551,11 @@ def test_gibbon_builder_raises_for_invalid_pending_points_shape(
     data = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
     space = Box([0, 0], [1, 1])
     builder = GIBBON(search_space=space)
-    builder.prepare_acquisition_function(
+    gibbon_acq = builder.prepare_acquisition_function(
         data, QuadraticMeanAndRBFKernel(), None
     )  # first initialize
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.prepare_acquisition_function(data, QuadraticMeanAndRBFKernel(), pending_points)
-
-
-def test_gibbon_raises_when_called_before_initialization() -> None:
-    data = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
-    search_space = Box([0, 0], [1, 1])
-    pending_points = tf.zeros([1, 2])
-    with pytest.raises(tf.errors.InvalidArgumentError):
-        GIBBON(search_space).prepare_acquisition_function(
-            data, QuadraticMeanAndRBFKernel(), pending_points
-        )
+        builder.update_acquisition_function(gibbon_acq, data, QuadraticMeanAndRBFKernel(), pending_points)
 
 
 def test_gibbon_raises_for_model_without_homoscedastic_likelihood() -> None:

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -1333,12 +1333,9 @@ def test_locally_penalized_expected_improvement_builder_raises_for_invalid_pendi
     data = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
     space = Box([0, 0], [1, 1])
     builder = LocalPenalizationAcquisitionFunction(search_space=space)
-    lp_acq = builder.prepare_acquisition_function(
-        data, QuadraticMeanAndRBFKernel(), None
-    )  # first initialize
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.update_acquisition_function(
-            lp_acq, data, QuadraticMeanAndRBFKernel(), pending_points
+        builder.prepare_acquisition_function(
+            data, QuadraticMeanAndRBFKernel(), pending_points
         )
 
 
@@ -1557,12 +1554,9 @@ def test_gibbon_builder_raises_for_invalid_pending_points_shape(
     data = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
     space = Box([0, 0], [1, 1])
     builder = GIBBON(search_space=space)
-    gibbon_acq = builder.prepare_acquisition_function(
-        data, QuadraticMeanAndRBFKernel(), None
-    )  # first initialize
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.update_acquisition_function(
-            gibbon_acq, data, QuadraticMeanAndRBFKernel(), pending_points
+        builder.prepare_acquisition_function(
+            data, QuadraticMeanAndRBFKernel(), pending_points
         )
 
 

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -1334,9 +1334,7 @@ def test_locally_penalized_expected_improvement_builder_raises_for_invalid_pendi
     space = Box([0, 0], [1, 1])
     builder = LocalPenalizationAcquisitionFunction(search_space=space)
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.prepare_acquisition_function(
-            data, QuadraticMeanAndRBFKernel(), pending_points
-        )
+        builder.prepare_acquisition_function(data, QuadraticMeanAndRBFKernel(), pending_points)
 
 
 @random_seed
@@ -1555,9 +1553,7 @@ def test_gibbon_builder_raises_for_invalid_pending_points_shape(
     space = Box([0, 0], [1, 1])
     builder = GIBBON(search_space=space)
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.prepare_acquisition_function(
-            data, QuadraticMeanAndRBFKernel(), pending_points
-        )
+        builder.prepare_acquisition_function(data, QuadraticMeanAndRBFKernel(), pending_points)
 
 
 def test_gibbon_raises_for_model_without_homoscedastic_likelihood() -> None:

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -17,7 +17,7 @@ import itertools
 import math
 import unittest.mock
 from collections.abc import Mapping
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 from unittest.mock import MagicMock
 
 import gpflow
@@ -92,7 +92,11 @@ class _ArbitrarySingleBuilder(SingleModelAcquisitionBuilder):
 
 class _ArbitraryGreedySingleBuilder(SingleModelGreedyAcquisitionBuilder):
     def update_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel, pending_points: TensorType = None
+        self,
+        function: Optional[AcquisitionFunction],
+        dataset: Dataset,
+        model: ProbabilisticModel,
+        pending_points: TensorType = None,
     ) -> AcquisitionFunction:
         return raise_exc
 
@@ -1333,7 +1337,9 @@ def test_locally_penalized_expected_improvement_builder_raises_for_invalid_pendi
         data, QuadraticMeanAndRBFKernel(), None
     )  # first initialize
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.update_acquisition_function(lp_acq, data, QuadraticMeanAndRBFKernel(), pending_points)
+        builder.update_acquisition_function(
+            lp_acq, data, QuadraticMeanAndRBFKernel(), pending_points
+        )
 
 
 @random_seed
@@ -1555,7 +1561,9 @@ def test_gibbon_builder_raises_for_invalid_pending_points_shape(
         data, QuadraticMeanAndRBFKernel(), None
     )  # first initialize
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.update_acquisition_function(gibbon_acq, data, QuadraticMeanAndRBFKernel(), pending_points)
+        builder.update_acquisition_function(
+            gibbon_acq, data, QuadraticMeanAndRBFKernel(), pending_points
+        )
 
 
 def test_gibbon_raises_for_model_without_homoscedastic_likelihood() -> None:

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -207,7 +207,7 @@ class _GreedyBatchModelMinusMeanMaximumSingleBuilder(SingleModelGreedyAcquisitio
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
+        function: Optional[AcquisitionFunction],
         dataset: Dataset,
         model: ProbabilisticModel,
         pending_points: Optional[TensorType] = None,
@@ -232,7 +232,7 @@ def test_greedy_batch_acquisition_rule_acquire() -> None:
 
     query_point = ego.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
     npt.assert_allclose(query_point, [[0.0, 0.0]] * num_query_points, atol=1e-3)
-    assert acq._update_count == 2 * num_query_points - 1
+    assert acq._update_count == 2 * (num_query_points - 1)
 
 
 @pytest.mark.parametrize("datasets", [{}, {"foo": empty_dataset([1], [1])}])

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -1274,7 +1274,7 @@ class GreedyAcquisitionFunctionBuilder(ABC):
     @abstractmethod
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
+        function: Optional[AcquisitionFunction],
         datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
         pending_points: Optional[TensorType] = None,
@@ -1321,7 +1321,7 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
 
             def update_acquisition_function(
                 self,
-                function: AcquisitionFunction,
+                function: Optional[AcquisitionFunction],
                 datasets: Mapping[str, Dataset],
                 models: Mapping[str, ProbabilisticModel],
                 pending_points: Optional[TensorType] = None,
@@ -1353,7 +1353,7 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
     @abstractmethod
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
+        function: Optional[AcquisitionFunction],
         dataset: Dataset,
         model: ProbabilisticModel,
         pending_points: Optional[TensorType] = None,
@@ -1449,13 +1449,13 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
 
         acq = self._update_base_acquisition_function(dataset, model)
         if pending_points is not None:
-            acq = self._update_penalization(None, dataset, model, pending_points)
+            acq = self._update_penalization(acq, dataset, model, pending_points)
 
         return acq
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
+        function: Optional[AcquisitionFunction],
         dataset: Dataset,
         model: ProbabilisticModel,
         pending_points: Optional[TensorType] = None,
@@ -1479,7 +1479,7 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
 
     def _update_penalization(
         self,
-        function: AcquisitionFunction,
+        function: Optional[AcquisitionFunction],
         dataset: Dataset,
         model: ProbabilisticModel,
         pending_points: Optional[TensorType] = None,
@@ -1784,7 +1784,7 @@ class GIBBON(SingleModelGreedyAcquisitionBuilder):
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
+        function: Optional[AcquisitionFunction],
         dataset: Dataset,
         model: ProbabilisticModel,
         pending_points: Optional[TensorType] = None,
@@ -1803,12 +1803,12 @@ class GIBBON(SingleModelGreedyAcquisitionBuilder):
         if pending_points is None:
             # no repulsion term required if no pending_points.
             return self._update_quality_term(dataset, model)
-  
+
         return self._update_repulsion_term(function, dataset, model, pending_points)
 
     def _update_repulsion_term(
         self,
-        function: AcquisitionFunction,
+        function: Optional[AcquisitionFunction],
         dataset: Dataset,
         model: ProbabilisticModel,
         pending_points: Optional[TensorType] = None,

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -1348,7 +1348,7 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
             where M is the number of pending points and D is the search space dimension.
         :return: An acquisition function.
         """
-        return self.update_acquisition_function(None, dataset, model)
+        return self.update_acquisition_function(None, dataset, model, pending_points)
 
     @abstractmethod
     def update_acquisition_function(
@@ -1454,6 +1454,7 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
             self._update_base_acquisition_function(dataset, model)
 
         if pending_points is None or len(pending_points) == 0:
+            # no penalization required if no pending_points
             return self._base_acquisition_function
 
         tf.debugging.assert_rank(pending_points, 2)
@@ -1755,6 +1756,7 @@ class GIBBON(SingleModelGreedyAcquisitionBuilder):
             self._update_quality_term(dataset, model)
 
         if pending_points is None or len(pending_points) == 0:
+            # no diversity term required if no pending_points.
             return cast(AcquisitionFunction, self._quality_term)
 
         tf.debugging.assert_rank(pending_points, 2)

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -184,8 +184,10 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
         :param models: The models of the specified ``datasets``.
         :return: The single (or batch of) points to query.
         """
-        if self._acquisition_function is None \
-           or isinstance(self._builder, GreedyAcquisitionFunctionBuilder):
+        if self._acquisition_function is None or isinstance(
+            self._builder, GreedyAcquisitionFunctionBuilder
+        ):
+            # for greedy batch approaches prepare shall be called to begin collecting the batch
             self._acquisition_function = self._builder.prepare_acquisition_function(
                 datasets, models
             )

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -184,7 +184,8 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
         :param models: The models of the specified ``datasets``.
         :return: The single (or batch of) points to query.
         """
-        if self._acquisition_function is None:
+        if self._acquisition_function is None \
+           or isinstance(self._builder, GreedyAcquisitionFunctionBuilder):
             self._acquisition_function = self._builder.prepare_acquisition_function(
                 datasets, models
             )


### PR DESCRIPTION
This PR is an early prep for async BO.

At the moment pending points are assumed in "prepare", but are not used and in fact validated to be None. Since in async scenarios we would like to pass pending points from outside, this PR ensures pending points are propagated both from "prepare" and "update" functions.