### PR TITLE
fix `TaggedProductSearchSpace.dimension()` to return the correct type

### DIFF
--- a/trieste/space.py
+++ b/trieste/space.py
@@ -457,7 +457,7 @@ class TaggedProductSearchSpace(SearchSpace):
     @property
     def dimension(self) -> int:
         """The number of inputs in this product search space."""
-        return self._dimension
+        return int(self._dimension)
 
     def get_subspace(self, tag: str) -> SearchSpace:
         """


### PR DESCRIPTION
All `SearchSpace.dimension()` implementations are supposed to return an `int`.
`TaggedProductSearchSpace.dimension()` was returning a tensor instead, which can cause type issues in calling code.