### PR TITLE
Fix slow running test failures

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
-import copy
 import tempfile
-from typing import List, Tuple, Union, cast
+from typing import List, Tuple, Union
 
 import gpflow
 import numpy.testing as npt
@@ -65,27 +64,30 @@ from trieste.observer import OBJECTIVE
 from trieste.space import Box, SearchSpace
 from trieste.types import State, TensorType
 
-# Optimizer parameters for testing against the Branin function.
+
+# Optimizer parameters for testing against the branin function.
 # We also use these for a quicker test against a simple quadratic function
 # (regenerating is necessary as some of the acquisition rules are stateful).
-OPTIMIZER_PARAMS = lambda: (
-    "num_steps, acquisition_rule",
-    cast(
-        List[
-            Tuple[
-                int,
-                Union[
-                    AcquisitionRule[TensorType, Box],
-                    AcquisitionRule[
-                        State[
-                            TensorType,
-                            Union[AsynchronousRuleState, TrustRegion.State],
-                        ],
-                        Box,
+def OPTIMIZER_PARAMS() -> Tuple[
+    str,
+    List[
+        Tuple[
+            int,
+            Union[
+                AcquisitionRule[TensorType, Box],
+                AcquisitionRule[
+                    State[
+                        TensorType,
+                        Union[AsynchronousRuleState, TrustRegion.State],
                     ],
+                    Box,
                 ],
-            ]
-        ],
+            ],
+        ]
+    ],
+]:
+    return (
+        "num_steps, acquisition_rule",
         [
             (20, EfficientGlobalOptimization()),
             (25, EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE))),
@@ -146,8 +148,7 @@ OPTIMIZER_PARAMS = lambda: (
             (10, DiscreteThompsonSampling(500, 3)),
             (10, DiscreteThompsonSampling(500, 3, num_fourier_features=1000)),
         ],
-    ),
-)
+    )
 
 
 @random_seed

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -65,10 +65,10 @@ from trieste.observer import OBJECTIVE
 from trieste.space import Box, SearchSpace
 from trieste.types import State, TensorType
 
-# Optimizer parameters for testing against the branin function.
-# We use a copy of these for a quicker test against a simple quadratic function
-# (copying is necessary as some of the acquisition rules are stateful).
-OPTIMIZER_PARAMS = (
+# Optimizer parameters for testing against the Branin function.
+# We also use these for a quicker test against a simple quadratic function
+# (regenerating is necessary as some of the acquisition rules are stateful).
+OPTIMIZER_PARAMS = lambda: (
     "num_steps, acquisition_rule",
     cast(
         List[
@@ -152,7 +152,7 @@ OPTIMIZER_PARAMS = (
 
 @random_seed
 @pytest.mark.slow  # to run this, add --runslow yes to the pytest command
-@pytest.mark.parametrize(*OPTIMIZER_PARAMS)
+@pytest.mark.parametrize(*OPTIMIZER_PARAMS())
 def test_optimizer_finds_minima_of_the_scaled_branin_function(
     num_steps: int,
     acquisition_rule: AcquisitionRule[TensorType, SearchSpace]
@@ -162,7 +162,7 @@ def test_optimizer_finds_minima_of_the_scaled_branin_function(
 
 
 @random_seed
-@pytest.mark.parametrize(*copy.deepcopy(OPTIMIZER_PARAMS))
+@pytest.mark.parametrize(*OPTIMIZER_PARAMS())
 def test_optimizer_finds_minima_of_simple_quadratic(
     num_steps: int,
     acquisition_rule: AcquisitionRule[TensorType, SearchSpace]


### PR DESCRIPTION
Looks like there's some issue with the deecopy. I might investigate that separately to make sure that doesn't impact state tracking.