### PR TITLE
Change random seed in constrained BO notebook

### DIFF
--- a/docs/notebooks/inequality_constraints.pct.py
+++ b/docs/notebooks/inequality_constraints.pct.py
@@ -5,8 +5,8 @@
 import numpy as np
 import tensorflow as tf
 
-np.random.seed(1793)
-tf.random.set_seed(1793)
+np.random.seed(1799)
+tf.random.set_seed(1799)
 
 # %% [markdown]
 # ## The problem


### PR DESCRIPTION
Our recent commits don't pass full doc build with inequality constraints notebook failing with an error. Local testing suggests a different random seed in the notebook resolves the error. This PR updates the random seed.

Since quickdocs build doesn't catch this error, verified locally by reproducing the error and then running the full docs build. 