### PR TITLE
Uri/optional datasets

### DIFF
--- a/docs/notebooks/batch_optimization.pct.py
+++ b/docs/notebooks/batch_optimization.pct.py
@@ -121,7 +121,7 @@ from trieste.acquisition import ExpectedImprovement
 
 # plot standard EI acquisition function
 ei = ExpectedImprovement()
-ei_acq_function = ei.prepare_acquisition_function(initial_data, model)
+ei_acq_function = ei.prepare_acquisition_function(model, dataset=initial_data)
 plot_acq_function_2d(ei_acq_function, [0, 0], [1, 1], contour=True, grid_density=100)
 
 plt.scatter(

--- a/docs/notebooks/batch_optimization.pct.py
+++ b/docs/notebooks/batch_optimization.pct.py
@@ -87,7 +87,7 @@ from trieste.acquisition.rule import EfficientGlobalOptimization
 batch_ei_acq = BatchMonteCarloExpectedImprovement(sample_size=1000, jitter=1e-5)
 batch_ei_acq_rule = EfficientGlobalOptimization(  # type: ignore
     num_query_points=10, builder=batch_ei_acq)
-points_chosen_by_batch_ei = batch_ei_acq_rule.acquire_single(search_space, initial_data, model)
+points_chosen_by_batch_ei = batch_ei_acq_rule.acquire_single(search_space, model, dataset=initial_data)
 
 # %% [markdown]
 # then we do the same with `LocalPenalizationAcquisitionFunction` ...
@@ -99,7 +99,7 @@ local_penalization_acq = LocalPenalizationAcquisitionFunction(search_space, num_
 local_penalization_acq_rule = EfficientGlobalOptimization(  # type: ignore
     num_query_points=10, builder=local_penalization_acq)
 points_chosen_by_local_penalization = local_penalization_acq_rule.acquire_single(
-    search_space, initial_data, model)
+    search_space, model, dataset=initial_data)
 
 # %% [markdown]
 # and finally we use `GIBBON`.
@@ -111,7 +111,7 @@ gibbon_acq = GIBBON(search_space, grid_size = 2000)
 gibbon_acq_rule = EfficientGlobalOptimization(  # type: ignore
     num_query_points=10, builder=gibbon_acq)
 points_chosen_by_gibbon = gibbon_acq_rule.acquire_single(
-    search_space, initial_data, model)
+    search_space, model, dataset=initial_data)
 
 # %% [markdown]
 # We can now visualize the batch of 10 points chosen by each of these methods overlayed on the standard `ExpectedImprovement` acquisition function. `BatchMonteCarloExpectedImprovement` chooses a more diverse set of points, whereas `LocalPenalizationAcquisitionFunction` and `GIBBON` focus evaluations in the most promising areas of the space.

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -151,7 +151,7 @@ from trieste.acquisition import (
 )
 
 class ProbabilityOfValidity(SingleModelAcquisitionBuilder):
-    def prepare_acquisition_function(self, dataset, model):
+    def prepare_acquisition_function(self, model, dataset = None):
         def acquisition(at):
             mean, _ = model.predict_y(tf.squeeze(at, -2))
             return mean

--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -167,7 +167,7 @@ class BatchExpectedConstrainedImprovement(
         self._sample_size = sample_size
         self._threshold = threshold
 
-    def prepare_acquisition_function(self, datasets, models):
+    def prepare_acquisition_function(self, models, datasets):
         objective_model = models[OBJECTIVE]
         objective_dataset = datasets[OBJECTIVE]
 

--- a/tests/unit/acquisition/test_combination.py
+++ b/tests/unit/acquisition/test_combination.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from typing import Optional
 
 import numpy.testing as npt
 import pytest
@@ -52,7 +53,9 @@ def test_reducer__repr_builders() -> None:
             return f"Builder({self._name!r})"
 
         def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            self,
+            models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> AcquisitionFunction:
             return raise_exc
 
@@ -65,7 +68,9 @@ class _Static(AcquisitionFunctionBuilder):
         self._f = f
 
     def prepare_acquisition_function(
-        self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+        self,
+        models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         return self._f
 
@@ -77,7 +82,7 @@ def test_reducer__reduce() -> None:
 
     mean = Mean(_Static(lambda x: -2.0 * x), _Static(lambda x: 3.0 * x))
     data, models = {"": empty_dataset([1], [1])}, {"": QuadraticMeanAndRBFKernel()}
-    acq = mean.prepare_acquisition_function(data, models)
+    acq = mean.prepare_acquisition_function(models, datasets=data)
     xs = tf.random.uniform([3, 5, 1], minval=-1.0)
     npt.assert_allclose(acq(xs), 0.5 * xs)
 
@@ -85,7 +90,7 @@ def test_reducer__reduce() -> None:
 def test_sum() -> None:
     sum_ = Sum(_Static(lambda x: x), _Static(lambda x: x ** 2), _Static(lambda x: x ** 3))
     data, models = {"": empty_dataset([1], [1])}, {"": QuadraticMeanAndRBFKernel()}
-    acq = sum_.prepare_acquisition_function(data, models)
+    acq = sum_.prepare_acquisition_function(models, datasets=data)
     xs = tf.random.uniform([3, 5, 1], minval=-1.0)
     npt.assert_allclose(acq(xs), xs + xs ** 2 + xs ** 3)
 
@@ -93,7 +98,7 @@ def test_sum() -> None:
 def test_product() -> None:
     prod = Product(_Static(lambda x: x + 1), _Static(lambda x: x + 2))
     data, models = {"": empty_dataset([1], [1])}, {"": QuadraticMeanAndRBFKernel()}
-    acq = prod.prepare_acquisition_function(data, models)
+    acq = prod.prepare_acquisition_function(models, datasets=data)
     xs = tf.random.uniform([3, 5, 1], minval=-1.0, dtype=tf.float64)
     npt.assert_allclose(acq(xs), (xs + 1) * (xs + 2))
 
@@ -101,6 +106,8 @@ def test_product() -> None:
 @pytest.mark.parametrize("reducer_class", [Sum, Product])
 def test_sum_and_product_for_single_builder(reducer_class: type[Sum | Product]) -> None:
     data, models = {"": empty_dataset([1], [1])}, {"": QuadraticMeanAndRBFKernel()}
-    acq = reducer_class(_Static(lambda x: x ** 2)).prepare_acquisition_function(data, models)
+    acq = reducer_class(_Static(lambda x: x ** 2)).prepare_acquisition_function(
+        models, datasets=data
+    )
     xs = tf.random.uniform([3, 5, 1], minval=-1.0)
     npt.assert_allclose(acq(xs), xs ** 2)

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -505,10 +505,7 @@ def test_min_value_entropy_search_chooses_same_as_probability_of_improvement() -
 def test_negative_lower_confidence_bound_builder_builds_negative_lower_confidence_bound() -> None:
     model = QuadraticMeanAndRBFKernel()
     beta = 1.96
-    acq_fn = NegativeLowerConfidenceBound(beta).prepare_acquisition_function(
-        model,
-        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
-    )
+    acq_fn = NegativeLowerConfidenceBound(beta).prepare_acquisition_function(model)
     query_at = tf.linspace([[-10]], [[10]], 100)
     expected = -lower_confidence_bound(model, beta)(query_at)
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
@@ -518,21 +515,14 @@ def test_negative_lower_confidence_bound_builder_updates_without_retracing() -> 
     model = QuadraticMeanAndRBFKernel()
     beta = 1.96
     builder = NegativeLowerConfidenceBound(beta)
-    acq_fn = builder.prepare_acquisition_function(
-        model,
-        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
-    )
+    acq_fn = builder.prepare_acquisition_function(model)
     assert acq_fn._get_tracing_count() == 0  # type: ignore
     query_at = tf.linspace([[-10]], [[10]], 100)
     expected = -lower_confidence_bound(model, beta)(query_at)
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
     assert acq_fn._get_tracing_count() == 1  # type: ignore
 
-    up_acq_fn = builder.update_acquisition_function(
-        acq_fn,
-        model,
-        dataset=Dataset(tf.ones([0, 1]), tf.ones([0, 1])),
-    )
+    up_acq_fn = builder.update_acquisition_function(acq_fn, model)
     assert up_acq_fn == acq_fn
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
     assert acq_fn._get_tracing_count() == 1  # type: ignore
@@ -584,7 +574,7 @@ def test_probability_of_feasibility(threshold: float, at: tf.Tensor, expected: f
 @pytest.mark.parametrize("threshold", [-2.3, 0.2])
 def test_probability_of_feasibility_builder_builds_pof(threshold: float, at: tf.Tensor) -> None:
     builder = ProbabilityOfFeasibility(threshold)
-    acq = builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), empty_dataset([1], [1]))
+    acq = builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel())
     expected = probability_of_feasibility(QuadraticMeanAndRBFKernel(), threshold)(at)
 
     npt.assert_allclose(acq(at), expected)
