### PR TITLE
Remove superfluous quality checks and update docs README

### DIFF
--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -48,16 +48,6 @@ jobs:
     - run: pip install tox
     - run: tox -e tests
 
-  notebooks:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - run: pip install tox
-    - run: tox -e notebooks
-
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,15 +9,46 @@ $ tox -e docs
 
 Open `docs/_build/html/index.html` in a browser to view the docs.
 
+Alternatively, to build the docs in a virtual environment rather than using tox, first ensure you
+have the necessary requirements installed:
+
+```bash
+$ pip install -r notebooks/requirements.txt
+$ pip install -r docs/requirements.txt
+```
+
+And then run `make html` in the `docs` subdirectory.
+
 ### Fixing documentation build errors
 
 Any errors in the notebooks or API documentation markup will result in documentation
-build errors that must be fixed. To fix these, ensure that all new documentation is valid [reST markup](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
+build errors that must be fixed. To fix these, ensure that all new documentation is valid
+[reST markup](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
 
 Note that since the API documentation is generated from inline Python docstrings, 
 **the line numbers in any API error logs refer to generated reST files,
 not the original Python source files**. You can find these generated reST files
 at `docs/autoapi`.
+
+### Building just parts of the documentation
+
+To save time, you can build just the API documentation (ignoring the notebooks) by
+setting up a virtual environment as described above and running the following from the
+`docs` subdirectory. Note that this will report warnings about the missing notebooks,
+which you can ignore.
+
+```bash
+sphinx-build -M html . _build -D exclude_patterns=_build,Thumbs.db,.DS_Store,notebooks
+```
+
+The easiest way to test a specific notebook for *Python errors* is to run it with `python`
+or in `jupyter-notebook`, as described in the [notebooks README](notebooks/README.md). However,
+if you wish to build the documentation for a specific notebook, you can run something like
+the following command to exclude all other notebooks and the API documentation:
+
+```bash
+sphinx-build -M html . _build -D autoapi_dirs= -D exclude_patterns=_build,Thumbs.db,.DS_Store,notebooks/[a-su-z]*
+```
 
 # License
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,6 @@ commands =
     tests: pytest
     alltests: pip install . -r tests/requirements.txt -c tests/constraints.txt
     alltests: pytest --runslow yes
-    notebooks: pip install . -r notebooks/requirements.txt -c notebooks/constraints.txt
-    notebooks: bash -c "res=0; for f in notebooks/*.py; do python "$f" || res=$?; done; $(exit $res)"
     docs: pip install . -r notebooks/requirements.txt -c notebooks/constraints.txt
     docs: pip install -r docs/requirements.txt -c docs/constraints.txt
-    docs: bash -c "cd docs; make html; make html"
+    docs: bash -c "cd docs; make html"


### PR DESCRIPTION
The GitHub merge checks are now taking far too long. Speedups implemented so far:

1. Remove the notebook check, as that's subsumed by the docs check (the former just executes the python in the notebooks, while the latter also generates the docs).
2. Make the tox docs build rune make html just once. We were running it twice before due to bibtex which isn't important for finding errors; we'll still run it twice when we deploy new documentation (not 100% sure it's necessary but no harm).
3. Add some notes in the docs README about how to generate the API docs without running the notebooks at all, which could save people lots of time when debugging docs issues.