### PR TITLE
support for keras models part 2 - utils

### DIFF
--- a/tests/unit/models/keras/test_utils.py
+++ b/tests/unit/models/keras/test_utils.py
@@ -30,7 +30,8 @@ def test_get_tensor_spec_from_data_raises_for_incorrect_dataset() -> None:
 
 
 @pytest.mark.parametrize(
-    "query_point_shape, observation_shape", [([1], [1]), ([2], [1]), ([5], [1]), ([5], [2])]
+    "query_point_shape, observation_shape",
+    [([1], [1]), ([2], [1]), ([5], [1]), ([5], [2]), ([3, 2], [3, 1])],
 )
 def test_get_tensor_spec_from_data(
     query_point_shape: ShapeLike, observation_shape: ShapeLike
@@ -64,11 +65,16 @@ def test_sample_with_replacement_raises_for_empty_dataset() -> None:
 
 
 @random_seed
-def test_sample_with_replacement_seems_correct() -> None:
+@pytest.mark.parametrize("rank", [2, 3])
+def test_sample_with_replacement_seems_correct(rank: int) -> None:
 
     n_rows = 100
-    x = tf.constant(np.arange(0, n_rows, 1), shape=[n_rows, 1])
-    y = tf.constant(np.arange(0, n_rows, 1), shape=[n_rows, 1])
+    if rank == 2:
+        x = tf.constant(np.arange(0, n_rows, 1), shape=[n_rows, 1])
+        y = tf.constant(np.arange(0, n_rows, 1), shape=[n_rows, 1])
+    elif rank == 3:
+        x = tf.constant(np.arange(0, n_rows, 1).repeat(2), shape=[n_rows, 2, 1])
+        y = tf.constant(np.arange(0, n_rows, 1).repeat(2), shape=[n_rows, 2, 1])
     dataset = Dataset(x, y)
 
     dataset_resampled = sample_with_replacement(dataset)
@@ -83,14 +89,16 @@ def test_sample_with_replacement_seems_correct() -> None:
     assert tf.reduce_any(dataset_resampled.observations != y)
 
     # values are likely to repeat due to replacement
-    _, _, count = tf.unique_with_counts(tf.squeeze(dataset_resampled.query_points))
+    _, _, count = tf.unique_with_counts(tf.squeeze(dataset_resampled.query_points[:, 0]))
     assert tf.reduce_any(count > 1)
 
     # mean of bootstrap samples should be close to true mean
     mean = [
-        tf.reduce_mean(tf.cast(sample_with_replacement(dataset).query_points, dtype=tf.float32))
+        tf.reduce_mean(
+            tf.cast(sample_with_replacement(dataset).query_points[:, 0], dtype=tf.float32)
+        )
         for _ in range(100)
     ]
-    x = tf.cast(x, dtype=tf.float32)
+    x = tf.cast(x[:, 0], dtype=tf.float32)
     assert (tf.reduce_mean(mean) - tf.reduce_mean(x)) < 1
     assert tf.math.abs(tf.math.reduce_std(mean) - tf.math.reduce_std(x) / 10.0) < 0.1

--- a/tests/unit/models/keras/test_utils.py
+++ b/tests/unit/models/keras/test_utils.py
@@ -1,0 +1,97 @@
+# Copyright 2021 The Bellman Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from tests.util.misc import ShapeLike, empty_dataset, random_seed
+
+from trieste.data import Dataset
+from trieste.models.keras.utils import get_tensor_spec_from_data, sample_with_replacement
+
+
+def test_get_tensor_spec_from_data_raises_for_incorrect_dataset() -> None:
+
+    dataset = empty_dataset([1], [1])
+
+    with pytest.raises(ValueError):
+        get_tensor_spec_from_data(dataset.query_points)
+
+@pytest.mark.parametrize(
+    "query_point_shape, observation_shape", 
+    [([1], [1]), ([2], [1]), ([5], [1]), ([5], [2])]
+)
+def test_get_tensor_spec_from_data(
+    query_point_shape: ShapeLike, observation_shape: ShapeLike
+) -> None:
+    dataset = empty_dataset(query_point_shape, observation_shape)
+    input_spec, output_spec = get_tensor_spec_from_data(dataset)
+
+    assert input_spec.shape == query_point_shape
+    assert input_spec.dtype == dataset.query_points.dtype
+    assert input_spec.name == "query_points"
+
+    assert output_spec.shape == observation_shape
+    assert output_spec.dtype == dataset.observations.dtype
+    assert output_spec.name == "observations"
+
+
+def test_sample_with_replacement_raises_for_invalid_dataset() -> None:
+
+    dataset = empty_dataset([1], [1])
+
+    with pytest.raises(ValueError):
+        sample_with_replacement(dataset.query_points)
+
+
+def test_sample_with_replacement_raises_for_empty_dataset() -> None:
+
+    dataset = empty_dataset([1], [1])
+
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        sample_with_replacement(dataset)
+
+
+@random_seed
+def test_sample_with_replacement_seems_correct() -> None:
+
+    n_rows = 100
+    x = tf.constant(np.arange(0, n_rows, 1), shape=[n_rows, 1])
+    y = tf.constant(np.arange(0, n_rows, 1), shape=[n_rows, 1])
+    dataset = Dataset(x, y)
+
+    dataset_resampled = sample_with_replacement(dataset)
+
+    # basic check that original dataset has not been changed
+    assert tf.reduce_all(dataset.query_points == x)
+    assert tf.reduce_all(dataset.observations == y)
+
+    # x and y should be resampled the same, and should differ from the original
+    assert tf.reduce_all(dataset_resampled.query_points == dataset_resampled.observations)
+    assert tf.reduce_any(dataset_resampled.query_points != x)
+    assert tf.reduce_any(dataset_resampled.observations != y)
+
+    # values are likely to repeat due to replacement
+    _, _, count = tf.unique_with_counts(tf.squeeze(dataset_resampled.query_points))
+    assert tf.reduce_any(count > 1)
+
+    # mean of bootstrap samples should be close to true mean
+    mean = [
+        tf.reduce_mean(tf.cast(sample_with_replacement(dataset).query_points, dtype=tf.float32)) 
+        for _ in range(100)
+    ]
+    x = tf.cast(x, dtype=tf.float32)
+    assert (tf.reduce_mean(mean) - tf.reduce_mean(x)) < 1
+    assert tf.math.abs(tf.math.reduce_std(mean) - tf.math.reduce_std(x)/10.0) < 0.1

--- a/tests/unit/models/keras/test_utils.py
+++ b/tests/unit/models/keras/test_utils.py
@@ -17,7 +17,6 @@ import pytest
 import tensorflow as tf
 
 from tests.util.misc import ShapeLike, empty_dataset, random_seed
-
 from trieste.data import Dataset
 from trieste.models.keras.utils import get_tensor_spec_from_data, sample_with_replacement
 
@@ -29,9 +28,9 @@ def test_get_tensor_spec_from_data_raises_for_incorrect_dataset() -> None:
     with pytest.raises(ValueError):
         get_tensor_spec_from_data(dataset.query_points)
 
+
 @pytest.mark.parametrize(
-    "query_point_shape, observation_shape", 
-    [([1], [1]), ([2], [1]), ([5], [1]), ([5], [2])]
+    "query_point_shape, observation_shape", [([1], [1]), ([2], [1]), ([5], [1]), ([5], [2])]
 )
 def test_get_tensor_spec_from_data(
     query_point_shape: ShapeLike, observation_shape: ShapeLike
@@ -89,9 +88,9 @@ def test_sample_with_replacement_seems_correct() -> None:
 
     # mean of bootstrap samples should be close to true mean
     mean = [
-        tf.reduce_mean(tf.cast(sample_with_replacement(dataset).query_points, dtype=tf.float32)) 
+        tf.reduce_mean(tf.cast(sample_with_replacement(dataset).query_points, dtype=tf.float32))
         for _ in range(100)
     ]
     x = tf.cast(x, dtype=tf.float32)
     assert (tf.reduce_mean(mean) - tf.reduce_mean(x)) < 1
-    assert tf.math.abs(tf.math.reduce_std(mean) - tf.math.reduce_std(x)/10.0) < 0.1
+    assert tf.math.abs(tf.math.reduce_std(mean) - tf.math.reduce_std(x) / 10.0) < 0.1

--- a/trieste/models/keras/__init__.py
+++ b/trieste/models/keras/__init__.py
@@ -22,3 +22,4 @@ the Trieste toolbox.
 """
 
 from .interface import NeuralNetworkPredictor
+from .utils import get_tensor_spec_from_data, sample_with_replacement

--- a/trieste/models/keras/utils.py
+++ b/trieste/models/keras/utils.py
@@ -39,7 +39,6 @@ def get_tensor_spec_from_data(dataset: Dataset) -> tuple[tf.TensorSpec, tf.Tenso
     :return: Tensor specification objects for the ``query_points`` and ``observations`` tensors.
     :raise ValueError: If the dataset is not an instance of :class:`~trieste.data.Dataset`.
     """
-    data = Dataset(tf.constant([[0.1, 0.2], [0.3, 0.4]]), tf.constant([[0.5], [0.7]]))
     if not isinstance(dataset, Dataset):
         raise ValueError(
             f"This function works only on trieste.data.Dataset objects, however got"

--- a/trieste/models/keras/utils.py
+++ b/trieste/models/keras/utils.py
@@ -14,12 +14,9 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Union
-
 import tensorflow as tf
 
 from ...data import Dataset
-from ...types import TensorType
 
 
 def get_tensor_spec_from_data(dataset: Dataset) -> tuple[tf.TensorSpec, tf.TensorSpec]:

--- a/trieste/models/keras/utils.py
+++ b/trieste/models/keras/utils.py
@@ -1,0 +1,78 @@
+# Copyright 2021 The Trieste Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Iterable, Union
+
+import tensorflow as tf
+
+from ...data import Dataset
+from ...types import TensorType
+
+
+def get_tensor_spec_from_data(dataset: Dataset) -> tuple[tf.TensorSpec, tf.TensorSpec]:
+    """
+    Extract tensor specifications for inputs and outputs of neural network models, based on the
+    dataset. This utility faciliates constructing neural networks.
+
+    :param dataset: A dataset with ``query_points`` and ``observations`` tensors.
+    :return: Tensor specification objects for the ``query_points`` and ``observations`` tensors.
+    :raise ValueError: If the dataset is not an instance of :class:`~trieste.data.Dataset`.
+    """
+    if not isinstance(dataset, Dataset):
+        raise ValueError(
+            f"This function works only on trieste.data.Dataset objects, however got"
+            f"{type(dataset)} which is incompatible."
+        )
+    input_tensor_spec = tf.TensorSpec(
+        shape=(dataset.query_points.shape[-1],),
+        dtype=dataset.query_points.dtype,
+        name="query_points",
+    )
+    output_tensor_spec = tf.TensorSpec(
+        shape=(dataset.observations.shape[-1],),
+        dtype=dataset.observations.dtype,
+        name="observations",
+    )
+    return input_tensor_spec, output_tensor_spec
+
+
+def sample_with_replacement(dataset: Dataset) -> Dataset:
+    """
+    Create a new ``dataset`` with data sampled with replacement. This
+    function is useful for creating bootstrap samples of data for training ensembles.
+
+    :param dataset: The data that should be sampled.
+    :return: A (new) ``dataset`` with sampled data.
+    :raise ValueError (or InvalidArgumentError): If the dataset is not an instance of
+        :class:`~trieste.data.Dataset` or it is empty.
+    """
+    if not isinstance(dataset, Dataset):
+        raise ValueError(
+            f"This function works only on trieste.data.Dataset objects, however got"
+            f"{type(dataset)} which is incompatible."
+        )
+    tf.debugging.assert_positive(len(dataset), message="Dataset must not be empty.")
+
+    n_rows = dataset.observations.shape[0]
+
+    index_tensor = tf.random.uniform(
+        (n_rows,), maxval=n_rows, dtype=tf.dtypes.int32
+    )  # pylint: disable=all
+
+    observations = tf.gather(dataset.observations, index_tensor)  # pylint: disable=all
+    query_points = tf.gather(dataset.query_points, index_tensor)  # pylint: disable=all
+
+    return Dataset(query_points=query_points, observations=observations)

--- a/trieste/models/keras/utils.py
+++ b/trieste/models/keras/utils.py
@@ -20,9 +20,20 @@ from ...data import Dataset
 
 
 def get_tensor_spec_from_data(dataset: Dataset) -> tuple[tf.TensorSpec, tf.TensorSpec]:
-    """
+    r"""
     Extract tensor specifications for inputs and outputs of neural network models, based on the
-    dataset. This utility faciliates constructing neural networks.
+    dataset. This utility faciliates constructing neural networks, providing the required
+    dimensions for the input and the output of the network. For example
+
+    >>> data = Dataset(
+    ...     tf.constant([[0.1, 0.2], [0.3, 0.4]]),
+    ...     tf.constant([[0.5], [0.7]])
+    ... )
+    >>> input_spec, output_spec = get_tensor_spec_from_data(data)
+    >>> input_spec
+    <TensorSpec(shape=(2,), dtype=tf.float32, name='query_points')>
+    >>> output_spec
+    <TensorSpec(shape=(1,), dtype=tf.float32, name='observations')>
 
     :param dataset: A dataset with ``query_points`` and ``observations`` tensors.
     :return: Tensor specification objects for the ``query_points`` and ``observations`` tensors.
@@ -34,12 +45,12 @@ def get_tensor_spec_from_data(dataset: Dataset) -> tuple[tf.TensorSpec, tf.Tenso
             f"{type(dataset)} which is incompatible."
         )
     input_tensor_spec = tf.TensorSpec(
-        shape=(dataset.query_points.shape[-1],),
+        shape=(dataset.query_points.shape[1:]),
         dtype=dataset.query_points.dtype,
         name="query_points",
     )
     output_tensor_spec = tf.TensorSpec(
-        shape=(dataset.observations.shape[-1],),
+        shape=(dataset.observations.shape[1:]),
         dtype=dataset.observations.dtype,
         name="observations",
     )
@@ -65,11 +76,9 @@ def sample_with_replacement(dataset: Dataset) -> Dataset:
 
     n_rows = dataset.observations.shape[0]
 
-    index_tensor = tf.random.uniform(
-        (n_rows,), maxval=n_rows, dtype=tf.dtypes.int32
-    )  # pylint: disable=all
+    index_tensor = tf.random.uniform((n_rows,), maxval=n_rows, dtype=tf.dtypes.int32)
 
-    observations = tf.gather(dataset.observations, index_tensor)  # pylint: disable=all
-    query_points = tf.gather(dataset.query_points, index_tensor)  # pylint: disable=all
+    observations = tf.gather(dataset.observations, index_tensor, axis=0)
+    query_points = tf.gather(dataset.query_points, index_tensor, axis=0)
 
     return Dataset(query_points=query_points, observations=observations)

--- a/trieste/models/keras/utils.py
+++ b/trieste/models/keras/utils.py
@@ -31,14 +31,15 @@ def get_tensor_spec_from_data(dataset: Dataset) -> tuple[tf.TensorSpec, tf.Tenso
     ... )
     >>> input_spec, output_spec = get_tensor_spec_from_data(data)
     >>> input_spec
-    <TensorSpec(shape=(2,), dtype=tf.float32, name='query_points')>
+    TensorSpec(shape=(2,), dtype=tf.float32, name='query_points')
     >>> output_spec
-    <TensorSpec(shape=(1,), dtype=tf.float32, name='observations')>
+    TensorSpec(shape=(1,), dtype=tf.float32, name='observations')
 
     :param dataset: A dataset with ``query_points`` and ``observations`` tensors.
     :return: Tensor specification objects for the ``query_points`` and ``observations`` tensors.
     :raise ValueError: If the dataset is not an instance of :class:`~trieste.data.Dataset`.
     """
+    data = Dataset(tf.constant([[0.1, 0.2], [0.3, 0.4]]), tf.constant([[0.5], [0.7]]))
     if not isinstance(dataset, Dataset):
         raise ValueError(
             f"This function works only on trieste.data.Dataset objects, however got"


### PR DESCRIPTION
support for neural nets with Keras comes in four parts:

1. interface (done)
2. utilities (this PR)
3. model and architectures (deep ensembles only)
4. trajectory sampler 
5. integration tests and notebook