### PR TITLE
Fix optimizer bug in VGP models

### DIFF
--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -377,6 +377,10 @@ def test_vgp_raises_for_invalid_init() -> None:
         optimizer = Optimizer(gpflow.optimizers.Scipy())
         VariationalGaussianProcess(vgp_model(x, y), optimizer=optimizer, use_natgrads=True)
 
+    with pytest.raises(ValueError):
+        optimizer = BatchOptimizer(gpflow.optimizers.Scipy())
+        VariationalGaussianProcess(vgp_model(x, y), optimizer=optimizer, use_natgrads=True)
+
 
 def test_vgp_update_updates_num_data() -> None:
     x_np = np.arange(5, dtype=np.float64).reshape(-1, 1)

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -71,7 +71,7 @@ class GaussianProcessRegression(GPflowPredictor, TrainableProbabilisticModel):
         # GPflow stores the data in Tensors. However, since we want to be able to update the data
         # without having to retrace the acquisition functions, put it in Variables instead.
         # Data has to be stored in variables with dynamic shape to allow for changes
-        # Sometimes, for instance after serialization-deserialization, the shape can be overriden
+        # Sometimes, for instance after serialization-deserialization, the shape can be overridden
         # Thus here we ensure data is stored in dynamic shape Variables
 
         if all(isinstance(x, tf.Variable) and x.shape[0] is None for x in self._model.data):
@@ -337,11 +337,11 @@ class VariationalGaussianProcess(GPflowPredictor, TrainableProbabilisticModel):
         self._model = model
 
         if use_natgrads:
-            if not isinstance(self._optimizer, BatchOptimizer):
+            if not isinstance(self._optimizer.optimizer, tf.optimizers.Optimizer):
                 raise ValueError(
                     f"""
-                    Natgrads can only be used alongside an optimizer from tf.optimizers however
-                    received f{self._optimizer}
+                    Natgrads can only be used alongside an optimizer built from tf.optimizers
+                    however received f{self._optimizer}.
                     """
                 )
 
@@ -401,7 +401,7 @@ class VariationalGaussianProcess(GPflowPredictor, TrainableProbabilisticModel):
         f_mu, f_cov = self.model.predict_f(dataset.query_points, full_cov=True)  # [N, L], [L, N, N]
 
         # GPflow's VGP model is hard-coded to use the whitened representation, i.e.
-        # q_mu and q_sqrt parametrise q(v), and u = f(X) = L v, where L = cholesky(K(X, X))
+        # q_mu and q_sqrt parametrize q(v), and u = f(X) = L v, where L = cholesky(K(X, X))
         # Hence we need to back-transform from f_mu and f_cov to obtain the updated
         # new_q_mu and new_q_sqrt:
         Knn = model.kernel(dataset.query_points, full_cov=True)  # [N, N]

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -323,7 +323,8 @@ class VariationalGaussianProcess(GPflowPredictor, TrainableProbabilisticModel):
         """
         :param model: The GPflow :class:`~gpflow.models.VGP`.
         :param optimizer: The optimizer with which to train the model. Defaults to
-            :class:`~trieste.models.optimizer.Optimizer` with :class:`~gpflow.optimizers.Scipy`.
+            :class:`~trieste.models.optimizer.BatchOptimizer` with :class:`~tf.optimizers.Adam` with
+            batch size 100.
         :param use_natgrads: If True then alternate model optimization steps with natural
             gradient updates. Note that natural gradients requires
             an :class:`~trieste.models.optimizer.Optimizer` optimizer.
@@ -333,6 +334,10 @@ class VariationalGaussianProcess(GPflowPredictor, TrainableProbabilisticModel):
             optimizer.
         """
         tf.debugging.assert_rank(model.q_sqrt, 3)
+
+        if optimizer is None:
+            optimizer = BatchOptimizer(tf.optimizers.Adam(), batch_size=100)
+
         super().__init__(optimizer)
         self._model = model
 


### PR DESCRIPTION
After model optimizer refactor, a bug was introduced that raises a spurious error message.  We require the **base** optimizer of an optimzer to be a tensorflow one (i.e. not scipy), however we were checking that the optimizer itself BatchOptimizer instead.

I have also added a valid default for the VGP optimizer. Before, it was defaulting to a scipy optimizer.

Also included an extra test to make sure this doesn't happen again. 


