### PR TITLE
Don't swallow return code in quickdocs task

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,4 +44,4 @@ commands =
     docs: bash -c "cd docs; make html"
     quickdocs: pip install . -r notebooks/requirements.txt -c notebooks/constraints.txt
     quickdocs: pip install -r docs/requirements.txt -c docs/constraints.txt
-    quickdocs: bash -c "cd docs; python notebooks/quickrun/quickrun.py; if make html; then python notebooks/quickrun/quickrun.py --revert; else python notebooks/quickrun/quickrun.py --revert; exit1; fi"
+    quickdocs: bash -c "cd docs; python notebooks/quickrun/quickrun.py; if make html; then python notebooks/quickrun/quickrun.py --revert; else python notebooks/quickrun/quickrun.py --revert; exit 1; fi"

--- a/tox.ini
+++ b/tox.ini
@@ -44,4 +44,4 @@ commands =
     docs: bash -c "cd docs; make html"
     quickdocs: pip install . -r notebooks/requirements.txt -c notebooks/constraints.txt
     quickdocs: pip install -r docs/requirements.txt -c docs/constraints.txt
-    quickdocs: bash -c "cd docs; python notebooks/quickrun/quickrun.py; make html; python notebooks/quickrun/quickrun.py --revert"
+    quickdocs: bash -c "cd docs; python notebooks/quickrun/quickrun.py; if make html; then python notebooks/quickrun/quickrun.py --revert; else python notebooks/quickrun/quickrun.py --revert; exit1; fi"


### PR DESCRIPTION
Turns out the quickdocs tox task was swallowing the return code, meaning it would never mark a build as failed!

This fixes that using an if-then-else. There might be a shorter way to do this by capturing $@, but I'd rather write as little bash as possible and this way is simpler.