@@ -622,11 +612,11 @@ def test_probability_of_feasibility_builder_updates_without_retracing(
     builder = ProbabilityOfFeasibility(threshold)
     model = QuadraticMeanAndRBFKernel()
     expected = probability_of_feasibility(QuadraticMeanAndRBFKernel(), threshold)(at)
-    acq = builder.prepare_acquisition_function(model, dataset=empty_dataset([1], [1]))
+    acq = builder.prepare_acquisition_function(model)
     assert acq._get_tracing_count() == 0  # type: ignore
     npt.assert_allclose(acq(at), expected)
     assert acq._get_tracing_count() == 1  # type: ignore
-    up_acq = builder.update_acquisition_function(acq, model, dataset=empty_dataset([2], [2]))
+    up_acq = builder.update_acquisition_function(acq, model)
     assert up_acq == acq
     npt.assert_allclose(acq(at), expected)
     assert acq._get_tracing_count() == 1  # type: ignore
@@ -1818,10 +1808,7 @@ def test_echvi_is_constraint_when_no_feasible_points() -> None:
 
 def test_predictive_variance_builder_builds_predictive_variance() -> None:
     model = QuadraticMeanAndRBFKernel()
-    acq_fn = PredictiveVariance().prepare_acquisition_function(
-        model,
-        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
-    )
+    acq_fn = PredictiveVariance().prepare_acquisition_function(model)
     query_at = tf.linspace([[-10]], [[10]], 100)
     _, covariance = model.predict_joint(query_at)
     expected = tf.linalg.det(covariance)
@@ -1841,10 +1828,7 @@ def test_predictive_variance_returns_correct_shape(
     at: TensorType, acquisition_shape: TensorType
 ) -> None:
     model = QuadraticMeanAndRBFKernel()
-    acq_fn = PredictiveVariance().prepare_acquisition_function(
-        model,
-        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
-    )
+    acq_fn = PredictiveVariance().prepare_acquisition_function(model)
     npt.assert_array_equal(acq_fn(at).shape, acquisition_shape)
 
 
@@ -1886,21 +1870,14 @@ def test_predictive_variance(
 def test_predictive_variance_builder_updates_without_retracing() -> None:
     model = QuadraticMeanAndRBFKernel()
     builder = PredictiveVariance()
-    acq_fn = builder.prepare_acquisition_function(
-        model,
-        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
-    )
+    acq_fn = builder.prepare_acquisition_function(model)
     assert acq_fn._get_tracing_count() == 0  # type: ignore
     query_at = tf.linspace([[-10]], [[10]], 100)
     expected = predictive_variance(model, DEFAULTS.JITTER)(query_at)
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
     assert acq_fn._get_tracing_count() == 1  # type: ignore
 
-    up_acq_fn = builder.update_acquisition_function(
-        acq_fn,
-        model,
-        dataset=Dataset(tf.ones([0, 1]), tf.ones([0, 1])),
-    )
+    up_acq_fn = builder.update_acquisition_function(acq_fn, model)
     assert up_acq_fn == acq_fn
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
     assert acq_fn._get_tracing_count() == 1  # type: ignore

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -17,7 +17,7 @@ import itertools
 import math
 import unittest.mock
 from collections.abc import Mapping
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 from unittest.mock import MagicMock
 
 import gpflow
@@ -88,7 +88,9 @@ from trieste.utils import DEFAULTS
 
 class _ArbitrarySingleBuilder(SingleModelAcquisitionBuilder):
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         return raise_exc
 
@@ -96,9 +98,9 @@ class _ArbitrarySingleBuilder(SingleModelAcquisitionBuilder):
 class _ArbitraryGreedySingleBuilder(SingleModelGreedyAcquisitionBuilder):
     def prepare_acquisition_function(
         self,
-        dataset: Dataset,
         model: ProbabilisticModel,
-        pending_points: TensorType = None,
+        dataset: Optional[Dataset] = None,
+        pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
         return raise_exc
 
@@ -108,7 +110,7 @@ def test_single_model_acquisition_builder_raises_immediately_for_wrong_key() -> 
 
     with pytest.raises(KeyError):
         builder.prepare_acquisition_function(
-            {"bar": empty_dataset([1], [1])}, {"bar": QuadraticMeanAndRBFKernel()}
+            {"bar": QuadraticMeanAndRBFKernel()}, datasets={"bar": empty_dataset([1], [1])}
         )
 
 
@@ -120,7 +122,9 @@ def test_single_model_acquisition_builder_repr_includes_class_name() -> None:
 def test_single_model_acquisition_builder_using_passes_on_correct_dataset_and_model() -> None:
     class Builder(SingleModelAcquisitionBuilder):
         def prepare_acquisition_function(
-            self, dataset: Dataset, model: ProbabilisticModel
+            self,
+            model: ProbabilisticModel,
+            dataset: Optional[Dataset] = None,
         ) -> AcquisitionFunction:
             assert dataset is data["foo"]
             assert model is models["foo"]
@@ -128,7 +132,7 @@ def test_single_model_acquisition_builder_using_passes_on_correct_dataset_and_mo
 
     data = {"foo": empty_dataset([1], [1]), "bar": empty_dataset([1], [1])}
     models = {"foo": QuadraticMeanAndRBFKernel(), "bar": QuadraticMeanAndRBFKernel()}
-    Builder().using("foo").prepare_acquisition_function(data, models)
+    Builder().using("foo").prepare_acquisition_function(models, datasets=data)
 
 
 def test_single_model_greedy_acquisition_builder_raises_immediately_for_wrong_key() -> None:
@@ -136,7 +140,7 @@ def test_single_model_greedy_acquisition_builder_raises_immediately_for_wrong_ke
 
     with pytest.raises(KeyError):
         builder.prepare_acquisition_function(
-            {"bar": empty_dataset([1], [1])}, {"bar": QuadraticMeanAndRBFKernel()}, None
+            {"bar": QuadraticMeanAndRBFKernel()}, {"bar": empty_dataset([1], [1])}, None
         )
 
 
@@ -151,7 +155,7 @@ def test_expected_improvement_builder_builds_expected_improvement_using_best_fro
         tf.constant([[4.1], [0.9], [0.1], [1.1], [3.9]]),
     )
     model = QuadraticMeanAndRBFKernel()
-    acq_fn = ExpectedImprovement().prepare_acquisition_function(dataset, model)
+    acq_fn = ExpectedImprovement().prepare_acquisition_function(model, dataset=dataset)
     xs = tf.linspace([[-10.0]], [[10.0]], 100)
     expected = expected_improvement(model, tf.constant([0.0]))(xs)
     npt.assert_allclose(acq_fn(xs), expected)
@@ -163,7 +167,7 @@ def test_expected_improvement_builder_updates_expected_improvement_using_best_fr
         tf.constant([[4.1], [0.9]]),
     )
     model = QuadraticMeanAndRBFKernel()
-    acq_fn = ExpectedImprovement().prepare_acquisition_function(dataset, model)
+    acq_fn = ExpectedImprovement().prepare_acquisition_function(model, dataset=dataset)
     assert acq_fn.__call__._get_tracing_count() == 0  # type: ignore
     xs = tf.linspace([[-10.0]], [[10.0]], 100)
     expected = expected_improvement(model, tf.constant([1.0]))(xs)
@@ -174,7 +178,9 @@ def test_expected_improvement_builder_updates_expected_improvement_using_best_fr
         tf.concat([dataset.query_points, tf.constant([[0.0], [1.0], [2.0]])], 0),
         tf.concat([dataset.observations, tf.constant([[0.1], [1.1], [3.9]])], 0),
     )
-    updated_acq_fn = ExpectedImprovement().update_acquisition_function(acq_fn, new_dataset, model)
+    updated_acq_fn = ExpectedImprovement().update_acquisition_function(
+        acq_fn, model, dataset=new_dataset
+    )
     assert updated_acq_fn == acq_fn
     expected = expected_improvement(model, tf.constant([0.0]))(xs)
     npt.assert_allclose(acq_fn(xs), expected)
@@ -185,7 +191,9 @@ def test_expected_improvement_builder_raises_for_empty_data() -> None:
     data = Dataset(tf.zeros([0, 1]), tf.ones([0, 1]))
 
     with pytest.raises(tf.errors.InvalidArgumentError):
-        ExpectedImprovement().prepare_acquisition_function(data, QuadraticMeanAndRBFKernel())
+        ExpectedImprovement().prepare_acquisition_function(
+            QuadraticMeanAndRBFKernel(), dataset=data
+        )
 
 
 @pytest.mark.parametrize("at", [tf.constant([[0.0], [1.0]]), tf.constant([[[0.0], [1.0]]])])
@@ -246,7 +254,8 @@ def test_augmented_expected_improvement_builder_raises_for_empty_data() -> None:
 
     with pytest.raises(tf.errors.InvalidArgumentError):
         AugmentedExpectedImprovement().prepare_acquisition_function(
-            data, QuadraticMeanAndRBFKernel()
+            QuadraticMeanAndRBFKernel(),
+            dataset=data,
         )
 
 
@@ -284,10 +293,10 @@ def test_augmented_expected_improvement_builder_builds_expected_improvement_time
     )
 
     model = QuadraticMeanAndRBFKernel(noise_variance=observation_noise)
-    acq_fn = AugmentedExpectedImprovement().prepare_acquisition_function(dataset, model)
+    acq_fn = AugmentedExpectedImprovement().prepare_acquisition_function(model, dataset=dataset)
 
     xs = tf.linspace([[-10.0]], [[10.0]], 100)
-    ei = ExpectedImprovement().prepare_acquisition_function(dataset, model)(xs)
+    ei = ExpectedImprovement().prepare_acquisition_function(model, dataset=dataset)(xs)
 
     @tf.function
     def augmentation() -> TensorType:
@@ -314,14 +323,17 @@ def test_augmented_expected_improvement_builder_updates_acquisition_function(
     model = QuadraticMeanAndRBFKernel(noise_variance=observation_noise)
 
     partial_data_acq_fn = AugmentedExpectedImprovement().prepare_acquisition_function(
-        partial_dataset, model
+        model,
+        dataset=partial_dataset,
     )
     updated_acq_fn = AugmentedExpectedImprovement().update_acquisition_function(
-        partial_data_acq_fn, full_dataset, model
+        partial_data_acq_fn,
+        model,
+        dataset=full_dataset,
     )
     assert updated_acq_fn == partial_data_acq_fn
     full_data_acq_fn = AugmentedExpectedImprovement().prepare_acquisition_function(
-        full_dataset, model
+        model, dataset=full_dataset
     )
 
     xs = tf.linspace([[-10.0]], [[10.0]], 100)
@@ -334,10 +346,10 @@ def test_min_value_entropy_search_builder_raises_for_empty_data() -> None:
     search_space = Box([0, 0], [1, 1])
     builder = MinValueEntropySearch(search_space)
     with pytest.raises(tf.errors.InvalidArgumentError):
-        builder.prepare_acquisition_function(empty_data, QuadraticMeanAndRBFKernel())
-    acq = builder.prepare_acquisition_function(non_empty_data, QuadraticMeanAndRBFKernel())
+        builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), dataset=empty_data)
+    acq = builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), dataset=non_empty_data)
     with pytest.raises(tf.errors.InvalidArgumentError):
-        builder.update_acquisition_function(acq, empty_data, QuadraticMeanAndRBFKernel())
+        builder.update_acquisition_function(acq, QuadraticMeanAndRBFKernel(), dataset=empty_data)
 
 
 @pytest.mark.parametrize("param", [-2, 0])
@@ -367,7 +379,7 @@ def test_min_value_entropy_search_builder_builds_min_value_samples(
     search_space = Box([0, 0], [1, 1])
     builder = MinValueEntropySearch(search_space, use_thompson=use_thompson)
     model = QuadraticMeanAndRBFKernel()
-    builder.prepare_acquisition_function(dataset, model)
+    builder.prepare_acquisition_function(model, dataset=dataset)
     mocked_mves.assert_called_once()
 
     # check that the Gumbel samples look sensible
@@ -400,14 +412,14 @@ def test_min_value_entropy_search_builder_updates_acquisition_function(use_thomp
     )
     xs = tf.cast(tf.linspace([[0.0]], [[1.0]], 10), tf.float64)
 
-    old_acq_fn = builder.prepare_acquisition_function(partial_dataset, model)
+    old_acq_fn = builder.prepare_acquisition_function(model, dataset=partial_dataset)
     tf.random.set_seed(0)  # to ensure consistent sampling
-    updated_acq_fn = builder.update_acquisition_function(old_acq_fn, full_dataset, model)
+    updated_acq_fn = builder.update_acquisition_function(old_acq_fn, model, dataset=full_dataset)
     assert updated_acq_fn == old_acq_fn
     updated_values = updated_acq_fn(xs)
 
     tf.random.set_seed(0)  # to ensure consistent sampling
-    new_acq_fn = builder.prepare_acquisition_function(full_dataset, model)
+    new_acq_fn = builder.prepare_acquisition_function(model, dataset=full_dataset)
     new_values = new_acq_fn(xs)
 
     npt.assert_allclose(updated_values, new_values)
@@ -431,7 +443,7 @@ def test_min_value_entropy_search_builder_builds_min_value_samples_rff(
     dataset = Dataset(xs, ys)
 
     builder = MinValueEntropySearch(search_space, use_thompson=True, num_fourier_features=100)
-    builder.prepare_acquisition_function(dataset, model)
+    builder.prepare_acquisition_function(model, dataset=dataset)
     mocked_mves.assert_called_once()
 
     # check that the Gumbel samples look sensible
@@ -494,7 +506,8 @@ def test_negative_lower_confidence_bound_builder_builds_negative_lower_confidenc
     model = QuadraticMeanAndRBFKernel()
     beta = 1.96
     acq_fn = NegativeLowerConfidenceBound(beta).prepare_acquisition_function(
-        Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])), model
+        model,
+        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
     )
     query_at = tf.linspace([[-10]], [[10]], 100)
     expected = -lower_confidence_bound(model, beta)(query_at)
@@ -506,7 +519,8 @@ def test_negative_lower_confidence_bound_builder_updates_without_retracing() -> 
     beta = 1.96
     builder = NegativeLowerConfidenceBound(beta)
     acq_fn = builder.prepare_acquisition_function(
-        Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])), model
+        model,
+        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
     )
     assert acq_fn._get_tracing_count() == 0  # type: ignore
     query_at = tf.linspace([[-10]], [[10]], 100)
@@ -515,7 +529,9 @@ def test_negative_lower_confidence_bound_builder_updates_without_retracing() -> 
     assert acq_fn._get_tracing_count() == 1  # type: ignore
 
     up_acq_fn = builder.update_acquisition_function(
-        acq_fn, Dataset(tf.ones([0, 1]), tf.ones([0, 1])), model
+        acq_fn,
+        model,
+        dataset=Dataset(tf.ones([0, 1]), tf.ones([0, 1])),
     )
     assert up_acq_fn == acq_fn
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
@@ -568,7 +584,7 @@ def test_probability_of_feasibility(threshold: float, at: tf.Tensor, expected: f
 @pytest.mark.parametrize("threshold", [-2.3, 0.2])
 def test_probability_of_feasibility_builder_builds_pof(threshold: float, at: tf.Tensor) -> None:
     builder = ProbabilityOfFeasibility(threshold)
-    acq = builder.prepare_acquisition_function(empty_dataset([1], [1]), QuadraticMeanAndRBFKernel())
+    acq = builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), empty_dataset([1], [1]))
     expected = probability_of_feasibility(QuadraticMeanAndRBFKernel(), threshold)(at)
 
     npt.assert_allclose(acq(at), expected)
