### PR TITLE
Fixed to get new_point_score for acquisition from optimization result

### DIFF
--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -196,7 +196,7 @@ def generate_continuous_optimizer(
                 successful_optimization = True
 
                 new_point = variable  # [1, D]
-                new_point_score = target_func(new_point[:, None, :])  # [1, 1]
+                new_point_score = -opt_result.fun  # [1, 1]
 
                 if new_point_score > chosen_point_score:  # if found a better point then keep
                     chosen_point = new_point  # [1, D]


### PR DESCRIPTION
Compiling the `target_func` in the acquisition optimizer can cause things to break when calling the `target_func` to obtain the `chosen_point_score`. This PR changes it so that we get the `chosen_point_score` directly from the Scipy optimizer.