### PR TITLE
Non-greedy async optimization

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -205,3 +205,16 @@
   journal={arXiv preprint arXiv:1905.03350},
   year={2019}
 }
+
+@InProceedings{kandasamy18a,
+  title = {Parallelised Bayesian Optimisation via Thompson Sampling},
+  author = {Kandasamy, Kirthevasan and Krishnamurthy, Akshay and Schneider, Jeff and Poczos, Barnabas},
+  booktitle = {Proceedings of the Twenty-First International Conference on Artificial Intelligence and Statistics},
+  pages = {133--142},
+  year = {2018},
+  editor = {Storkey, Amos and Perez-Cruz, Fernando},
+  volume = {84},
+  series = {Proceedings of Machine Learning Research},
+  publisher = {PMLR},
+  url = {https://proceedings.mlr.press/v84/kandasamy18a.html}
+}

--- a/tests/integration/test_ask_tell_optimization.py
+++ b/tests/integration/test_ask_tell_optimization.py
@@ -27,6 +27,7 @@ from trieste.acquisition.function import LocalPenalizationAcquisitionFunction
 from trieste.acquisition.rule import (
     AcquisitionRule,
     AsynchronousGreedy,
+    AsynchronousRuleState,
     EfficientGlobalOptimization,
     TrustRegion,
 )
@@ -61,7 +62,7 @@ from trieste.types import State, TensorType
                         AcquisitionRule[
                             State[
                                 TensorType,
-                                Union[AsynchronousGreedy.State, TrustRegion.State],
+                                Union[AsynchronousRuleState, TrustRegion.State],
                             ],
                             Box,
                         ],
@@ -102,7 +103,7 @@ def test_ask_tell_optimization_finds_minima_of_the_scaled_branin_function(
     acquisition_rule_fn: Callable[[], AcquisitionRule[TensorType, SearchSpace]]
     | Callable[
         [],
-        AcquisitionRule[State[TensorType, AsynchronousGreedy.State | TrustRegion.State], Box],
+        AcquisitionRule[State[TensorType, AsynchronousRuleState | TrustRegion.State], Box],
     ],
 ) -> None:
     # For the case when optimization state is saved and reload on each iteration
@@ -141,7 +142,7 @@ def test_ask_tell_optimization_finds_minima_of_the_scaled_branin_function(
 
         if reload_state:
             state: Record[
-                None | State[TensorType, AsynchronousGreedy.State | TrustRegion.State]
+                None | State[TensorType, AsynchronousRuleState | TrustRegion.State]
             ] = ask_tell.to_record()
             written_state = pickle.dumps(state)
 
@@ -154,7 +155,7 @@ def test_ask_tell_optimization_finds_minima_of_the_scaled_branin_function(
         ask_tell.tell(new_data_point)
 
     result: OptimizationResult[
-        None | State[TensorType, AsynchronousGreedy.State | TrustRegion.State]
+        None | State[TensorType, AsynchronousRuleState | TrustRegion.State]
     ] = ask_tell.to_result()
     dataset = result.try_get_final_dataset()
 

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -34,6 +34,8 @@ from trieste.acquisition.function import (
 from trieste.acquisition.rule import (
     AcquisitionRule,
     AsynchronousGreedy,
+    AsynchronousOptimization,
+    AsynchronousRuleState,
     DiscreteThompsonSampling,
     EfficientGlobalOptimization,
     TrustRegion,
@@ -70,7 +72,7 @@ from trieste.types import State, TensorType
                     AcquisitionRule[
                         State[
                             TensorType,
-                            Union[AsynchronousGreedy.State, TrustRegion.State],
+                            Union[AsynchronousRuleState, TrustRegion.State],
                         ],
                         Box,
                     ],
@@ -95,6 +97,7 @@ from trieste.types import State, TensorType
                     num_query_points=3,
                 ),
             ),
+            (36, AsynchronousOptimization()),
             (
                 10,
                 EfficientGlobalOptimization(
@@ -140,7 +143,7 @@ from trieste.types import State, TensorType
 def test_optimizer_finds_minima_of_the_scaled_branin_function(
     num_steps: int,
     acquisition_rule: AcquisitionRule[TensorType, SearchSpace]
-    | AcquisitionRule[State[TensorType, AsynchronousGreedy.State | TrustRegion.State], Box],
+    | AcquisitionRule[State[TensorType, AsynchronousRuleState | TrustRegion.State], Box],
 ) -> None:
     search_space = BRANIN_SEARCH_SPACE
 

--- a/tests/integration/test_multi_objective_bayesian_optimization.py
+++ b/tests/integration/test_multi_objective_bayesian_optimization.py
@@ -23,7 +23,11 @@ from trieste.acquisition.function import (
 )
 from trieste.acquisition.multi_objective.pareto import Pareto, get_reference_point
 from trieste.acquisition.optimizer import generate_continuous_optimizer
-from trieste.acquisition.rule import AcquisitionRule, EfficientGlobalOptimization
+from trieste.acquisition.rule import (
+    AcquisitionRule,
+    AsynchronousOptimization,
+    EfficientGlobalOptimization,
+)
 from trieste.bayesian_optimizer import BayesianOptimizer
 from trieste.data import Dataset
 from trieste.models.gpflow import GaussianProcessRegression
@@ -60,6 +64,15 @@ from trieste.types import TensorType
             EfficientGlobalOptimization(
                 BatchMonteCarloExpectedHypervolumeImprovement(sample_size=250).using(OBJECTIVE),
                 num_query_points=4,
+                optimizer=generate_continuous_optimizer(num_initial_samples=500),
+            ),
+            -3.2095,
+            id="qehvi_vlmop2_q_4",
+        ),
+        pytest.param(
+            40,
+            AsynchronousOptimization(
+                BatchMonteCarloExpectedHypervolumeImprovement(sample_size=250).using(OBJECTIVE),
                 optimizer=generate_continuous_optimizer(num_initial_samples=500),
             ),
             -3.2095,

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -528,11 +528,18 @@ def test_trust_region_state_deepcopy() -> None:
 
 
 def test_asynchronous_rule_state_pending_points() -> None:
-    pending_points = tf.constant([1, 2, 3])
+    pending_points = tf.constant([[1], [2], [3]])
 
     state = AsynchronousRuleState(pending_points)
-
     npt.assert_array_equal(pending_points, state.pending_points)
+
+
+def test_asynchronous_rule_state_raises_incorrect_shape() -> None:
+    with pytest.raises(ValueError):
+        AsynchronousRuleState(tf.constant([1, 2]))
+
+    with pytest.raises(ValueError):
+        AsynchronousRuleState(tf.constant([[[1], [2]]]))
 
 
 def test_asynchronous_rule_state_has_pending_points() -> None:
@@ -555,6 +562,10 @@ def test_asynchronous_rule_subtract_points_raises_shape_mismatch() -> None:
     state = AsynchronousRuleState(tf.constant([[1, 1], [2, 2]]))
     with pytest.raises(ValueError):
         state.subtract_points(tf.constant([[1]]))
+
+    state = AsynchronousRuleState(tf.constant([[1, 1], [2, 2]]))
+    with pytest.raises(ValueError):
+        state.subtract_points(tf.constant([[[1, 1], [2, 2]]]))
 
 
 def test_asynchronous_rule_subtract_points() -> None:
@@ -589,6 +600,10 @@ def test_asynchronous_rule_add_points_raises_shape_mismatch() -> None:
     state = AsynchronousRuleState(tf.constant([[1, 1], [2, 2]]))
     with pytest.raises(ValueError):
         state.add_points(tf.constant([[1]]))
+
+    state = AsynchronousRuleState(tf.constant([[1, 1], [2, 2]]))
+    with pytest.raises(ValueError):
+        state.add_points(tf.constant([[[1, 1], [2, 2]]]))
 
 
 def test_asynchronous_rule_add_points() -> None:

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -35,6 +35,8 @@ from trieste.acquisition.optimizer import AcquisitionOptimizer
 from trieste.acquisition.rule import (
     AcquisitionRule,
     AsynchronousGreedy,
+    AsynchronousOptimization,
+    AsynchronousRuleState,
     DiscreteThompsonSampling,
     EfficientGlobalOptimization,
     TrustRegion,
@@ -175,16 +177,39 @@ class _JointBatchModelMinusMeanMaximumSingleBuilder(AcquisitionFunctionBuilder):
 
 
 @random_seed
-def test_joint_batch_acquisition_rule_acquire() -> None:
+@pytest.mark.parametrize(
+    "rule_fn, num_query_points",
+    [
+        (lambda acq: EfficientGlobalOptimization(acq, num_query_points=4), 4),
+        (lambda acq: AsynchronousOptimization(acq), 1),
+    ],
+)
+# As a side effect, this test ensures and EGO and AsynchronousOptimization
+# behave similarly in sync mode
+def test_joint_batch_acquisition_rule_acquire(
+    rule_fn: Callable[
+        # callable input type(s)
+        [_JointBatchModelMinusMeanMaximumSingleBuilder],
+        # callable output type
+        AcquisitionRule[TensorType, Box]
+        | AcquisitionRule[State[TensorType, AsynchronousRuleState], Box],
+    ],
+    num_query_points: int,
+) -> None:
     search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
-    num_query_points = 4
     acq = _JointBatchModelMinusMeanMaximumSingleBuilder()
-    ego: EfficientGlobalOptimization[Box] = EfficientGlobalOptimization(
-        acq, num_query_points=num_query_points
-    )
-    dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
-    query_point = ego.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
+    acq_rule: AcquisitionRule[TensorType, Box] | AcquisitionRule[
+        State[TensorType, AsynchronousRuleState], Box
+    ] = rule_fn(acq)
 
+    dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
+    points_or_stateful = acq_rule.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
+    if callable(points_or_stateful):
+        _, query_point = points_or_stateful(None)
+    else:
+        query_point = points_or_stateful
+
+    print(query_point)
     npt.assert_allclose(query_point, [[0.0, 0.0]] * num_query_points, atol=1e-3)
 
 
@@ -234,7 +259,7 @@ def test_greedy_batch_acquisition_rule_acquire(
         [_GreedyBatchModelMinusMeanMaximumSingleBuilder],
         # callable output type
         AcquisitionRule[TensorType, Box]
-        | AcquisitionRule[State[TensorType, AsynchronousGreedy.State], Box],
+        | AcquisitionRule[State[TensorType, AsynchronousRuleState], Box],
     ],
     num_query_points: int,
 ) -> None:
@@ -242,7 +267,7 @@ def test_greedy_batch_acquisition_rule_acquire(
     acq = _GreedyBatchModelMinusMeanMaximumSingleBuilder()
     assert acq._update_count == 0
     acq_rule: AcquisitionRule[TensorType, Box] | AcquisitionRule[
-        State[TensorType, AsynchronousGreedy.State], Box
+        State[TensorType, AsynchronousRuleState], Box
     ] = rule_fn(acq)
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
     points_or_stateful = acq_rule.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
@@ -262,7 +287,7 @@ def test_greedy_batch_acquisition_rule_acquire(
     assert acq._update_count == 2 * num_query_points - 1
 
 
-def test_async_ego_raises_for_non_greedy_function() -> None:
+def test_async_greedy_raises_for_non_greedy_function() -> None:
     non_greedy_function_builder = NegativeLowerConfidenceBound()
     with pytest.raises(NotImplementedError):
         # we are deliberately passing in wrong object
@@ -270,10 +295,18 @@ def test_async_ego_raises_for_non_greedy_function() -> None:
         AsynchronousGreedy(non_greedy_function_builder)  # type: ignore
 
 
-def test_async_ego_keeps_track_of_pending_points() -> None:
+@random_seed
+@pytest.mark.parametrize(
+    "async_rule",
+    [
+        AsynchronousOptimization(_JointBatchModelMinusMeanMaximumSingleBuilder()),
+        AsynchronousGreedy(_GreedyBatchModelMinusMeanMaximumSingleBuilder()),
+    ],
+)
+def test_async_keeps_track_of_pending_points(
+    async_rule: AcquisitionRule[State[TensorType, AsynchronousRuleState], Box]
+) -> None:
     search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
-    acq = _GreedyBatchModelMinusMeanMaximumSingleBuilder()
-    async_rule: AsynchronousGreedy[Box] = AsynchronousGreedy(acq)
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
 
     state_fn = async_rule.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
@@ -283,7 +316,7 @@ def test_async_ego_keeps_track_of_pending_points() -> None:
     assert state is not None
     assert len(state.pending_points) == 2
 
-    # let's pretend we saw observations for the first point
+    # pretend we saw observation for the first point
     new_observations = Dataset(
         query_points=point1,
         observations=tf.constant([[1]], dtype=tf.float32),
@@ -295,7 +328,9 @@ def test_async_ego_keeps_track_of_pending_points() -> None:
 
     assert state is not None
     assert len(state.pending_points) == 2
-    # two points from the first batch and all points from second
+
+    # we saw first point, so pendings points are
+    # second point and new third point
     npt.assert_allclose(state.pending_points, tf.concat([point2, point3], axis=0))
 
 
@@ -490,3 +525,81 @@ def test_trust_region_state_deepcopy() -> None:
     npt.assert_allclose(tr_state_copy.eps, tr_state.eps)
     npt.assert_allclose(tr_state_copy.y_min, tr_state.y_min)
     assert tr_state_copy.is_global == tr_state.is_global
+
+
+def test_asynchronous_rule_state_pending_points() -> None:
+    pending_points = tf.constant([1, 2, 3])
+
+    state = AsynchronousRuleState(pending_points)
+
+    npt.assert_array_equal(pending_points, state.pending_points)
+
+
+def test_asynchronous_rule_state_has_pending_points() -> None:
+    state = AsynchronousRuleState(None)
+    assert not state.has_pending_points
+
+    state = AsynchronousRuleState(tf.zeros([0, 2]))
+    assert not state.has_pending_points
+
+    pending_points = tf.constant([[1], [2], [3]])
+    state = AsynchronousRuleState(pending_points)
+    assert state.has_pending_points
+
+
+def test_asynchronous_rule_subtract_points_raises_shape_mismatch() -> None:
+    state = AsynchronousRuleState(tf.constant([[1], [2], [3]]))
+    with pytest.raises(ValueError):
+        state.subtract_points(tf.constant([[1, 1]]))
+
+    state = AsynchronousRuleState(tf.constant([[1, 1], [2, 2]]))
+    with pytest.raises(ValueError):
+        state.subtract_points(tf.constant([[1]]))
+
+
+def test_asynchronous_rule_subtract_points() -> None:
+    pending_points = tf.constant([[1], [2], [3]])
+
+    state = AsynchronousRuleState(pending_points)
+    state = state.subtract_points(tf.constant([[1], [2], [3]]))
+    assert not state.has_pending_points
+
+    state = AsynchronousRuleState(pending_points)
+    state = state.subtract_points(tf.constant([[3], [1], [2]]))
+    assert not state.has_pending_points
+
+    state = AsynchronousRuleState(pending_points)
+    state = state.subtract_points(tf.constant([[4], [5], [6]]))
+    npt.assert_array_equal(state.pending_points, [[1], [2], [3]])
+
+    state = AsynchronousRuleState(pending_points)
+    state = state.subtract_points(tf.constant([[1]]))
+    npt.assert_array_equal(state.pending_points, [[2], [3]])
+
+    state = AsynchronousRuleState(tf.constant([[1, 1], [2, 2], [3, 3]]))
+    state = state.subtract_points(tf.constant([[1, 1], [3, 2]]))
+    npt.assert_array_equal(state.pending_points, [[2, 2], [3, 3]])
+
+
+def test_asynchronous_rule_add_points_raises_shape_mismatch() -> None:
+    state = AsynchronousRuleState(tf.constant([[1], [2], [3]]))
+    with pytest.raises(ValueError):
+        state.add_points(tf.constant([[1, 1]]))
+
+    state = AsynchronousRuleState(tf.constant([[1, 1], [2, 2]]))
+    with pytest.raises(ValueError):
+        state.add_points(tf.constant([[1]]))
+
+
+def test_asynchronous_rule_add_points() -> None:
+    state = AsynchronousRuleState(None)
+    state = state.add_points(tf.constant([[1]]))
+    npt.assert_array_equal(state.pending_points, [[1]])
+
+    state = AsynchronousRuleState(tf.constant([[1], [2]]))
+    state = state.add_points(tf.constant([[1]]))
+    npt.assert_array_equal(state.pending_points, [[1], [2], [1]])
+
+    state = AsynchronousRuleState(tf.constant([[1, 1], [2, 2]]))
+    state = state.add_points(tf.constant([[3, 3], [4, 4]]))
+    npt.assert_array_equal(state.pending_points, [[1, 1], [2, 2], [3, 3], [4, 4]])

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -368,6 +368,7 @@ class AsynchronousOptimization(
 
             if state.has_pending_points:
                 pending_points: TensorType = state.pending_points
+
                 def function_with_pending_points(x: TensorType) -> TensorType:
                     # stuff below is quite tricky, and thus deserves an elaborate comment
                     # we receive unknown number N of points to evaluate

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -218,7 +218,7 @@ class AsynchronousRuleState:
     These are points which were requested but are not observed yet.
     """
 
-    pending_points: TensorType
+    pending_points: Optional[TensorType] = None
 
     def __post_init__(self) -> None:
         if self.pending_points is None:
@@ -420,10 +420,9 @@ class AsynchronousOptimization(
                     all_points = tf.concat([pending_points_repeated, x], axis=1)
                     return cast(AcquisitionFunction, self._acquisition_function)(all_points)
 
-                acquisition_function = function_with_pending_points
+                acquisition_function = cast(AcquisitionFunction, function_with_pending_points)
             else:
-                # mypy gets confused about types of these functions
-                acquisition_function = self._acquisition_function  # type: ignore
+                acquisition_function = cast(AcquisitionFunction, self._acquisition_function)
 
             new_point = self._optimizer(search_space, acquisition_function)
             state = state.add_pending_points(new_point)


### PR DESCRIPTION
This PR contains implementation for a second rule for async optimization, conveniently named AsynchronousOptimization. This isn't expected to be high-performant (and we warn users in docs about it), but it gives access to non-greedy batch functions in async mode.

Although not a part of the PR, new rule was verified to run in the async notebook in addition to all tests.

Plus there is a bit of a clean up for blunders I made in #366 .