### PR TITLE
Fix description of the failure dataset

### DIFF
--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -55,7 +55,7 @@ fig.show()
 #   - one containing only those query_points and observations where the observations are finite.
 #     We'll label this with `OBJECTIVE`.
 #   - the other containing all the query points, but whose observations indicate if evaluating the
-#     observer failed at that point, using `1` if the evaluation failed, else `0`. We'll label this
+#     observer failed at that point, using `0` if the evaluation failed, else `1`. We'll label this
 #     with `FAILURE`.
 #
 # Let's define an observer that outputs the data in these formats.


### PR DESCRIPTION
In the notebook that shows how to model failure regions, when describing the failure dataset, the code assigns labels in the opposite way compared to what the text says. But it seems that the code is actually correct, so we only need to fix the text.