### PR TITLE
Make AcquisitionFunctionBuilder generic on ProbabilisticModel

### DIFF
--- a/tests/unit/acquisition/function/test_function.py
+++ b/tests/unit/acquisition/function/test_function.py
@@ -394,7 +394,7 @@ def test_expected_constrained_improvement_raises_for_invalid_batch_size(at: Tens
 
 
 def test_expected_constrained_improvement_can_reproduce_expected_improvement() -> None:
-    class _Certainty(AcquisitionFunctionBuilder):
+    class _Certainty(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             models: Mapping[str, ProbabilisticModel],
@@ -425,7 +425,7 @@ def test_expected_constrained_improvement_can_reproduce_expected_improvement() -
 
 
 def test_expected_constrained_improvement_is_relative_to_feasible_point() -> None:
-    class _Constraint(AcquisitionFunctionBuilder):
+    class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             models: Mapping[str, ProbabilisticModel],
@@ -448,7 +448,7 @@ def test_expected_constrained_improvement_is_relative_to_feasible_point() -> Non
 
 
 def test_expected_constrained_improvement_is_less_for_constrained_points() -> None:
-    class _Constraint(AcquisitionFunctionBuilder):
+    class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             models: Mapping[str, ProbabilisticModel],
@@ -472,7 +472,7 @@ def test_expected_constrained_improvement_is_less_for_constrained_points() -> No
 
 
 def test_expected_constrained_improvement_raises_for_empty_data() -> None:
-    class _Constraint(AcquisitionFunctionBuilder):
+    class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             models: Mapping[str, ProbabilisticModel],
@@ -491,7 +491,7 @@ def test_expected_constrained_improvement_raises_for_empty_data() -> None:
 
 
 def test_expected_constrained_improvement_is_constraint_when_no_feasible_points() -> None:
-    class _Constraint(AcquisitionFunctionBuilder):
+    class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             models: Mapping[str, ProbabilisticModel],
@@ -520,7 +520,7 @@ def test_expected_constrained_improvement_min_feasibility_probability_bound_is_i
     def pof(x_: TensorType) -> TensorType:
         return tfp.bijectors.Sigmoid().forward(tf.squeeze(x_, -2))
 
-    class _Constraint(AcquisitionFunctionBuilder):
+    class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             models: Mapping[str, ProbabilisticModel],

--- a/tests/unit/acquisition/multi_objective/test_function.py
+++ b/tests/unit/acquisition/multi_objective/test_function.py
@@ -483,7 +483,7 @@ def test_expected_constrained_hypervolume_improvement_can_reproduce_ehvi() -> No
     obj_model = _mo_test_model(num_obj, *[None] * num_obj)
     model_pred_observation = obj_model.predict(train_x)[0]
 
-    class _Certainty(AcquisitionFunctionBuilder):
+    class _Certainty(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             models: Mapping[str, ProbabilisticModel],
@@ -520,7 +520,7 @@ def test_expected_constrained_hypervolume_improvement_can_reproduce_ehvi() -> No
 
 
 def test_echvi_is_constraint_when_no_feasible_points() -> None:
-    class _Constraint(AcquisitionFunctionBuilder):
+    class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             models: Mapping[str, ProbabilisticModel],
@@ -557,7 +557,7 @@ def test_echvi_raises_for_out_of_range_min_pof() -> None:
 
 
 def test_echvi_raises_for_empty_data() -> None:
-    class _Constraint(AcquisitionFunctionBuilder):
+    class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             models: Mapping[str, ProbabilisticModel],

--- a/tests/unit/acquisition/test_combination.py
+++ b/tests/unit/acquisition/test_combination.py
@@ -45,7 +45,7 @@ def test_reducer__repr_builders() -> None:
 
         _reduce = raise_exc
 
-    class Builder(AcquisitionFunctionBuilder):
+    class Builder(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def __init__(self, name: str):
             self._name = name
 
@@ -63,7 +63,7 @@ def test_reducer__repr_builders() -> None:
     assert repr(Dummy(Builder("foo"), Builder("bar"))) == "Dummy(Builder('foo'), Builder('bar'))"
 
 
-class _Static(AcquisitionFunctionBuilder):
+class _Static(AcquisitionFunctionBuilder[ProbabilisticModel]):
     def __init__(self, f: AcquisitionFunction):
         self._f = f
 

--- a/tests/unit/acquisition/test_interface.py
+++ b/tests/unit/acquisition/test_interface.py
@@ -51,7 +51,7 @@ class _ArbitrarySingleBuilder(SingleModelAcquisitionBuilder[ProbabilisticModel])
         return raise_exc
 
 
-class _ArbitraryGreedySingleBuilder(SingleModelGreedyAcquisitionBuilder):
+class _ArbitraryGreedySingleBuilder(SingleModelGreedyAcquisitionBuilder[ProbabilisticModel]):
     def prepare_acquisition_function(
         self,
         model: ProbabilisticModel,

--- a/tests/unit/acquisition/test_interface.py
+++ b/tests/unit/acquisition/test_interface.py
@@ -42,7 +42,7 @@ from trieste.types import TensorType
 from trieste.utils import DEFAULTS
 
 
-class _ArbitrarySingleBuilder(SingleModelAcquisitionBuilder):
+class _ArbitrarySingleBuilder(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     def prepare_acquisition_function(
         self,
         model: ProbabilisticModel,
@@ -76,7 +76,7 @@ def test_single_model_acquisition_builder_repr_includes_class_name() -> None:
 
 
 def test_single_model_acquisition_builder_using_passes_on_correct_dataset_and_model() -> None:
-    class Builder(SingleModelAcquisitionBuilder):
+    class Builder(SingleModelAcquisitionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
             model: ProbabilisticModel,
@@ -122,7 +122,7 @@ def test_single_model_greedy_acquisition_builder_repr_includes_class_name() -> N
     ],
 )
 def test_single_model_acquisition_function_builder_reprs(
-    function: SingleModelAcquisitionBuilder, function_repr: str
+    function: SingleModelAcquisitionBuilder[ProbabilisticModel], function_repr: str
 ) -> None:
     assert repr(function) == function_repr
     assert repr(function.using("TAG")) == f"{function_repr} using tag 'TAG'"

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -142,7 +142,7 @@ def test_efficient_global_optimization_raises_for_no_batch_fn_with_many_query_po
 
 @pytest.mark.parametrize("optimizer", [_line_search_maximize, None])
 def test_efficient_global_optimization(optimizer: AcquisitionOptimizer[Box]) -> None:
-    class NegQuadratic(SingleModelAcquisitionBuilder):
+    class NegQuadratic(SingleModelAcquisitionBuilder[ProbabilisticModel]):
         def __init__(self) -> None:
             self._updated = False
 
@@ -174,7 +174,7 @@ def test_efficient_global_optimization(optimizer: AcquisitionOptimizer[Box]) -> 
     assert function._updated
 
 
-class _JointBatchModelMinusMeanMaximumSingleBuilder(AcquisitionFunctionBuilder):
+class _JointBatchModelMinusMeanMaximumSingleBuilder(AcquisitionFunctionBuilder[ProbabilisticModel]):
     def prepare_acquisition_function(
         self,
         models: Mapping[str, ProbabilisticModel],

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -222,7 +222,9 @@ def test_joint_batch_acquisition_rule_acquire(
     npt.assert_allclose(query_point, [[0.0, 0.0]] * num_query_points, atol=1e-3)
 
 
-class _GreedyBatchModelMinusMeanMaximumSingleBuilder(SingleModelGreedyAcquisitionBuilder):
+class _GreedyBatchModelMinusMeanMaximumSingleBuilder(
+    SingleModelGreedyAcquisitionBuilder[ProbabilisticModel]
+):
     def __init__(self) -> None:
         self._update_count = 0
 

--- a/trieste/acquisition/combination.py
+++ b/trieste/acquisition/combination.py
@@ -25,7 +25,7 @@ from ..types import TensorType
 from .interface import AcquisitionFunction, AcquisitionFunctionBuilder
 
 
-class Reducer(AcquisitionFunctionBuilder):
+class Reducer(AcquisitionFunctionBuilder[ProbabilisticModel]):
     r"""
     A :class:`Reducer` builds an :const:`~trieste.acquisition.AcquisitionFunction` whose output is
     calculated from the outputs of a number of other
@@ -33,7 +33,7 @@ class Reducer(AcquisitionFunctionBuilder):
     by the method :meth:`_reduce`.
     """
 
-    def __init__(self, *builders: AcquisitionFunctionBuilder):
+    def __init__(self, *builders: AcquisitionFunctionBuilder[ProbabilisticModel]):
         r"""
         :param \*builders: Acquisition function builders. At least one must be provided.
         :raise `~tf.errors.InvalidArgumentError`: If no builders are specified.
@@ -75,7 +75,7 @@ class Reducer(AcquisitionFunctionBuilder):
     # TODO: define update_acquisition_function to avoid unnecessary retracing
 
     @property
-    def acquisitions(self) -> Sequence[AcquisitionFunctionBuilder]:
+    def acquisitions(self) -> Sequence[AcquisitionFunctionBuilder[ProbabilisticModel]]:
         """The acquisition function builders specified at class initialisation."""
         return self._acquisitions
 

--- a/trieste/acquisition/function/active_learning.py
+++ b/trieste/acquisition/function/active_learning.py
@@ -31,7 +31,7 @@ from ...utils import DEFAULTS
 from ..interface import AcquisitionFunction, SingleModelAcquisitionBuilder
 
 
-class PredictiveVariance(SingleModelAcquisitionBuilder):
+class PredictiveVariance(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     """
     Builder for the determinant of the predictive covariance matrix over the batch points.
     For a batch of size 1 it is the same as maximizing the predictive variance.
@@ -106,7 +106,7 @@ def predictive_variance(model: ProbabilisticModel, jitter: float) -> TensorType:
     return acquisition
 
 
-class ExpectedFeasibility(SingleModelAcquisitionBuilder):
+class ExpectedFeasibility(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     """
     Builder for the Expected feasibility acquisition function for identifying a failure or
     feasibility region. It implements two related sampling strategies called *bichon* criterion

--- a/trieste/acquisition/function/entropy.py
+++ b/trieste/acquisition/function/entropy.py
@@ -205,7 +205,7 @@ class min_value_entropy_search(AcquisitionFunctionClass):
         return tf.math.reduce_mean(f_acqu_x, axis=1, keepdims=True)
 
 
-class GIBBON(SingleModelGreedyAcquisitionBuilder):
+class GIBBON(SingleModelGreedyAcquisitionBuilder[ProbabilisticModel]):
     r"""
     The General-purpose Information-Based Bayesian Optimisation (GIBBON) acquisition function
     of :cite:`Moss:2021`. :class:`GIBBON` provides a computationally cheap approximation of the

--- a/trieste/acquisition/function/entropy.py
+++ b/trieste/acquisition/function/entropy.py
@@ -43,7 +43,7 @@ from ..sampler import (
 CLAMP_LB = 1e-8
 
 
-class MinValueEntropySearch(SingleModelAcquisitionBuilder):
+class MinValueEntropySearch(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     r"""
     Builder for the max-value entropy search acquisition function modified for objective
     minimisation. :class:`MinValueEntropySearch` estimates the information in the distribution

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -35,7 +35,7 @@ from ..interface import (
 from ..sampler import BatchReparametrizationSampler
 
 
-class ExpectedImprovement(SingleModelAcquisitionBuilder):
+class ExpectedImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     """
     Builder for the expected improvement function where the "best" value is taken to be the minimum
     of the posterior mean at observed points.
@@ -122,7 +122,7 @@ class expected_improvement(AcquisitionFunctionClass):
         return (self._eta - mean) * normal.cdf(self._eta) + variance * normal.prob(self._eta)
 
 
-class AugmentedExpectedImprovement(SingleModelAcquisitionBuilder):
+class AugmentedExpectedImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     """
     Builder for the augmented expected improvement function for optimization single-objective
     optimization problems with high levels of observation noise.
@@ -231,7 +231,7 @@ class augmented_expected_improvement(AcquisitionFunctionClass):
         return expected_improvement * augmentation
 
 
-class NegativeLowerConfidenceBound(SingleModelAcquisitionBuilder):
+class NegativeLowerConfidenceBound(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     """
     Builder for the negative of the lower confidence bound. The lower confidence bound is typically
     minimised, so the negative is suitable for maximisation.
@@ -324,7 +324,7 @@ def lower_confidence_bound(model: ProbabilisticModel, beta: float) -> Acquisitio
     return acquisition
 
 
-class ProbabilityOfFeasibility(SingleModelAcquisitionBuilder):
+class ProbabilityOfFeasibility(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     r"""
     Builder for the :func:`probability_of_feasibility` acquisition function, defined in
     :cite:`gardner14` as
@@ -422,7 +422,7 @@ def probability_of_feasibility(
     return acquisition
 
 
-class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
+class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticModel]):
     """
     Builder for the *expected constrained improvement* acquisition function defined in
     :cite:`gardner14`. The acquisition function computes the expected improvement from the best
@@ -433,7 +433,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
     def __init__(
         self,
         objective_tag: str,
-        constraint_builder: AcquisitionFunctionBuilder,
+        constraint_builder: AcquisitionFunctionBuilder[ProbabilisticModel],
         min_feasibility_probability: float | TensorType = 0.5,
     ):
         """
@@ -584,7 +584,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder):
             self._expected_improvement_fn.update(eta)  # type: ignore
 
 
-class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder):
+class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     """
     Expected improvement for batches of points (or :math:`q`-EI), approximated using Monte Carlo
     estimation with the reparametrization trick. See :cite:`Ginsbourger2010` for details.

--- a/trieste/acquisition/function/local_penalization.py
+++ b/trieste/acquisition/function/local_penalization.py
@@ -36,7 +36,7 @@ from .entropy import MinValueEntropySearch
 from .function import ExpectedImprovement, expected_improvement
 
 
-class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
+class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder[ProbabilisticModel]):
     r"""
     Builder of the acquisition function maker for greedily collecting batches by local
     penalization.  The resulting :const:`AcquisitionFunctionMaker` takes in a set of pending

--- a/trieste/acquisition/function/local_penalization.py
+++ b/trieste/acquisition/function/local_penalization.py
@@ -90,7 +90,9 @@ class LocalPenalizationAcquisitionFunction(SingleModelGreedyAcquisitionBuilder):
         self._lipschitz_penalizer = soft_local_penalizer if penalizer is None else penalizer
 
         if base_acquisition_function_builder is None:
-            self._base_builder: SingleModelAcquisitionBuilder = ExpectedImprovement()
+            self._base_builder: SingleModelAcquisitionBuilder[
+                ProbabilisticModel
+            ] = ExpectedImprovement()
         else:
             self._base_builder = base_acquisition_function_builder
 

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -36,7 +36,7 @@ from ..sampler import BatchReparametrizationSampler
 from .function import ExpectedConstrainedImprovement
 
 
-class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder):
+class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     """
     Builder for the expected hypervolume improvement acquisition function.
     The implementation of the acquisition function largely
@@ -201,7 +201,9 @@ class expected_hv_improvement(AcquisitionFunctionClass):
         )
 
 
-class BatchMonteCarloExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder):
+class BatchMonteCarloExpectedHypervolumeImprovement(
+    SingleModelAcquisitionBuilder[ProbabilisticModel]
+):
     """
     Builder for the batch expected hypervolume improvement acquisition function.
     The implementation of the acquisition function largely

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -156,7 +156,7 @@ class SingleModelAcquisitionBuilder(Generic[T], ABC):
         return self.prepare_acquisition_function(model, dataset=dataset)
 
 
-class GreedyAcquisitionFunctionBuilder(ABC):
+class GreedyAcquisitionFunctionBuilder(Generic[T], ABC):
     """
     A :class:`GreedyAcquisitionFunctionBuilder` builds an acquisition function
     suitable for greedily building batches for batch Bayesian
@@ -170,7 +170,7 @@ class GreedyAcquisitionFunctionBuilder(ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModel],
+        models: Mapping[str, T],
         datasets: Optional[Mapping[str, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
@@ -189,7 +189,7 @@ class GreedyAcquisitionFunctionBuilder(ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, ProbabilisticModel],
+        models: Mapping[str, T],
         datasets: Optional[Mapping[str, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
@@ -215,13 +215,13 @@ class GreedyAcquisitionFunctionBuilder(ABC):
         )
 
 
-class SingleModelGreedyAcquisitionBuilder(ABC):
+class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
     """
     Convenience acquisition function builder for a greedy acquisition function (or component of a
     composite greedy acquisition function) that requires only one model, dataset pair.
     """
 
-    def using(self, tag: str) -> GreedyAcquisitionFunctionBuilder:
+    def using(self, tag: str) -> GreedyAcquisitionFunctionBuilder[T]:
         """
         :param tag: The tag for the model, dataset pair to use to build this acquisition function.
         :return: An acquisition function builder that selects the model and dataset specified by
@@ -229,10 +229,10 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
         """
         single_builder = self
 
-        class _Anon(GreedyAcquisitionFunctionBuilder):
+        class _Anon(GreedyAcquisitionFunctionBuilder[T]):
             def prepare_acquisition_function(
                 self,
-                models: Mapping[str, ProbabilisticModel],
+                models: Mapping[str, T],
                 datasets: Optional[Mapping[str, Dataset]] = None,
                 pending_points: Optional[TensorType] = None,
             ) -> AcquisitionFunction:
@@ -245,7 +245,7 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
             def update_acquisition_function(
                 self,
                 function: AcquisitionFunction,
-                models: Mapping[str, ProbabilisticModel],
+                models: Mapping[str, T],
                 datasets: Optional[Mapping[str, Dataset]] = None,
                 pending_points: Optional[TensorType] = None,
                 new_optimization_step: bool = True,
@@ -266,7 +266,7 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        model: ProbabilisticModel,
+        model: T,
         dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
@@ -281,7 +281,7 @@ class SingleModelGreedyAcquisitionBuilder(ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        model: ProbabilisticModel,
+        model: T,
         dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -164,7 +164,7 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
 
         self._builder: Union[
             AcquisitionFunctionBuilder[ProbabilisticModel],
-            GreedyAcquisitionFunctionBuilder[ProbabilisticModel]
+            GreedyAcquisitionFunctionBuilder[ProbabilisticModel],
         ] = builder
         self._optimizer = optimizer
         self._num_query_points = num_query_points
@@ -499,9 +499,8 @@ class AsynchronousGreedy(
 
     def __init__(
         self,
-        builder:
-            GreedyAcquisitionFunctionBuilder[ProbabilisticModel]
-            | SingleModelGreedyAcquisitionBuilder[ProbabilisticModel],
+        builder: GreedyAcquisitionFunctionBuilder[ProbabilisticModel]
+        | SingleModelGreedyAcquisitionBuilder[ProbabilisticModel],
         optimizer: AcquisitionOptimizer[SP_contra] | None = None,
         num_query_points: int = 1,
     ):

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -119,9 +119,9 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
         self,
         builder: Optional[
             AcquisitionFunctionBuilder[ProbabilisticModel]
-            | GreedyAcquisitionFunctionBuilder
+            | GreedyAcquisitionFunctionBuilder[ProbabilisticModel]
             | SingleModelAcquisitionBuilder[ProbabilisticModel]
-            | SingleModelGreedyAcquisitionBuilder
+            | SingleModelGreedyAcquisitionBuilder[ProbabilisticModel]
         ] = None,
         optimizer: AcquisitionOptimizer[SP_contra] | None = None,
         num_query_points: int = 1,
@@ -163,7 +163,8 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
             optimizer = batchify(optimizer, num_query_points)
 
         self._builder: Union[
-            AcquisitionFunctionBuilder[ProbabilisticModel], GreedyAcquisitionFunctionBuilder
+            AcquisitionFunctionBuilder[ProbabilisticModel],
+            GreedyAcquisitionFunctionBuilder[ProbabilisticModel]
         ] = builder
         self._optimizer = optimizer
         self._num_query_points = num_query_points
@@ -498,7 +499,9 @@ class AsynchronousGreedy(
 
     def __init__(
         self,
-        builder: GreedyAcquisitionFunctionBuilder | SingleModelGreedyAcquisitionBuilder,
+        builder:
+            GreedyAcquisitionFunctionBuilder[ProbabilisticModel]
+            | SingleModelGreedyAcquisitionBuilder[ProbabilisticModel],
         optimizer: AcquisitionOptimizer[SP_contra] | None = None,
         num_query_points: int = 1,
     ):
@@ -533,7 +536,7 @@ class AsynchronousGreedy(
         if isinstance(builder, SingleModelGreedyAcquisitionBuilder):
             builder = builder.using(OBJECTIVE)
 
-        self._builder: GreedyAcquisitionFunctionBuilder = builder
+        self._builder: GreedyAcquisitionFunctionBuilder[ProbabilisticModel] = builder
         self._optimizer = optimizer
         self._acquisition_function: Optional[AcquisitionFunction] = None
         self._num_query_points = num_query_points

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -118,9 +118,9 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
     def __init__(
         self,
         builder: Optional[
-            AcquisitionFunctionBuilder
+            AcquisitionFunctionBuilder[ProbabilisticModel]
             | GreedyAcquisitionFunctionBuilder
-            | SingleModelAcquisitionBuilder
+            | SingleModelAcquisitionBuilder[ProbabilisticModel]
             | SingleModelGreedyAcquisitionBuilder
         ] = None,
         optimizer: AcquisitionOptimizer[SP_contra] | None = None,
@@ -162,7 +162,9 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
             # Joint batch acquisitions require batch optimizers
             optimizer = batchify(optimizer, num_query_points)
 
-        self._builder: Union[AcquisitionFunctionBuilder, GreedyAcquisitionFunctionBuilder] = builder
+        self._builder: Union[
+            AcquisitionFunctionBuilder[ProbabilisticModel], GreedyAcquisitionFunctionBuilder
+        ] = builder
         self._optimizer = optimizer
         self._num_query_points = num_query_points
         self._acquisition_function: Optional[AcquisitionFunction] = None
@@ -348,7 +350,10 @@ class AsynchronousOptimization(
 
     def __init__(
         self,
-        builder: Optional[AcquisitionFunctionBuilder | SingleModelAcquisitionBuilder] = None,
+        builder: Optional[
+            AcquisitionFunctionBuilder[ProbabilisticModel]
+            | SingleModelAcquisitionBuilder[ProbabilisticModel]
+        ] = None,
         optimizer: AcquisitionOptimizer[SP_contra] | None = None,
         num_query_points: int = 1,
     ):
@@ -380,7 +385,7 @@ class AsynchronousOptimization(
         if num_query_points > 1:
             optimizer = batchify(optimizer, num_query_points)
 
-        self._builder: AcquisitionFunctionBuilder = builder
+        self._builder: AcquisitionFunctionBuilder[ProbabilisticModel] = builder
         self._optimizer = optimizer
         self._acquisition_function: Optional[AcquisitionFunction] = None
 


### PR DESCRIPTION
This PR makes `AcquisitionFunctionBuilder` and `SingleModelAcquisitionFunctionBuilder` generic on the type of `ProbabilisticModel`.

Motivation for change:

In our project we have many different types of constraints, which are implemented as `AcquisitionFunction`s. Some of these constraints require particular types of model (i.e. particular subclasses of `ProbabilisticModel`). For example, a constraint on the quantile of a modelled quantity requires a model which can predict quantiles, however some of the our quantile models are speciailsed for predicting quantiles, and therefore don't predict other quantities, like the mean, and so can't be used in a constraint which requires a mean prediction. This PR enables mypy to enforce that the correct model types are used when constructing the `AcquistionFunction`. It should effectively amount to a no-op when it's valid to use any `ProbabilisticModel` with a given `AcquistionFunction`, which seems to be the case throughout the Trieste codebase.