@@ -606,11 +622,11 @@ def test_probability_of_feasibility_builder_updates_without_retracing(
     builder = ProbabilityOfFeasibility(threshold)
     model = QuadraticMeanAndRBFKernel()
     expected = probability_of_feasibility(QuadraticMeanAndRBFKernel(), threshold)(at)
-    acq = builder.prepare_acquisition_function(empty_dataset([1], [1]), model)
+    acq = builder.prepare_acquisition_function(model, dataset=empty_dataset([1], [1]))
     assert acq._get_tracing_count() == 0  # type: ignore
     npt.assert_allclose(acq(at), expected)
     assert acq._get_tracing_count() == 1  # type: ignore
-    up_acq = builder.update_acquisition_function(acq, empty_dataset([2], [2]), model)
+    up_acq = builder.update_acquisition_function(acq, model, dataset=empty_dataset([2], [2]))
     assert up_acq == acq
     npt.assert_allclose(acq(at), expected)
     assert acq._get_tracing_count() == 1  # type: ignore
@@ -654,7 +670,7 @@ def test_expected_constrained_improvement_raises_for_invalid_batch_size(at: Tens
     initial_objective_function_values = tf.constant([[1.0]])
     data = {"": Dataset(initial_query_points, initial_objective_function_values)}
 
-    eci = builder.prepare_acquisition_function(data, {"": QuadraticMeanAndRBFKernel()})
+    eci = builder.prepare_acquisition_function({"": QuadraticMeanAndRBFKernel()}, datasets=data)
 
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
         eci(at)
@@ -663,7 +679,9 @@ def test_expected_constrained_improvement_raises_for_invalid_batch_size(at: Tens
 def test_expected_constrained_improvement_can_reproduce_expected_improvement() -> None:
     class _Certainty(AcquisitionFunctionBuilder):
         def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            self,
+            models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> AcquisitionFunction:
             return lambda x: tf.ones_like(tf.squeeze(x, -2))
 
@@ -671,17 +689,19 @@ def test_expected_constrained_improvement_can_reproduce_expected_improvement() -
     models_ = {"foo": QuadraticMeanAndRBFKernel()}
 
     builder = ExpectedConstrainedImprovement("foo", _Certainty(), 0)
-    eci = builder.prepare_acquisition_function(data, models_)
+    eci = builder.prepare_acquisition_function(models_, datasets=data)
 
-    ei = ExpectedImprovement().using("foo").prepare_acquisition_function(data, models_)
+    ei = ExpectedImprovement().using("foo").prepare_acquisition_function(models_, datasets=data)
 
     at = tf.constant([[[-0.1]], [[1.23]], [[-6.78]]])
     npt.assert_allclose(eci(at), ei(at))
 
     new_data = {"foo": Dataset(tf.constant([[0.5], [1.0]]), tf.constant([[0.25], [0.5]]))}
-    up_eci = builder.update_acquisition_function(eci, new_data, models_)
+    up_eci = builder.update_acquisition_function(eci, models_, datasets=new_data)
     assert up_eci == eci
-    up_ei = ExpectedImprovement().using("foo").prepare_acquisition_function(new_data, models_)
+    up_ei = (
+        ExpectedImprovement().using("foo").prepare_acquisition_function(models_, datasets=new_data)
+    )
 
     npt.assert_allclose(eci(at), up_ei(at))
     assert eci._get_tracing_count() == 1  # type: ignore
@@ -690,7 +710,9 @@ def test_expected_constrained_improvement_can_reproduce_expected_improvement() -
 def test_expected_constrained_improvement_is_relative_to_feasible_point() -> None:
     class _Constraint(AcquisitionFunctionBuilder):
         def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            self,
+            models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> AcquisitionFunction:
             return lambda x: tf.cast(tf.squeeze(x, -2) >= 0, x.dtype)
 
@@ -698,11 +720,12 @@ def test_expected_constrained_improvement_is_relative_to_feasible_point() -> Non
 
     eci_data = {"foo": Dataset(tf.constant([[-0.2], [0.3]]), tf.constant([[0.04], [0.09]]))}
     eci = ExpectedConstrainedImprovement("foo", _Constraint()).prepare_acquisition_function(
-        eci_data, models_
+        models_,
+        datasets=eci_data,
     )
 
     ei_data = {"foo": Dataset(tf.constant([[0.3]]), tf.constant([[0.09]]))}
-    ei = ExpectedImprovement().using("foo").prepare_acquisition_function(ei_data, models_)
+    ei = ExpectedImprovement().using("foo").prepare_acquisition_function(models_, datasets=ei_data)
 
     npt.assert_allclose(eci(tf.constant([[0.1]])), ei(tf.constant([[0.1]])))
 
@@ -710,7 +733,9 @@ def test_expected_constrained_improvement_is_relative_to_feasible_point() -> Non
 def test_expected_constrained_improvement_is_less_for_constrained_points() -> None:
     class _Constraint(AcquisitionFunctionBuilder):
         def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            self,
+            models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> AcquisitionFunction:
             return lambda x: tf.cast(tf.squeeze(x, -2) >= 0, x.dtype)
 
@@ -722,7 +747,8 @@ def test_expected_constrained_improvement_is_less_for_constrained_points() -> No
     models_ = {"foo": GaussianProcess([two_global_minima], [rbf()])}
 
     eci = ExpectedConstrainedImprovement("foo", _Constraint()).prepare_acquisition_function(
-        data, models_
+        models_,
+        datasets=data,
     )
 
     npt.assert_array_less(eci(tf.constant([[-1.0]])), eci(tf.constant([[1.0]])))
@@ -740,7 +766,9 @@ def test_expected_constrained_improvement_raises_for_empty_data(
 ) -> None:
     class _Constraint(AcquisitionFunctionBuilder):
         def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            self,
+            models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> AcquisitionFunction:
             return raise_exc
 
@@ -749,13 +777,15 @@ def test_expected_constrained_improvement_raises_for_empty_data(
     builder = function("foo", _Constraint())
 
     with pytest.raises(tf.errors.InvalidArgumentError):
-        builder.prepare_acquisition_function(data, models_)
+        builder.prepare_acquisition_function(models_, datasets=data)
 
 
 def test_expected_constrained_improvement_is_constraint_when_no_feasible_points() -> None:
     class _Constraint(AcquisitionFunctionBuilder):
         def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            self,
+            models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> AcquisitionFunction:
             def acquisition(x: TensorType) -> TensorType:
                 x_ = tf.squeeze(x, -2)
@@ -766,10 +796,11 @@ def test_expected_constrained_improvement_is_constraint_when_no_feasible_points(
     data = {"foo": Dataset(tf.constant([[-2.0], [1.0]]), tf.constant([[4.0], [1.0]]))}
     models_ = {"foo": QuadraticMeanAndRBFKernel()}
     eci = ExpectedConstrainedImprovement("foo", _Constraint()).prepare_acquisition_function(
-        data, models_
+        models_,
+        datasets=data,
     )
 
-    constraint_fn = _Constraint().prepare_acquisition_function(data, models_)
+    constraint_fn = _Constraint().prepare_acquisition_function(models_, datasets=data)
 
     xs = tf.linspace([[-10.0]], [[10.0]], 100)
     npt.assert_allclose(eci(xs), constraint_fn(xs))
@@ -781,7 +812,9 @@ def test_expected_constrained_improvement_min_feasibility_probability_bound_is_i
 
     class _Constraint(AcquisitionFunctionBuilder):
         def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            self,
+            models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> AcquisitionFunction:
             return pof
 
@@ -790,9 +823,12 @@ def test_expected_constrained_improvement_min_feasibility_probability_bound_is_i
     data = {"foo": Dataset(tf.constant([[1.1], [2.0]]), tf.constant([[1.21], [4.0]]))}
     eci = ExpectedConstrainedImprovement(
         "foo", _Constraint(), min_feasibility_probability=tfp.bijectors.Sigmoid().forward(1.0)
-    ).prepare_acquisition_function(data, models_)
+    ).prepare_acquisition_function(
+        models_,
+        datasets=data,
+    )
 
-    ei = ExpectedImprovement().using("foo").prepare_acquisition_function(data, models_)
+    ei = ExpectedImprovement().using("foo").prepare_acquisition_function(models_, datasets=data)
     x = tf.constant([[1.5]])
     npt.assert_allclose(eci(x), ei(x) * pof(x))
 
@@ -809,7 +845,7 @@ def test_ehvi_builder_raises_for_empty_data() -> None:
     model = QuadraticMeanAndRBFKernel()
 
     with pytest.raises(tf.errors.InvalidArgumentError):
-        ExpectedHypervolumeImprovement().prepare_acquisition_function(dataset, model)
+        ExpectedHypervolumeImprovement().prepare_acquisition_function(model, dataset=dataset)
 
 
 def test_ehvi_builder_builds_expected_hv_improvement_using_pareto_from_model() -> None:
@@ -823,7 +859,7 @@ def test_ehvi_builder_builds_expected_hv_improvement_using_pareto_from_model() -
     )
 
     model = _mo_test_model(num_obj, *[10, 10] * num_obj)
-    acq_fn = ExpectedHypervolumeImprovement().prepare_acquisition_function(dataset, model)
+    acq_fn = ExpectedHypervolumeImprovement().prepare_acquisition_function(model, dataset=dataset)
 
     model_pred_observation = model.predict(train_x)[0]
     _prt = Pareto(model_pred_observation)
@@ -848,7 +884,9 @@ def test_ehvi_builder_updates_expected_hv_improvement_using_pareto_from_model() 
     xs = tf.linspace([[-10.0]], [[10.0]], 100)
 
     model = _mo_test_model(num_obj, *[10, 10] * num_obj)
-    acq_fn = ExpectedHypervolumeImprovement().prepare_acquisition_function(partial_dataset, model)
+    acq_fn = ExpectedHypervolumeImprovement().prepare_acquisition_function(
+        model, dataset=partial_dataset
+    )
     assert acq_fn.__call__._get_tracing_count() == 0  # type: ignore
     model_pred_observation = model.predict(train_x)[0]
     _prt = Pareto(model_pred_observation)
@@ -861,7 +899,9 @@ def test_ehvi_builder_updates_expected_hv_improvement_using_pareto_from_model() 
 
     # update the acquisition function, evaluate it, and check that it hasn't been retraced
     updated_acq_fn = ExpectedHypervolumeImprovement().update_acquisition_function(
-        acq_fn, dataset, model
+        acq_fn,
+        model,
+        dataset=dataset,
     )
     assert updated_acq_fn == acq_fn
     model_pred_observation = model.predict(train_x)[0]
@@ -987,7 +1027,8 @@ def test_qehvi_builder_raises_for_empty_data() -> None:
 
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
         BatchMonteCarloExpectedHypervolumeImprovement(sample_size=100).prepare_acquisition_function(
-            dataset, model
+            model,
+            dataset=dataset,
         )
 
 
@@ -1063,7 +1104,7 @@ def test_batch_monte_carlo_expected_hypervolume_improvement_can_reproduce_ehvi(
     )
 
     qehvi_builder = BatchMonteCarloExpectedHypervolumeImprovement(sample_size=num_samples_per_point)
-    qehvi_acq = qehvi_builder.prepare_acquisition_function(_model_based_tr_dataset, model)
+    qehvi_acq = qehvi_builder.prepare_acquisition_function(model, dataset=_model_based_tr_dataset)
     ehvi_acq = expected_hv_improvement(model, _partition_bounds)
 
     test_xs = tf.convert_to_tensor(
@@ -1210,7 +1251,7 @@ def test_batch_monte_carlo_expected_improvement_raises_for_empty_data() -> None:
     data = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
     model = QuadraticMeanAndRBFKernel()
     with pytest.raises(tf.errors.InvalidArgumentError):
-        builder.prepare_acquisition_function(data, model)
+        builder.prepare_acquisition_function(model, dataset=data)
 
 
 def test_batch_monte_carlo_expected_improvement_raises_for_model_with_wrong_event_shape() -> None:
@@ -1221,7 +1262,7 @@ def test_batch_monte_carlo_expected_improvement_raises_for_model_with_wrong_even
     )
     model = GaussianProcess([lambda x: branin(x), lambda x: quadratic(x)], [matern52, rbf()])
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.prepare_acquisition_function(data, model)
+        builder.prepare_acquisition_function(model, dataset=data)
 
 
 @random_seed
@@ -1229,8 +1270,10 @@ def test_batch_monte_carlo_expected_improvement_can_reproduce_ei() -> None:
     known_query_points = tf.random.uniform([5, 2], dtype=tf.float64)
     data = Dataset(known_query_points, quadratic(known_query_points))
     model = QuadraticMeanAndRBFKernel()
-    batch_ei = BatchMonteCarloExpectedImprovement(10_000).prepare_acquisition_function(data, model)
-    ei = ExpectedImprovement().prepare_acquisition_function(data, model)
+    batch_ei = BatchMonteCarloExpectedImprovement(10_000).prepare_acquisition_function(
+        model, dataset=data
+    )
+    ei = ExpectedImprovement().prepare_acquisition_function(model, dataset=data)
     xs = tf.random.uniform([3, 5, 1, 2], dtype=tf.float64)
     npt.assert_allclose(batch_ei(xs), ei(xs), rtol=0.06)
     # and again, since the sampler uses cacheing
@@ -1253,7 +1296,9 @@ def test_batch_monte_carlo_expected_improvement() -> None:
     # fmt: on
 
     builder = BatchMonteCarloExpectedImprovement(10_000)
-    acq = builder.prepare_acquisition_function(mk_dataset([[0.3], [0.5]], [[0.09], [0.25]]), model)
+    acq = builder.prepare_acquisition_function(
+        model, dataset=mk_dataset([[0.3], [0.5]], [[0.09], [0.25]])
+    )
 
     npt.assert_allclose(acq(xs), expected, rtol=0.05)
 
@@ -1264,16 +1309,16 @@ def test_batch_monte_carlo_expected_improvement_updates_without_retracing() -> N
     data = Dataset(known_query_points[:5], quadratic(known_query_points[:5]))
     model = QuadraticMeanAndRBFKernel()
     builder = BatchMonteCarloExpectedImprovement(10_000)
-    ei = ExpectedImprovement().prepare_acquisition_function(data, model)
+    ei = ExpectedImprovement().prepare_acquisition_function(model, dataset=data)
     xs = tf.random.uniform([3, 5, 1, 2], dtype=tf.float64)
 
-    batch_ei = builder.prepare_acquisition_function(data, model)
+    batch_ei = builder.prepare_acquisition_function(model, dataset=data)
     assert batch_ei.__call__._get_tracing_count() == 0  # type: ignore
     npt.assert_allclose(batch_ei(xs), ei(xs), rtol=0.06)
     assert batch_ei.__call__._get_tracing_count() == 1  # type: ignore
 
     data = Dataset(known_query_points, quadratic(known_query_points))
-    up_batch_ei = builder.update_acquisition_function(batch_ei, data, model)
+    up_batch_ei = builder.update_acquisition_function(batch_ei, model, dataset=data)
     assert up_batch_ei == batch_ei
     assert batch_ei.__call__._get_tracing_count() == 1  # type: ignore
     npt.assert_allclose(batch_ei(xs), ei(xs), rtol=0.06)
@@ -1315,7 +1360,8 @@ def test_locally_penalized_expected_improvement_builder_raises_for_empty_data() 
     space = Box([0, 0], [1, 1])
     with pytest.raises(tf.errors.InvalidArgumentError):
         LocalPenalizationAcquisitionFunction(search_space=space).prepare_acquisition_function(
-            data, QuadraticMeanAndRBFKernel()
+            QuadraticMeanAndRBFKernel(),
+            dataset=data,
         )
 
 
@@ -1333,7 +1379,7 @@ def test_locally_penalized_expected_improvement_builder_raises_for_invalid_pendi
     space = Box([0, 0], [1, 1])
     builder = LocalPenalizationAcquisitionFunction(search_space=space)
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.prepare_acquisition_function(data, QuadraticMeanAndRBFKernel(), pending_points)
+        builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), data, pending_points)
 
 
 @random_seed
@@ -1354,9 +1400,9 @@ def test_locally_penalized_acquisitions_match_base_acquisition(
     lp_acq_builder = LocalPenalizationAcquisitionFunction(
         search_space, base_acquisition_function_builder=base_builder
     )
-    lp_acq = lp_acq_builder.prepare_acquisition_function(data, model, None)
+    lp_acq = lp_acq_builder.prepare_acquisition_function(model, data, None)
 
-    base_acq = base_builder.prepare_acquisition_function(data, model)
+    base_acq = base_builder.prepare_acquisition_function(model, dataset=data)
 
     x_range = tf.linspace(0.0, 1.0, 11)
     x_range = tf.cast(x_range, dtype=tf.float64)
@@ -1388,12 +1434,12 @@ def test_locally_penalized_acquisitions_combine_base_and_penalization_correctly(
     acq_builder = LocalPenalizationAcquisitionFunction(
         search_space, penalizer=penalizer, base_acquisition_function_builder=base_builder
     )
-    lp_acq = acq_builder.prepare_acquisition_function(data, model, None)  # initialize
-    lp_acq = acq_builder.update_acquisition_function(lp_acq, data, model, pending_points[:1], False)
-    up_lp_acq = acq_builder.update_acquisition_function(lp_acq, data, model, pending_points, False)
+    lp_acq = acq_builder.prepare_acquisition_function(model, data, None)  # initialize
+    lp_acq = acq_builder.update_acquisition_function(lp_acq, model, data, pending_points[:1], False)
+    up_lp_acq = acq_builder.update_acquisition_function(lp_acq, model, data, pending_points, False)
     assert up_lp_acq == lp_acq  # in-place updates
 
-    base_acq = base_builder.prepare_acquisition_function(data, model)
+    base_acq = base_builder.prepare_acquisition_function(model, dataset=data)
 
     best = acq_builder._eta
     lipshitz_constant = acq_builder._lipschitz_constant
@@ -1447,10 +1493,10 @@ def test_gibbon_builder_raises_for_empty_data() -> None:
     search_space = Box([0, 0], [1, 1])
     builder = GIBBON(search_space)
     with pytest.raises(tf.errors.InvalidArgumentError):
-        builder.prepare_acquisition_function(empty_data, QuadraticMeanAndRBFKernel())
-    acq = builder.prepare_acquisition_function(non_empty_data, QuadraticMeanAndRBFKernel())
+        builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), empty_data)
+    acq = builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), non_empty_data)
     with pytest.raises(tf.errors.InvalidArgumentError):
