### PR TITLE
Added batch size to async rules

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -96,7 +96,7 @@ from trieste.types import State, TensorType
                     num_query_points=3,
                 ),
             ),
-            (36, AsynchronousOptimization()),
+            (12, AsynchronousOptimization(num_query_points=3)),
             (
                 10,
                 EfficientGlobalOptimization(
@@ -107,11 +107,12 @@ from trieste.types import State, TensorType
                 ),
             ),
             (
-                30,
+                10,
                 AsynchronousGreedy(
                     LocalPenalizationAcquisitionFunction(
                         BRANIN_SEARCH_SPACE,
                     ).using(OBJECTIVE),
+                    num_query_points=3,
                 ),
             ),
             (

--- a/tests/integration/test_multi_objective_bayesian_optimization.py
+++ b/tests/integration/test_multi_objective_bayesian_optimization.py
@@ -70,9 +70,10 @@ from trieste.types import TensorType
             id="qehvi_vlmop2_q_4",
         ),
         pytest.param(
-            40,
+            10,
             AsynchronousOptimization(
                 BatchMonteCarloExpectedHypervolumeImprovement(sample_size=250).using(OBJECTIVE),
+                num_query_points=4,
                 optimizer=generate_continuous_optimizer(num_initial_samples=500),
             ),
             -3.2095,

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -316,9 +316,10 @@ class AsynchronousOptimization(
     For example, it would work with
     :class:`~trieste.acquisition.BatchMonteCarloExpectedImprovement`,
     but cannot be used with :class:`~trieste.acquisition.ExpectedImprovement`.
-    If there are P pending points, the acquisition function is used with batch size P+1.
+    If there are P pending points and the batch of size B is requested,
+    the acquisition function is used with batch size P+B.
     During optimization first P points are fixed to pending, and thus optimization
-    is done over the last point only, which is then returned.
+    is done over the last B points only, which are then returned.
 
     `Warning`: it is not clear how efficient this approach towards asynchronous BO is.
     If you require efficiency, consider using :class:`AsynchronousGreedy`.
@@ -452,7 +453,8 @@ class AsynchronousGreedy(
     asynchronous BO, see documentation for :class:`~trieste.acquisition.AsynchronousOptimization`.
 
     AsynchronousGreedy rule works with greedy batch acquisition functions,
-    and effectively does one step of greedy batch collection process.
+    and effectively does B steps of greedy batch collection process,
+    where B is the requested batch size.
     """
 
     def __init__(

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -420,9 +420,9 @@ class AsynchronousOptimization(
                     # we receive unknown number N of points to evaluate
                     # and need to collect batch of B new points
                     # so the shape of `x` is [N, B, D]
-                    # we want to add P pending points to each point
-                    # so that acquisition actually receives N batches of size [P+B, D] each
-                    # therefore here we prepend each point with all pending points
+                    # we want to add P pending points to each batch
+                    # so that acquisition actually receives N batches of shape [P+B, D] each
+                    # therefore here we prepend each batch with all pending points
                     # resulting a shape [N, P+B, D]
                     # we do that by repeating pending points N times and concatenating with x
 

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -318,11 +318,8 @@ class AsynchronousOptimization(
     but cannot be used with :class:`~trieste.acquisition.ExpectedImprovement`.
     If there are P pending points and the batch of size B is requested,
     the acquisition function is used with batch size P+B.
-    During optimization first P points are fixed to pending, and thus optimization
-    is done over the last B points only, which are then returned.
-
-    `Warning`: it is not clear how efficient this approach towards asynchronous BO is.
-    If you require efficiency, consider using :class:`AsynchronousGreedy`.
+    During optimization first P points are fixed to pending,
+    and thus we optimize and return the last B points only.
     """
 
     def __init__(
@@ -418,7 +415,7 @@ class AsynchronousOptimization(
 
                 def function_with_pending_points(x: TensorType) -> TensorType:
                     # stuff below is quite tricky, and thus deserves an elaborate comment
-                    # we receive unknown number N of points to evaluate
+                    # we receive unknown number N of batches to evaluate
                     # and need to collect batch of B new points
                     # so the shape of `x` is [N, B, D]
                     # we want to add P pending points to each batch
@@ -452,8 +449,8 @@ class AsynchronousGreedy(
     is designed for asynchronous BO scenarios. To see what we understand by
     asynchronous BO, see documentation for :class:`~trieste.acquisition.AsynchronousOptimization`.
 
-    AsynchronousGreedy rule works with greedy batch acquisition functions,
-    and effectively does B steps of greedy batch collection process,
+    AsynchronousGreedy rule works with greedy batch acquisition functions
+    and performs B steps of a greedy batch collection process,
     where B is the requested batch size.
     """
 


### PR DESCRIPTION
Due to popular demand both asynchronous acquisition rules now support variable batch sizes.