-        builder.update_acquisition_function(acq, empty_data, QuadraticMeanAndRBFKernel())
+        builder.update_acquisition_function(acq, QuadraticMeanAndRBFKernel(), empty_data)
 
 
 @pytest.mark.parametrize("param", [-2, 0])
@@ -1506,7 +1552,7 @@ def test_gibbon_builder_builds_min_value_samples(
     search_space = Box([0, 0], [1, 1])
     builder = GIBBON(search_space, use_thompson=use_thompson)
     model = QuadraticMeanAndRBFKernel()
-    builder.prepare_acquisition_function(dataset, model)
+    builder.prepare_acquisition_function(model, dataset=dataset)
     mocked_mves.assert_called_once()
 
     # check that the Gumbel samples look sensible
@@ -1531,14 +1577,14 @@ def test_gibbon_builder_updates_acquisition_function(use_thompson: bool) -> None
     xs = tf.cast(tf.linspace([[0.0]], [[1.0]], 10), tf.float64)
     model = QuadraticMeanAndRBFKernel()
 
-    old_acq_fn = builder.prepare_acquisition_function(partial_dataset, model)
+    old_acq_fn = builder.prepare_acquisition_function(model, dataset=partial_dataset)
     tf.random.set_seed(0)  # to ensure consistent sampling
-    updated_acq_fn = builder.update_acquisition_function(old_acq_fn, full_dataset, model)
+    updated_acq_fn = builder.update_acquisition_function(old_acq_fn, model, dataset=full_dataset)
     assert updated_acq_fn == old_acq_fn
     updated_values = updated_acq_fn(xs)
 
     tf.random.set_seed(0)  # to ensure consistent sampling
-    new_acq_fn = builder.prepare_acquisition_function(full_dataset, model)
+    new_acq_fn = builder.prepare_acquisition_function(model, dataset=full_dataset)
     new_values = new_acq_fn(xs)
 
     npt.assert_allclose(updated_values, new_values)
@@ -1552,7 +1598,7 @@ def test_gibbon_builder_raises_for_invalid_pending_points_shape(
     space = Box([0, 0], [1, 1])
     builder = GIBBON(search_space=space)
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        builder.prepare_acquisition_function(data, QuadraticMeanAndRBFKernel(), pending_points)
+        builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), data, pending_points)
 
 
 def test_gibbon_raises_for_model_without_homoscedastic_likelihood() -> None:
@@ -1611,7 +1657,7 @@ def test_gibbon_builder_builds_min_value_samples_rff(mocked_mves: MagicMock) -> 
     dataset = Dataset(xs, ys)
 
     builder = GIBBON(search_space, use_thompson=True, num_fourier_features=100)
-    builder.prepare_acquisition_function(dataset, model)
+    builder.prepare_acquisition_function(model, dataset=dataset)
     mocked_mves.assert_called_once()
 
     # check that the Gumbel samples look sensible
@@ -1696,7 +1742,7 @@ def test_expected_constrained_hypervolume_improvement_raises_for_invalid_batch_s
     initial_objective_function_values = tf.constant([[1.0, 1.0]])
     data = {"": Dataset(initial_query_points, initial_objective_function_values)}
 
-    echvi = builder.prepare_acquisition_function(data, {"": QuadraticMeanAndRBFKernel()})
+    echvi = builder.prepare_acquisition_function({"": QuadraticMeanAndRBFKernel()}, datasets=data)
 
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
         echvi(at)
@@ -1711,7 +1757,9 @@ def test_expected_constrained_hypervolume_improvement_can_reproduce_ehvi() -> No
 
     class _Certainty(AcquisitionFunctionBuilder):
         def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            self,
+            models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> AcquisitionFunction:
             return lambda x: tf.ones_like(tf.squeeze(x, -2))
 
@@ -1719,20 +1767,24 @@ def test_expected_constrained_hypervolume_improvement_can_reproduce_ehvi() -> No
     models_ = {"foo": obj_model}
 
     builder = ExpectedConstrainedHypervolumeImprovement("foo", _Certainty(), 0)
-    echvi = builder.prepare_acquisition_function(data, models_)
+    echvi = builder.prepare_acquisition_function(models_, datasets=data)
 
-    ehvi = ExpectedHypervolumeImprovement().using("foo").prepare_acquisition_function(data, models_)
+    ehvi = (
+        ExpectedHypervolumeImprovement()
+        .using("foo")
+        .prepare_acquisition_function(models_, datasets=data)
+    )
 
     at = tf.constant([[[-0.1]], [[1.23]], [[-6.78]]])
     npt.assert_allclose(echvi(at), ehvi(at))
 
     new_data = {"foo": Dataset(train_x, model_pred_observation)}
-    up_echvi = builder.update_acquisition_function(echvi, new_data, models_)
+    up_echvi = builder.update_acquisition_function(echvi, models_, datasets=new_data)
     assert up_echvi == echvi
     up_ehvi = (
         ExpectedHypervolumeImprovement()
         .using("foo")
-        .prepare_acquisition_function(new_data, models_)
+        .prepare_acquisition_function(models_, datasets=new_data)
     )
 
     npt.assert_allclose(up_echvi(at), up_ehvi(at))
@@ -1742,7 +1794,9 @@ def test_expected_constrained_hypervolume_improvement_can_reproduce_ehvi() -> No
 def test_echvi_is_constraint_when_no_feasible_points() -> None:
     class _Constraint(AcquisitionFunctionBuilder):
         def prepare_acquisition_function(
-            self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+            self,
+            models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> AcquisitionFunction:
             def acquisition(x: TensorType) -> TensorType:
                 x_ = tf.squeeze(x, -2)
@@ -1754,9 +1808,9 @@ def test_echvi_is_constraint_when_no_feasible_points() -> None:
     models_ = {"foo": QuadraticMeanAndRBFKernel()}
     echvi = ExpectedConstrainedHypervolumeImprovement(
         "foo", _Constraint()
-    ).prepare_acquisition_function(data, models_)
+    ).prepare_acquisition_function(models_, datasets=data)
 
-    constraint_fn = _Constraint().prepare_acquisition_function(data, models_)
+    constraint_fn = _Constraint().prepare_acquisition_function(models_, datasets=data)
 
     xs = tf.linspace([[-10.0]], [[10.0]], 100)
     npt.assert_allclose(echvi(xs), constraint_fn(xs))
@@ -1765,7 +1819,8 @@ def test_echvi_is_constraint_when_no_feasible_points() -> None:
 def test_predictive_variance_builder_builds_predictive_variance() -> None:
     model = QuadraticMeanAndRBFKernel()
     acq_fn = PredictiveVariance().prepare_acquisition_function(
-        Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])), model
+        model,
+        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
     )
     query_at = tf.linspace([[-10]], [[10]], 100)
     _, covariance = model.predict_joint(query_at)
@@ -1787,7 +1842,8 @@ def test_predictive_variance_returns_correct_shape(
 ) -> None:
     model = QuadraticMeanAndRBFKernel()
     acq_fn = PredictiveVariance().prepare_acquisition_function(
-        Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])), model
+        model,
+        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
     )
     npt.assert_array_equal(acq_fn(at).shape, acquisition_shape)
 
@@ -1831,7 +1887,8 @@ def test_predictive_variance_builder_updates_without_retracing() -> None:
     model = QuadraticMeanAndRBFKernel()
     builder = PredictiveVariance()
     acq_fn = builder.prepare_acquisition_function(
-        Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])), model
+        model,
+        dataset=Dataset(tf.zeros([0, 1]), tf.zeros([0, 1])),
     )
     assert acq_fn._get_tracing_count() == 0  # type: ignore
     query_at = tf.linspace([[-10]], [[10]], 100)
@@ -1840,7 +1897,9 @@ def test_predictive_variance_builder_updates_without_retracing() -> None:
     assert acq_fn._get_tracing_count() == 1  # type: ignore
 
     up_acq_fn = builder.update_acquisition_function(
-        acq_fn, Dataset(tf.ones([0, 1]), tf.ones([0, 1])), model
+        acq_fn,
+        model,
+        dataset=Dataset(tf.ones([0, 1]), tf.ones([0, 1])),
     )
     assert up_acq_fn == acq_fn
     npt.assert_array_almost_equal(acq_fn(query_at), expected)

--- a/tests/unit/acquisition/test_function.py
+++ b/tests/unit/acquisition/test_function.py
@@ -194,6 +194,8 @@ def test_expected_improvement_builder_raises_for_empty_data() -> None:
         ExpectedImprovement().prepare_acquisition_function(
             QuadraticMeanAndRBFKernel(), dataset=data
         )
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        ExpectedImprovement().prepare_acquisition_function(QuadraticMeanAndRBFKernel())
 
 
 @pytest.mark.parametrize("at", [tf.constant([[0.0], [1.0]]), tf.constant([[[0.0], [1.0]]])])
@@ -257,6 +259,8 @@ def test_augmented_expected_improvement_builder_raises_for_empty_data() -> None:
             QuadraticMeanAndRBFKernel(),
             dataset=data,
         )
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        AugmentedExpectedImprovement().prepare_acquisition_function(QuadraticMeanAndRBFKernel())
 
 
 @pytest.mark.parametrize("at", [tf.constant([[0.0], [1.0]]), tf.constant([[[0.0], [1.0]]])])
@@ -347,9 +351,13 @@ def test_min_value_entropy_search_builder_raises_for_empty_data() -> None:
     builder = MinValueEntropySearch(search_space)
     with pytest.raises(tf.errors.InvalidArgumentError):
         builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), dataset=empty_data)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel())
     acq = builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), dataset=non_empty_data)
     with pytest.raises(tf.errors.InvalidArgumentError):
         builder.update_acquisition_function(acq, QuadraticMeanAndRBFKernel(), dataset=empty_data)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        builder.update_acquisition_function(acq, QuadraticMeanAndRBFKernel())
 
 
 @pytest.mark.parametrize("param", [-2, 0])
@@ -768,6 +776,8 @@ def test_expected_constrained_improvement_raises_for_empty_data(
 
     with pytest.raises(tf.errors.InvalidArgumentError):
         builder.prepare_acquisition_function(models_, datasets=data)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        builder.prepare_acquisition_function(models_)
 
 
 def test_expected_constrained_improvement_is_constraint_when_no_feasible_points() -> None:
@@ -836,6 +846,8 @@ def test_ehvi_builder_raises_for_empty_data() -> None:
 
     with pytest.raises(tf.errors.InvalidArgumentError):
         ExpectedHypervolumeImprovement().prepare_acquisition_function(model, dataset=dataset)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        ExpectedHypervolumeImprovement().prepare_acquisition_function(model, dataset)
 
 
 def test_ehvi_builder_builds_expected_hv_improvement_using_pareto_from_model() -> None:
@@ -1019,6 +1031,10 @@ def test_qehvi_builder_raises_for_empty_data() -> None:
         BatchMonteCarloExpectedHypervolumeImprovement(sample_size=100).prepare_acquisition_function(
             model,
             dataset=dataset,
+        )
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        BatchMonteCarloExpectedHypervolumeImprovement(sample_size=100).prepare_acquisition_function(
+            model,
         )
 
 
@@ -1242,6 +1258,8 @@ def test_batch_monte_carlo_expected_improvement_raises_for_empty_data() -> None:
     model = QuadraticMeanAndRBFKernel()
     with pytest.raises(tf.errors.InvalidArgumentError):
         builder.prepare_acquisition_function(model, dataset=data)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        builder.prepare_acquisition_function(model)
 
 
 def test_batch_monte_carlo_expected_improvement_raises_for_model_with_wrong_event_shape() -> None:
@@ -1352,6 +1370,10 @@ def test_locally_penalized_expected_improvement_builder_raises_for_empty_data() 
         LocalPenalizationAcquisitionFunction(search_space=space).prepare_acquisition_function(
             QuadraticMeanAndRBFKernel(),
             dataset=data,
+        )
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        LocalPenalizationAcquisitionFunction(search_space=space).prepare_acquisition_function(
+            QuadraticMeanAndRBFKernel(),
         )
 
 
@@ -1484,9 +1506,13 @@ def test_gibbon_builder_raises_for_empty_data() -> None:
     builder = GIBBON(search_space)
     with pytest.raises(tf.errors.InvalidArgumentError):
         builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), empty_data)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel())
     acq = builder.prepare_acquisition_function(QuadraticMeanAndRBFKernel(), non_empty_data)
     with pytest.raises(tf.errors.InvalidArgumentError):
         builder.update_acquisition_function(acq, QuadraticMeanAndRBFKernel(), empty_data)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        builder.update_acquisition_function(acq, QuadraticMeanAndRBFKernel())
 
 
 @pytest.mark.parametrize("param", [-2, 0])

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -169,7 +169,7 @@ def test_efficient_global_optimization(optimizer: AcquisitionOptimizer[Box]) -> 
     query_point = ego.acquire_single(search_space, model, dataset=data)
     npt.assert_allclose(query_point, [[1]], rtol=1e-4)
     assert not function._updated
-    query_point = ego.acquire(search_space, {OBJECTIVE: model}, datasets={OBJECTIVE: data})
+    query_point = ego.acquire(search_space, {OBJECTIVE: model})
     npt.assert_allclose(query_point, [[1]], rtol=1e-4)
     assert function._updated
 

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -92,7 +92,7 @@ def test_discrete_thompson_sampling_raises_for_invalid_models_keys(
     search_space = Box([-1], [1])
     rule = DiscreteThompsonSampling(100, 10)
     with pytest.raises(ValueError):
-        rule.acquire(search_space, datasets, models)
+        rule.acquire(search_space, models, datasets=datasets)
 
 
 @pytest.mark.parametrize("models", [{}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}])
@@ -110,7 +110,7 @@ def test_discrete_thompson_sampling_raises_for_invalid_dataset_keys(
     search_space = Box([-1], [1])
     rule = DiscreteThompsonSampling(10, 100)
     with pytest.raises(ValueError):
-        rule.acquire(search_space, datasets, models)
+        rule.acquire(search_space, models, datasets=datasets)
 
 
 @pytest.mark.parametrize("num_fourier_features", [None, 100])
@@ -125,7 +125,7 @@ def test_discrete_thompson_sampling_acquire_returns_correct_shape(
     model.kernel = (
         gpflow.kernels.RBF()
     )  # need a gpflow kernel object for random feature decompositions
-    query_points = ts.acquire_single(search_space, dataset, model)
+    query_points = ts.acquire_single(search_space, model, dataset=dataset)
 
     npt.assert_array_equal(query_points.shape, tf.constant([num_query_points, 2]))
 
@@ -161,10 +161,10 @@ def test_efficient_global_optimization(optimizer: AcquisitionOptimizer[Box]) -> 
     search_space = Box([-10], [10])
     ego = EfficientGlobalOptimization(function, optimizer)
     data, model = empty_dataset([1], [1]), QuadraticMeanAndRBFKernel(x_shift=1)
-    query_point = ego.acquire_single(search_space, data, model)
+    query_point = ego.acquire_single(search_space, model, dataset=data)
     npt.assert_allclose(query_point, [[1]], rtol=1e-4)
     assert not function._updated
-    query_point = ego.acquire(search_space, {OBJECTIVE: data}, {OBJECTIVE: model})
+    query_point = ego.acquire(search_space, {OBJECTIVE: model}, datasets={OBJECTIVE: data})
     npt.assert_allclose(query_point, [[1]], rtol=1e-4)
     assert function._updated
 
@@ -203,7 +203,9 @@ def test_joint_batch_acquisition_rule_acquire(
     ] = rule_fn(acq, num_query_points)
 
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
-    points_or_stateful = acq_rule.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
+    points_or_stateful = acq_rule.acquire_single(
+        search_space, QuadraticMeanAndRBFKernel(), dataset=dataset
+    )
     if callable(points_or_stateful):
         _, query_point = points_or_stateful(None)
     else:
@@ -270,7 +272,9 @@ def test_greedy_batch_acquisition_rule_acquire(
         State[TensorType, AsynchronousRuleState], Box
     ] = rule_fn(acq, num_query_points)
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
-    points_or_stateful = acq_rule.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
+    points_or_stateful = acq_rule.acquire_single(
+        search_space, QuadraticMeanAndRBFKernel(), dataset=dataset
+    )
     if callable(points_or_stateful):
         _, query_points = points_or_stateful(None)
     else:
@@ -278,7 +282,9 @@ def test_greedy_batch_acquisition_rule_acquire(
     assert acq._update_count == num_query_points - 1
     npt.assert_allclose(query_points, [[0.0, 0.0]] * num_query_points, atol=1e-3)
 
-    points_or_stateful = acq_rule.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
+    points_or_stateful = acq_rule.acquire_single(
+        search_space, QuadraticMeanAndRBFKernel(), dataset=dataset
+    )
     if callable(points_or_stateful):
         _, query_points = points_or_stateful(None)
     else:
@@ -329,7 +335,7 @@ def test_async_keeps_track_of_pending_points(
     search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
 
-    state_fn = async_rule.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())
+    state_fn = async_rule.acquire_single(search_space, QuadraticMeanAndRBFKernel(), dataset=dataset)
     state, point1 = state_fn(None)
     state, point2 = state_fn(state)
 
@@ -342,7 +348,9 @@ def test_async_keeps_track_of_pending_points(
         observations=tf.constant([[1]], dtype=tf.float32),
     )
     state_fn = async_rule.acquire_single(
-        search_space, dataset + new_observations, QuadraticMeanAndRBFKernel()
+        search_space,
+        QuadraticMeanAndRBFKernel(),
+        dataset=dataset + new_observations,
     )
     state, point3 = state_fn(state)
 
@@ -364,15 +372,15 @@ def test_trust_region_raises_for_missing_datasets_key(
     search_space = Box([-1], [1])
     rule = TrustRegion()
     with pytest.raises(KeyError):
-        rule.acquire(search_space, datasets, models)
+        rule.acquire(search_space, models, datasets=datasets)
 
 
 class _Midpoint(AcquisitionRule[TensorType, Box]):
     def acquire(
         self,
         search_space: Box,
-        datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> TensorType:
         return (search_space.upper[None] + search_space.lower[None]) / 2
 
@@ -393,7 +401,9 @@ def test_trust_region_for_default_state(
     upper_bound = tf.constant([1.3, 3.3])
     search_space = Box(lower_bound, upper_bound)
 
-    state, query_point = tr.acquire_single(search_space, dataset, QuadraticMeanAndRBFKernel())(None)
+    state, query_point = tr.acquire_single(
+        search_space, QuadraticMeanAndRBFKernel(), dataset=dataset
+    )(None)
 
     assert state is not None
     npt.assert_array_almost_equal(query_point, expected_query_point, 5)
@@ -425,7 +435,9 @@ def test_trust_region_successful_global_to_global_trust_region_unchanged(
     previous_state = TrustRegion.State(search_space, eps, previous_y_min, is_global)
 
     current_state, query_point = tr.acquire(
-        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}
+        search_space,
+        {OBJECTIVE: QuadraticMeanAndRBFKernel()},
+        datasets={OBJECTIVE: dataset},
     )(previous_state)
 
     assert current_state is not None
@@ -459,7 +471,9 @@ def test_trust_region_for_unsuccessful_global_to_local_trust_region_unchanged(
     previous_state = TrustRegion.State(acquisition_space, eps, previous_y_min, is_global)
 
     current_state, query_point = tr.acquire(
-        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}
+        search_space,
+        {OBJECTIVE: QuadraticMeanAndRBFKernel()},
+        datasets={OBJECTIVE: dataset},
     )(previous_state)
 
     assert current_state is not None
@@ -493,7 +507,9 @@ def test_trust_region_for_successful_local_to_global_trust_region_increased(
     previous_state = TrustRegion.State(acquisition_space, eps, previous_y_min, is_global)
 
     current_state, _ = tr.acquire(
-        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}
+        search_space,
+        {OBJECTIVE: QuadraticMeanAndRBFKernel()},
+        datasets={OBJECTIVE: dataset},
     )(previous_state)
 
     assert current_state is not None
@@ -526,7 +542,9 @@ def test_trust_region_for_unsuccessful_local_to_global_trust_region_reduced(
     previous_state = TrustRegion.State(acquisition_space, eps, previous_y_min, is_global)
 
     current_state, _ = tr.acquire(
-        search_space, {OBJECTIVE: dataset}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}
+        search_space,
+        {OBJECTIVE: QuadraticMeanAndRBFKernel()},
+        datasets={OBJECTIVE: dataset},
     )(previous_state)
 
     assert current_state is not None

--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -215,8 +215,8 @@ def test_ask_tell_optimizer_uses_specified_acquisition_state(
         def acquire(
             self,
             search_space: Box,
-            datasets: Mapping[str, Dataset],
             models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> State[int | None, TensorType]:
             def go(state: int | None) -> tuple[int | None, TensorType]:
                 self.states_received.append(state)

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -205,8 +205,8 @@ def test_bayesian_optimizer_uses_specified_acquisition_state(
         def acquire(
             self,
             search_space: Box,
-            datasets: Mapping[str, Dataset],
             models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> State[int | None, TensorType]:
             def go(state: int | None) -> tuple[int | None, TensorType]:
                 self.states_received.append(state)
@@ -277,8 +277,8 @@ class _BrokenRule(AcquisitionRule[NoReturn, SearchSpace]):
     def acquire(
         self,
         search_space: SearchSpace,
-        datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> NoReturn:
         raise _Whoops
 
@@ -334,8 +334,8 @@ def test_bayesian_optimizer_optimize_is_noop_for_zero_steps() -> None:
         def acquire(
             self,
             search_space: Box,
-            datasets: Mapping[str, Dataset],
             models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> NoReturn:
             assert False
 
@@ -370,8 +370,8 @@ def test_bayesian_optimizer_can_use_two_gprs_for_objective_defined_by_two_dimens
         def acquire(
             self,
             search_space: Box,
-            datasets: Mapping[str, Dataset],
             models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> State[int | None, TensorType]:
             def go(previous_state: int | None) -> tuple[int | None, TensorType]:
                 if previous_state is None:
@@ -436,8 +436,8 @@ def test_bayesian_optimizer_optimize_tracked_state() -> None:
         def acquire(
             self,
             search_space: Box,
-            datasets: Mapping[str, Dataset],
             models: Mapping[str, ProbabilisticModel],
+            datasets: Optional[Mapping[str, Dataset]] = None,
         ) -> State[int | None, TensorType]:
             def go(state: int | None) -> tuple[int | None, TensorType]:
                 new_state = 0 if state is None else state + 1

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Container, Mapping
-from typing import Any, Callable, NoReturn, Sequence, TypeVar, Union, cast
+from typing import Any, Callable, NoReturn, Optional, Sequence, TypeVar, Union, cast
 
 import numpy.testing as npt
 import tensorflow as tf
@@ -129,13 +129,13 @@ class FixedAcquisitionRule(AcquisitionRule[TensorType, SearchSpace]):
     def acquire(
         self,
         search_space: SearchSpace,
-        datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> TensorType:
         """
         :param search_space: Unused.
-        :param datasets: Unused.
         :param models: Unused.
+        :param datasets: Unused.
         :return: The fixed value specified on initialisation.
         """
         return self._qp

--- a/trieste/acquisition/combination.py
+++ b/trieste/acquisition/combination.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
+from typing import Optional
 
 import tensorflow as tf
 
@@ -47,7 +48,9 @@ class Reducer(AcquisitionFunctionBuilder):
         return ", ".join(map(repr, self._acquisitions))
 
     def prepare_acquisition_function(
-        self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+        self,
+        models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         r"""
         Return an acquisition function. This acquisition function is defined by first building
@@ -61,13 +64,15 @@ class Reducer(AcquisitionFunctionBuilder):
         :return: The reduced acquisition function.
         """
         functions = tuple(
-            acq.prepare_acquisition_function(datasets, models) for acq in self.acquisitions
+            acq.prepare_acquisition_function(models, datasets=datasets) for acq in self.acquisitions
         )
 
         def evaluate_acquisition_function_fn(at: TensorType) -> TensorType:
             return self._reduce_acquisition_functions(at, functions)
 
         return evaluate_acquisition_function_fn
+
+    # TODO: define update_acquisition_function to avoid unnecessary retracing
 
     @property
     def acquisitions(self) -> Sequence[AcquisitionFunctionBuilder]:

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -18,9 +18,8 @@ functions --- functions that estimate the utility of evaluating sets of candidat
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
 from itertools import combinations, product
-from typing import Callable, Optional, Union, cast
+from typing import Callable, Mapping, Optional, Union, cast
 
 import tensorflow as tf
 import tensorflow_probability as tfp

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -77,10 +77,11 @@ class AcquisitionFunctionBuilder(ABC):
         datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
-        Prepare an acquisition function.
+        Prepare an acquisition function. We assume that this requires at least models, but
+        it may sometimes also need data.
 
         :param models: The models for each tag.
-        :param datasets: The data from the observer. (optional)
+        :param datasets: The data from the observer (optional).
         :return: An acquisition function.
         """
 
@@ -98,7 +99,7 @@ class AcquisitionFunctionBuilder(ABC):
 
         :param function: The acquisition function to update.
         :param models: The models for each tag.
-        :param datasets: The data from the observer. (optional)
+        :param datasets: The data from the observer (optional).
         :return: The updated acquisition function.
         """
         return self.prepare_acquisition_function(models, datasets=datasets)
@@ -151,7 +152,7 @@ class SingleModelAcquisitionBuilder(ABC):
     ) -> AcquisitionFunction:
         """
         :param model: The model.
-        :param dataset: The data to use to build the acquisition function. (optional)
+        :param dataset: The data to use to build the acquisition function (optional).
         :return: An acquisition function.
         """
 
@@ -164,7 +165,7 @@ class SingleModelAcquisitionBuilder(ABC):
         """
         :param function: The acquisition function to update.
         :param model: The model.
-        :param dataset: The data from the observer. (optional)
+        :param dataset: The data from the observer (optional).
         :return: The updated acquisition function.
         """
         return self.prepare_acquisition_function(model, dataset=dataset)
@@ -1344,7 +1345,7 @@ class GreedyAcquisitionFunctionBuilder(ABC):
         unless that has been overridden.
 
         :param models: The models over each tag.
-        :param datasets: The data from the observer. (optional)
+        :param datasets: The data from the observer (optional).
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :return: An acquisition function.
@@ -1366,7 +1367,7 @@ class GreedyAcquisitionFunctionBuilder(ABC):
 
         :param function: The acquisition function to update.
         :param models: The models over each tag.
-        :param datasets: The data from the observer. (optional)
+        :param datasets: The data from the observer (optional).
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :param new_optimization_step: Indicates whether this call to update_acquisition_function
@@ -1436,7 +1437,7 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
     ) -> AcquisitionFunction:
         """
         :param model: The model.
-        :param dataset: The data from the observer. (optional)
+        :param dataset: The data from the observer (optional).
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :return: An acquisition function.
@@ -1453,7 +1454,7 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
         """
         :param function: The acquisition function to update.
         :param model: The model.
-        :param dataset: The data from the observer. (optional)
+        :param dataset: The data from the observer (optional).
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :param new_optimization_step: Indicates whether this call to update_acquisition_function

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -72,21 +72,23 @@ class AcquisitionFunctionBuilder(ABC):
 
     @abstractmethod
     def prepare_acquisition_function(
-        self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+        self,
+        models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
         Prepare an acquisition function.
 
-        :param datasets: The data from the observer.
-        :param models: The models over each dataset in ``datasets``.
+        :param models: The models for each tag.
+        :param datasets: The data from the observer. (optional)
         :return: An acquisition function.
         """
 
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
         Update an acquisition function. By default this generates a new acquisition function each
@@ -95,11 +97,11 @@ class AcquisitionFunctionBuilder(ABC):
         every optimization loop.
 
         :param function: The acquisition function to update.
-        :param datasets: The data from the observer.
-        :param models: The models over each dataset in ``datasets``.
+        :param models: The models for each tag.
+        :param datasets: The data from the observer. (optional)
         :return: The updated acquisition function.
         """
-        return self.prepare_acquisition_function(datasets, models)
+        return self.prepare_acquisition_function(models, datasets=datasets)
 
 
 class SingleModelAcquisitionBuilder(ABC):
@@ -118,18 +120,22 @@ class SingleModelAcquisitionBuilder(ABC):
 
         class _Anon(AcquisitionFunctionBuilder):
             def prepare_acquisition_function(
-                self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+                self,
+                models: Mapping[str, ProbabilisticModel],
+                datasets: Optional[Mapping[str, Dataset]] = None,
             ) -> AcquisitionFunction:
-                return single_builder.prepare_acquisition_function(datasets[tag], models[tag])
+                return single_builder.prepare_acquisition_function(
+                    models[tag], dataset=None if datasets is None else datasets[tag]
+                )
 
             def update_acquisition_function(
                 self,
                 function: AcquisitionFunction,
-                datasets: Mapping[str, Dataset],
                 models: Mapping[str, ProbabilisticModel],
+                datasets: Optional[Mapping[str, Dataset]] = None,
             ) -> AcquisitionFunction:
                 return single_builder.update_acquisition_function(
-                    function, datasets[tag], models[tag]
+                    function, models[tag], dataset=None if datasets is None else datasets[tag]
                 )
 
             def __repr__(self) -> str:
@@ -139,24 +145,29 @@ class SingleModelAcquisitionBuilder(ABC):
 
     @abstractmethod
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
-        :param dataset: The data to use to build the acquisition function.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data to use to build the acquisition function. (optional)
         :return: An acquisition function.
         """
 
     def update_acquisition_function(
-        self, function: AcquisitionFunction, dataset: Dataset, model: ProbabilisticModel
+        self,
+        function: AcquisitionFunction,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer. (optional)
         :return: The updated acquisition function.
         """
-        return self.prepare_acquisition_function(dataset, model)
+        return self.prepare_acquisition_function(model, dataset=dataset)
 
 
 class ExpectedImprovement(SingleModelAcquisitionBuilder):
@@ -170,30 +181,39 @@ class ExpectedImprovement(SingleModelAcquisitionBuilder):
         return "ExpectedImprovement()"
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
+        :param model: The model.
         :param dataset: The data from the observer. Must be populated.
-        :param model: The model over the specified ``dataset``.
         :return: The expected improvement function. This function will raise
             :exc:`ValueError` or :exc:`~tf.errors.InvalidArgumentError` if used with a batch size
             greater than one.
         :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         mean, _ = model.predict(dataset.query_points)
         eta = tf.reduce_min(mean, axis=0)
         return expected_improvement(model, eta)
 
     def update_acquisition_function(
-        self, function: AcquisitionFunction, dataset: Dataset, model: ProbabilisticModel
+        self,
+        function: AcquisitionFunction,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer.  Must be populated.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, expected_improvement), [])
         mean, _ = model.predict(dataset.query_points)
         eta = tf.reduce_min(mean, axis=0)
@@ -248,30 +268,39 @@ class AugmentedExpectedImprovement(SingleModelAcquisitionBuilder):
         return "AugmentedExpectedImprovement()"
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
+        :param model: The model.
         :param dataset: The data from the observer. Must be populated.
-        :param model: The model over the specified ``dataset``.
         :return: The expected improvement function. This function will raise
             :exc:`ValueError` or :exc:`~tf.errors.InvalidArgumentError` if used with a batch size
             greater than one.
         :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         mean, _ = model.predict(dataset.query_points)
         eta = tf.reduce_min(mean, axis=0)
         return augmented_expected_improvement(model, eta)
 
     def update_acquisition_function(
-        self, function: AcquisitionFunction, dataset: Dataset, model: ProbabilisticModel
+        self,
+        function: AcquisitionFunction,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer. Must be populated.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, augmented_expected_improvement), [])
         mean, _ = model.predict(dataset.query_points)
         eta = tf.reduce_min(mean, axis=0)
@@ -389,17 +418,21 @@ class MinValueEntropySearch(SingleModelAcquisitionBuilder):
         self._num_fourier_features = num_fourier_features
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
+        :param model: The model.
         :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
         :return: The max-value entropy search acquisition function modified for objective
             minimisation. This function will raise :exc:`ValueError` or
             :exc:`~tf.errors.InvalidArgumentError` if used with a batch size greater than one.
         :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
         query_points = self._search_space.sample(num_samples=self._grid_size)
         tf.debugging.assert_same_float_dtype([dataset.query_points, query_points])
@@ -415,14 +448,19 @@ class MinValueEntropySearch(SingleModelAcquisitionBuilder):
         return min_value_entropy_search(model, min_value_samples)
 
     def update_acquisition_function(
-        self, function: AcquisitionFunction, dataset: Dataset, model: ProbabilisticModel
+        self,
+        function: AcquisitionFunction,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
+        :param model: The model.
         :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, min_value_entropy_search), [])
 
         query_points = self._search_space.sample(num_samples=self._grid_size)
@@ -508,11 +546,13 @@ class NegativeLowerConfidenceBound(SingleModelAcquisitionBuilder):
         return f"NegativeLowerConfidenceBound({self._beta!r})"
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
+        :param model: The model.
         :param dataset: Unused.
-        :param model: The model over the specified ``dataset``.
         :return: The negative lower confidence bound function. This function will raise
             :exc:`ValueError` or :exc:`~tf.errors.InvalidArgumentError` if used with a batch size
             greater than one.
@@ -522,12 +562,15 @@ class NegativeLowerConfidenceBound(SingleModelAcquisitionBuilder):
         return tf.function(lambda at: -lcb(at))
 
     def update_acquisition_function(
-        self, function: AcquisitionFunction, dataset: Dataset, model: ProbabilisticModel
+        self,
+        function: AcquisitionFunction,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
+        :param model: The model.
         :param dataset: Unused.
-        :param model: The model over the specified ``dataset``.
         """
         return function  # no need to update anything
 
@@ -613,11 +656,13 @@ class ProbabilityOfFeasibility(SingleModelAcquisitionBuilder):
         return self._threshold
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
+        :param model: The model.
         :param dataset: Unused.
-        :param model: The model over the specified ``dataset``.
         :return: The probability of feasibility function. This function will raise
             :exc:`ValueError` or :exc:`~tf.errors.InvalidArgumentError` if used with a batch size
             greater than one.
@@ -625,12 +670,15 @@ class ProbabilityOfFeasibility(SingleModelAcquisitionBuilder):
         return probability_of_feasibility(model, self.threshold)
 
     def update_acquisition_function(
-        self, function: AcquisitionFunction, dataset: Dataset, model: ProbabilisticModel
+        self,
+        function: AcquisitionFunction,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
+        :param model: The model.
         :param dataset: Unused.
-        :param model: The model over the specified ``dataset``.
         """
         return function  # no need to update anything
 
@@ -718,17 +766,22 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
         )
 
     def prepare_acquisition_function(
-        self, datasets: Mapping[str, Dataset], models: Mapping[str, ProbabilisticModel]
+        self,
+        models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
+        :param models: The models over each tag.
         :param datasets: The data from the observer.
-        :param models: The models over each dataset in ``datasets``.
         :return: The expected constrained improvement acquisition function. This function will raise
             :exc:`ValueError` or :exc:`~tf.errors.InvalidArgumentError` if used with a batch size
             greater than one.
         :raise KeyError: If `objective_tag` is not found in ``datasets`` and ``models``.
         :raise tf.errors.InvalidArgumentError: If the objective data is empty.
         """
+        tf.debugging.Assert(datasets is not None, [])
+        assert datasets is not None
+
         objective_model = models[self._objective_tag]
         objective_dataset = datasets[self._objective_tag]
 
@@ -739,7 +792,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
         )
 
         self._constraint_fn = self._constraint_builder.prepare_acquisition_function(
-            datasets, models
+            models, datasets=datasets
         )
         pof = self._constraint_fn(objective_dataset.query_points[:, None, ...])
         is_feasible = tf.squeeze(pof >= self._min_feasibility_probability, axis=-1)
@@ -763,14 +816,17 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
+        :param models: The models for each tag.
         :param datasets: The data from the observer.
-        :param models: The models over each dataset in ``datasets``.
         """
+        tf.debugging.Assert(datasets is not None, [])
+        assert datasets is not None
+
         objective_model = models[self._objective_tag]
         objective_dataset = datasets[self._objective_tag]
 
@@ -782,7 +838,9 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
         tf.debugging.Assert(self._constraint_fn is not None, [])
 
         constraint_fn = cast(AcquisitionFunction, self._constraint_fn)
-        self._constraint_builder.update_acquisition_function(constraint_fn, datasets, models)
+        self._constraint_builder.update_acquisition_function(
+            constraint_fn, models, datasets=datasets
+        )
         pof = constraint_fn(objective_dataset.query_points[:, None, ...])
         is_feasible = tf.squeeze(pof >= self._min_feasibility_probability, axis=-1)
 
@@ -835,13 +893,17 @@ class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder):
         return "ExpectedHypervolumeImprovement()"
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
+        :param model: The model.
         :param dataset: The data from the observer. Must be populated.
-        :param model: The model over the specified ``dataset``.
         :return: The expected hypervolume improvement acquisition function.
         """
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         mean, _ = model.predict(dataset.query_points)
 
@@ -853,13 +915,18 @@ class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder):
         return expected_hv_improvement(model, _partition_bounds)
 
     def update_acquisition_function(
-        self, function: AcquisitionFunction, dataset: Dataset, model: ProbabilisticModel
+        self,
+        function: AcquisitionFunction,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer. Must be populated.
         """
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, expected_hv_improvement), [])
         mean, _ = model.predict(dataset.query_points)
@@ -1011,14 +1078,17 @@ class BatchMonteCarloExpectedHypervolumeImprovement(SingleModelAcquisitionBuilde
         )
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
+        :param model: The model. Must have event shape [1].
         :param dataset: The data from the observer. Must be populated.
-        :param model: The model over the specified ``dataset``. Must have event shape [1].
         :return: The batch expected hypervolume improvement acquisition function.
         """
-
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         mean, _ = model.predict(dataset.query_points)
 
@@ -1175,16 +1245,20 @@ class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder):
         return f"BatchMonteCarloExpectedImprovement({self._sample_size!r}, jitter={self._jitter!r})"
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
+        :param model: The model. Must have event shape [1].
         :param dataset: The data from the observer. Must be populated.
-        :param model: The model over the specified ``dataset``. Must have event shape [1].
         :return: The batch *expected improvement* acquisition function.
         :raise ValueError (or InvalidArgumentError): If ``dataset`` is not populated, or ``model``
             does not have an event shape of [1].
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
         mean, _ = model.predict(dataset.query_points)
 
@@ -1196,14 +1270,19 @@ class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder):
         return batch_monte_carlo_expected_improvement(self._sample_size, model, eta, self._jitter)
 
     def update_acquisition_function(
-        self, function: AcquisitionFunction, dataset: Dataset, model: ProbabilisticModel
+        self,
+        function: AcquisitionFunction,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model. Must have event shape [1].
+        :param dataset: The data from the observer. Must be populated.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, batch_monte_carlo_expected_improvement), [])
         mean, _ = model.predict(dataset.query_points)
         eta = tf.reduce_min(mean, axis=0)
@@ -1255,8 +1334,8 @@ class GreedyAcquisitionFunctionBuilder(ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
         """
@@ -1264,8 +1343,8 @@ class GreedyAcquisitionFunctionBuilder(ABC):
         will be `None`. Subsequent calls will be via ``update_acquisition_funcion`` below,
         unless that has been overridden.
 
-        :param datasets: The data from the observer.
-        :param models: The models over each dataset in ``datasets``.
+        :param models: The models over each tag.
+        :param datasets: The data from the observer. (optional)
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :return: An acquisition function.
@@ -1274,8 +1353,8 @@ class GreedyAcquisitionFunctionBuilder(ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        datasets: Mapping[str, Dataset],
         models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
     ) -> AcquisitionFunction:
@@ -1286,8 +1365,8 @@ class GreedyAcquisitionFunctionBuilder(ABC):
         every optimization loop.
 
         :param function: The acquisition function to update.
-        :param datasets: The data from the observer.
-        :param models: The models over each dataset in ``datasets``.
+        :param models: The models over each tag.
+        :param datasets: The data from the observer. (optional)
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :param new_optimization_step: Indicates whether this call to update_acquisition_function
@@ -1295,7 +1374,9 @@ class GreedyAcquisitionFunctionBuilder(ABC):
             for the current step. Defaults to ``True``.
         :return: The updated acquisition function.
         """
-        return self.prepare_acquisition_function(datasets, models, pending_points=pending_points)
+        return self.prepare_acquisition_function(
+            models, datasets=datasets, pending_points=pending_points
+        )
 
 
 class SingleModelGreedyAcquisitionBuilder(ABC):
@@ -1315,26 +1396,28 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
         class _Anon(GreedyAcquisitionFunctionBuilder):
             def prepare_acquisition_function(
                 self,
-                datasets: Mapping[str, Dataset],
                 models: Mapping[str, ProbabilisticModel],
+                datasets: Optional[Mapping[str, Dataset]] = None,
                 pending_points: Optional[TensorType] = None,
             ) -> AcquisitionFunction:
                 return single_builder.prepare_acquisition_function(
-                    datasets[tag], models[tag], pending_points=pending_points
+                    models[tag],
+                    dataset=None if datasets is None else datasets[tag],
+                    pending_points=pending_points,
                 )
 
             def update_acquisition_function(
                 self,
                 function: AcquisitionFunction,
-                datasets: Mapping[str, Dataset],
                 models: Mapping[str, ProbabilisticModel],
+                datasets: Optional[Mapping[str, Dataset]] = None,
                 pending_points: Optional[TensorType] = None,
                 new_optimization_step: bool = True,
             ) -> AcquisitionFunction:
                 return single_builder.update_acquisition_function(
                     function,
-                    datasets[tag],
                     models[tag],
+                    dataset=None if datasets is None else datasets[tag],
                     pending_points=pending_points,
                     new_optimization_step=new_optimization_step,
                 )
@@ -1347,13 +1430,13 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        dataset: Dataset,
         model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
         """
-        :param dataset: The data to use to build the acquisition function.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer. (optional)
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :return: An acquisition function.
@@ -1362,15 +1445,15 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        dataset: Dataset,
         model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer. (optional)
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :param new_optimization_step: Indicates whether this call to update_acquisition_function
@@ -1379,8 +1462,8 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
         :return: The updated acquisition function.
         """
         return self.prepare_acquisition_function(
-            dataset,
             model,
+            dataset=dataset,
             pending_points=pending_points,
         )
 
@@ -1451,18 +1534,20 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
 
     def prepare_acquisition_function(
         self,
-        dataset: Dataset,
         model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
         """
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer. Must be populated.
         :param pending_points: The points we penalize with respect to.
         :return: The (log) expected improvement penalized with respect to the pending points.
         :raise tf.errors.InvalidArgumentError: If the ``dataset`` is empty.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
         acq = self._update_base_acquisition_function(dataset, model)
         if pending_points is not None and len(pending_points) != 0:
@@ -1473,15 +1558,15 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        dataset: Dataset,
         model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer. Must be populated.
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :param new_optimization_step: Indicates whether this call to update_acquisition_function
@@ -1489,7 +1574,9 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
             for the current step. Defaults to ``True``.
         :return: The updated acquisition function.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(self._base_acquisition_function is not None, [])
 
         if new_optimization_step:
@@ -1560,7 +1647,9 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
 
         if self._base_acquisition_function is not None:
             self._base_acquisition_function = self._base_builder.update_acquisition_function(
-                self._base_acquisition_function, dataset, model
+                self._base_acquisition_function,
+                model,
+                dataset=dataset,
             )
         elif isinstance(self._base_builder, ExpectedImprovement):  # reuse eta estimate
             self._base_acquisition_function = cast(
@@ -1568,7 +1657,8 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
             )
         else:
             self._base_acquisition_function = self._base_builder.prepare_acquisition_function(
-                dataset, model
+                model,
+                dataset=dataset,
             )
         return self._base_acquisition_function
 
@@ -1787,18 +1877,20 @@ class GIBBON(SingleModelGreedyAcquisitionBuilder):
 
     def prepare_acquisition_function(
         self,
-        dataset: Dataset,
         model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
         """
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer. Must be populated.
         :param pending_points: The points we penalize with respect to.
         :return: The GIBBON acquisition function modified for objective minimisation.
         :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
         acq = self._update_quality_term(dataset, model)
         if pending_points is not None and len(pending_points) != 0:
@@ -1809,15 +1901,15 @@ class GIBBON(SingleModelGreedyAcquisitionBuilder):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        dataset: Dataset,
         model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
-        :param dataset: The data from the observer.
-        :param model: The model over the specified ``dataset``.
+        :param model: The model.
+        :param dataset: The data from the observer. Must be populated.
         :param pending_points: Points already chosen to be in the current batch (of shape [M,D]),
             where M is the number of pending points and D is the search space dimension.
         :param new_optimization_step: Indicates whether this call to update_acquisition_function
@@ -1825,7 +1917,9 @@ class GIBBON(SingleModelGreedyAcquisitionBuilder):
             for the current step. Defaults to ``True``.
         :return: The updated acquisition function.
         """
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.Assert(dataset is not None, [])
+        assert dataset is not None
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(self._quality_term is not None, [])
 
         if new_optimization_step:
@@ -1870,7 +1964,7 @@ class GIBBON(SingleModelGreedyAcquisitionBuilder):
     def _update_quality_term(
         self, dataset: Dataset, model: ProbabilisticModel
     ) -> AcquisitionFunction:
-        tf.debugging.assert_positive(len(dataset))
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
         query_points = self._search_space.sample(num_samples=self._grid_size)
         tf.debugging.assert_same_float_dtype([dataset.query_points, query_points])
@@ -2117,11 +2211,13 @@ class PredictiveVariance(SingleModelAcquisitionBuilder):
         return f"PredictiveVariance(jitter={self._jitter!r})"
 
     def prepare_acquisition_function(
-        self, dataset: Dataset, model: ProbabilisticModel
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
+        :param model: The model.
         :param dataset: Unused.
-        :param model: The model over the specified ``dataset``.
 
         :return: The determinant of the predictive function.
         """
@@ -2129,12 +2225,15 @@ class PredictiveVariance(SingleModelAcquisitionBuilder):
         return predictive_variance(model, self._jitter)
 
     def update_acquisition_function(
-        self, function: AcquisitionFunction, dataset: Dataset, model: ProbabilisticModel
+        self,
+        function: AcquisitionFunction,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
+        :param model: The model.
         :param dataset: Unused.
-        :param model: The model over the specified ``dataset``.
         """
         return function  # no need to update anything
 

--- a/trieste/acquisition/function.py
+++ b/trieste/acquisition/function.py
@@ -195,7 +195,7 @@ class ExpectedImprovement(SingleModelAcquisitionBuilder):
         :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         mean, _ = model.predict(dataset.query_points)
         eta = tf.reduce_min(mean, axis=0)
@@ -213,7 +213,7 @@ class ExpectedImprovement(SingleModelAcquisitionBuilder):
         :param dataset: The data from the observer.  Must be populated.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, expected_improvement), [])
         mean, _ = model.predict(dataset.query_points)
@@ -282,7 +282,7 @@ class AugmentedExpectedImprovement(SingleModelAcquisitionBuilder):
         :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         mean, _ = model.predict(dataset.query_points)
         eta = tf.reduce_min(mean, axis=0)
@@ -300,7 +300,7 @@ class AugmentedExpectedImprovement(SingleModelAcquisitionBuilder):
         :param dataset: The data from the observer. Must be populated.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, augmented_expected_improvement), [])
         mean, _ = model.predict(dataset.query_points)
@@ -432,7 +432,7 @@ class MinValueEntropySearch(SingleModelAcquisitionBuilder):
         :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
         query_points = self._search_space.sample(num_samples=self._grid_size)
@@ -460,7 +460,7 @@ class MinValueEntropySearch(SingleModelAcquisitionBuilder):
         :param dataset: The data from the observer.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, min_value_entropy_search), [])
 
@@ -781,7 +781,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
         :raise tf.errors.InvalidArgumentError: If the objective data is empty.
         """
         tf.debugging.Assert(datasets is not None, [])
-        assert datasets is not None
+        datasets = cast(Mapping[str, Dataset], datasets)
 
         objective_model = models[self._objective_tag]
         objective_dataset = datasets[self._objective_tag]
@@ -826,7 +826,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
         :param datasets: The data from the observer.
         """
         tf.debugging.Assert(datasets is not None, [])
-        assert datasets is not None
+        datasets = cast(Mapping[str, Dataset], datasets)
 
         objective_model = models[self._objective_tag]
         objective_dataset = datasets[self._objective_tag]
@@ -904,7 +904,7 @@ class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder):
         :return: The expected hypervolume improvement acquisition function.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         mean, _ = model.predict(dataset.query_points)
 
@@ -927,7 +927,7 @@ class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder):
         :param dataset: The data from the observer. Must be populated.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, expected_hv_improvement), [])
         mean, _ = model.predict(dataset.query_points)
@@ -1089,7 +1089,7 @@ class BatchMonteCarloExpectedHypervolumeImprovement(SingleModelAcquisitionBuilde
         :return: The batch expected hypervolume improvement acquisition function.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         mean, _ = model.predict(dataset.query_points)
 
@@ -1258,7 +1258,7 @@ class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder):
             does not have an event shape of [1].
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
         mean, _ = model.predict(dataset.query_points)
@@ -1282,7 +1282,7 @@ class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder):
         :param dataset: The data from the observer. Must be populated.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(isinstance(function, batch_monte_carlo_expected_improvement), [])
         mean, _ = model.predict(dataset.query_points)
@@ -1547,7 +1547,7 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
         :raise tf.errors.InvalidArgumentError: If the ``dataset`` is empty.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
         acq = self._update_base_acquisition_function(dataset, model)
@@ -1576,7 +1576,7 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
         :return: The updated acquisition function.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(self._base_acquisition_function is not None, [])
 
@@ -1890,7 +1890,7 @@ class GIBBON(SingleModelGreedyAcquisitionBuilder):
         :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
         acq = self._update_quality_term(dataset, model)
@@ -1919,7 +1919,7 @@ class GIBBON(SingleModelGreedyAcquisitionBuilder):
         :return: The updated acquisition function.
         """
         tf.debugging.Assert(dataset is not None, [])
-        assert dataset is not None
+        dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(self._quality_term is not None, [])
 

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -72,7 +72,8 @@ class AcquisitionRule(ABC, Generic[T_co, SP_contra]):
         """
         Return a value of type `T_co`. Typically this will be a set of query points, either on its
         own as a `TensorType` (see e.g. :class:`EfficientGlobalOptimization`), or within some
-        context (see e.g. :class:`TrustRegion`).
+        context (see e.g. :class:`TrustRegion`). We assume that this requires at least models, but
+        it may sometimes also need data.
 
         **Type hints:**
           - The search space must be a :class:`~trieste.space.SearchSpace`. The exact type of
@@ -80,7 +81,7 @@ class AcquisitionRule(ABC, Generic[T_co, SP_contra]):
 
         :param search_space: The local acquisition search space for *this step*.
         :param models: The model for each tag.
-        :param datasets: The known observer query points and observations for each tag. (optional)
+        :param datasets: The known observer query points and observations for each tag (optional).
         :return: A value of type `T_co`.
         """
 
@@ -96,7 +97,7 @@ class AcquisitionRule(ABC, Generic[T_co, SP_contra]):
         :param search_space: The global search space over which the optimization problem
             is defined.
         :param model: The model to use.
-        :param dataset: The known observer query points and observations. (optional)
+        :param dataset: The known observer query points and observations (optional).
         :return: A value of type `T_co`.
         """
         if isinstance(dataset, dict) or isinstance(model, dict):
@@ -184,7 +185,8 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
         (see :meth:`__init__`).
         :param search_space: The local acquisition search space for *this step*.
         :param models: The model for each tag.
-        :param datasets: The known observer query points and observations. (optional)
+        :param datasets: The known observer query points and observations. Whether this is required
+            depends on the acquisition function used.
         :return: The single (or batch of) points to query.
         """
         if self._acquisition_function is None:

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -189,11 +189,14 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
         """
         if self._acquisition_function is None:
             self._acquisition_function = self._builder.prepare_acquisition_function(
-                datasets, models
+                models,
+                datasets=datasets,
             )
         else:
             self._acquisition_function = self._builder.update_acquisition_function(
-                self._acquisition_function, datasets, models
+                self._acquisition_function,
+                models,
+                datasets=datasets,
             )
 
         points = self._optimizer(search_space, self._acquisition_function)
@@ -204,8 +207,8 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
             ):  # greedily allocate remaining batch elements
                 self._acquisition_function = self._builder.update_acquisition_function(
                     self._acquisition_function,
-                    datasets,
                     models,
+                    datasets=datasets,
                     pending_points=points,
                     new_optimization_step=False,
                 )
@@ -405,11 +408,14 @@ class AsynchronousOptimization(
 
         if self._acquisition_function is None:
             self._acquisition_function = self._builder.prepare_acquisition_function(
-                datasets, models
+                models,
+                datasets=datasets,
             )
         else:
             self._acquisition_function = self._builder.update_acquisition_function(
-                self._acquisition_function, datasets, models
+                self._acquisition_function,
+                models,
+                datasets=datasets,
             )
 
         def state_func(
@@ -559,11 +565,16 @@ class AsynchronousGreedy(
 
             if self._acquisition_function is None:
                 self._acquisition_function = self._builder.prepare_acquisition_function(
-                    datasets, models, state.pending_points
+                    models,
+                    datasets=datasets,
+                    pending_points=state.pending_points,
                 )
             else:
                 self._acquisition_function = self._builder.update_acquisition_function(
-                    self._acquisition_function, datasets, models, state.pending_points
+                    self._acquisition_function,
+                    models,
+                    datasets=datasets,
+                    pending_points=state.pending_points,
                 )
 
             new_points_batch = self._optimizer(search_space, self._acquisition_function)
@@ -573,8 +584,8 @@ class AsynchronousGreedy(
                 # greedily allocate additional batch elements
                 self._acquisition_function = self._builder.update_acquisition_function(
                     self._acquisition_function,
-                    datasets,
                     models,
+                    datasets=datasets,
                     pending_points=state.pending_points,
                     new_optimization_step=False,
                 )

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -183,6 +183,7 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
         """
         Return the query point(s) that optimizes the acquisition function produced by ``builder``
         (see :meth:`__init__`).
+
         :param search_space: The local acquisition search space for *this step*.
         :param models: The model for each tag.
         :param datasets: The known observer query points and observations. Whether this is required

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -261,7 +261,7 @@ class AskTellOptimizer(Generic[SP]):
         # so code below is needed to cater for both cases
 
         points_or_stateful = self._acquisition_rule.acquire(
-            self._search_space, self._datasets, self._models
+            self._search_space, self._models, datasets=self._datasets
         )
 
         if callable(points_or_stateful):

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -364,7 +364,9 @@ class BayesianOptimizer(Generic[SP]):
                         model.update(dataset)
                         model.optimize(dataset)
 
-                points_or_stateful = acquisition_rule.acquire(self._search_space, datasets, models)
+                points_or_stateful = acquisition_rule.acquire(
+                    self._search_space, models, datasets=datasets
+                )
 
                 if callable(points_or_stateful):
                     acquisition_state, query_points = points_or_stateful(acquisition_state)


### PR DESCRIPTION
Update `AcquisitionRule.acquire` and the various  `prepare_acquisition_function` and `update_acquisition_function` acquisition function builder methods so that dataset is an optional keyword argument. Some builders and rules insist on data being present; others don't.