### PR TITLE
Support for vectorized acquisition functions

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -303,3 +303,10 @@
   journal={Advances in Neural Information Processing Systems},
   year={2018}
 }
+
+@article{torossian2020bayesian,
+  title={Bayesian quantile and expectile optimisation},
+  author={Torossian, L{\'e}onard and Picheny, Victor and Durrande, Nicolas},
+  journal={arXiv preprint arXiv:2001.04833},
+  year={2020}
+}

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -32,6 +32,7 @@ from trieste.acquisition import (
     Fantasizer,
     LocalPenalization,
     MinValueEntropySearch,
+    MultipleOptimismNegativeLowerConfidenceBound,
 )
 from trieste.acquisition.rule import (
     AcquisitionRule,
@@ -140,6 +141,15 @@ def OPTIMIZER_PARAMS() -> Tuple[
                         BRANIN_SEARCH_SPACE,
                     ).using(OBJECTIVE),
                     num_query_points=2,
+                ),
+            ),
+            (
+                10,
+                EfficientGlobalOptimization(
+                    MultipleOptimismNegativeLowerConfidenceBound(
+                        BRANIN_SEARCH_SPACE,
+                    ).using(OBJECTIVE),
+                    num_query_points=3,
                 ),
             ),
             (15, TrustRegion()),

--- a/tests/unit/acquisition/function/test_function.py
+++ b/tests/unit/acquisition/function/test_function.py
@@ -45,6 +45,8 @@ from trieste.acquisition.function.function import (
     ExpectedConstrainedImprovement,
     ExpectedImprovement,
     NegativeLowerConfidenceBound,
+    MultipleOptimismNegativeLowerConfidenceBound,
+    multiple_optimism_lower_confidence_bound,
     ProbabilityOfFeasibility,
     augmented_expected_improvement,
     expected_improvement,
@@ -55,7 +57,7 @@ from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.objectives import BRANIN_MINIMUM, branin
 from trieste.types import TensorType
-
+from trieste.space import Box
 
 def test_expected_improvement_builder_builds_expected_improvement_using_best_from_model() -> None:
     dataset = Dataset(
@@ -649,3 +651,75 @@ def test_batch_monte_carlo_expected_improvement_updates_without_retracing() -> N
     assert batch_ei.__call__._get_tracing_count() == 1  # type: ignore
     npt.assert_allclose(batch_ei(xs), ei(xs), rtol=0.06)
     assert batch_ei.__call__._get_tracing_count() == 1  # type: ignore
+
+
+
+
+
+
+
+
+
+
+
+
+def test_multiple_optimism_negative_lower_confidence_bound_builder_builds_negative_lower_confidence_bound() -> None:
+    model = QuadraticMeanAndRBFKernel()
+    search_space = Box([0, 0], [1, 1])
+    acq_fn = MultipleOptimismNegativeLowerConfidenceBound(search_space).prepare_acquisition_function(model)
+    query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [10,5,2])
+    expected = multiple_optimism_lower_confidence_bound(model, search_space.dimension)(query_at)
+    npt.assert_array_almost_equal(acq_fn(query_at), expected)
+
+
+# def test_multiple_optimism_negative_lower_confidence_bound_builder_updates_without_retracing() -> None:
+#     model = QuadraticMeanAndRBFKernel()
+#     beta = 1.96
+#     search_space = Box([0, 0], [1, 1])
+#     builder = MultipleOptimismNegativeLowerConfidenceBound(search_space)
+#     acq_fn = builder.prepare_acquisition_function(model)
+#     assert acq_fn._get_tracing_count() == 0  # type: ignore
+#     query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [10,5,2])
+#     expected = multiple_optimism_lower_confidence_bound(model, search_space.dimension)(query_at)
+#     npt.assert_array_almost_equal(acq_fn(query_at), expected)
+#     assert acq_fn._get_tracing_count() == 1  # type: ignore
+
+#     up_acq_fn = builder.update_acquisition_function(acq_fn, model)
+#     assert up_acq_fn == acq_fn
+#     npt.assert_array_almost_equal(acq_fn(query_at), expected)
+#     assert acq_fn._get_tracing_count() == 1  # type: ignore
+
+
+
+def test_multiple_optimism_negative_lower_confidence_bound_builder_raises_when_update_with_wrong_function() -> None:
+    model = QuadraticMeanAndRBFKernel()
+    search_space = Box([0, 0], [1, 1])
+    builder = MultipleOptimismNegativeLowerConfidenceBound(search_space)
+    acq_fn = builder.prepare_acquisition_function(model)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        builder.update_acquisition_function(lower_confidence_bound(model, 0.1),model)
+
+
+
+@pytest.mark.parametrize("d", [0,-5])
+def test_multiple_optimism_negative_confidence_bound_raises_for_negative_search_space_dim(d: float) -> None:
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        multiple_optimism_lower_confidence_bound(QuadraticMeanAndRBFKernel(), d)
+
+
+def test_multiple_optimism_negative_confidence_bound_raises_for_changing_batch_size() -> None:
+    model = QuadraticMeanAndRBFKernel()
+    search_space = Box([0, 0], [1, 1])
+    acq_fn = MultipleOptimismNegativeLowerConfidenceBound(search_space).prepare_acquisition_function(model)
+    query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [10,5,2])
+    acq_fn(query_at)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [5,10,2])
+        acq_fn(query_at)
+
+
+
+
+
+
+#check builder update with different acq

--- a/tests/unit/acquisition/function/test_function.py
+++ b/tests/unit/acquisition/function/test_function.py
@@ -44,20 +44,21 @@ from trieste.acquisition.function.function import (
     BatchMonteCarloExpectedImprovement,
     ExpectedConstrainedImprovement,
     ExpectedImprovement,
-    NegativeLowerConfidenceBound,
     MultipleOptimismNegativeLowerConfidenceBound,
-    multiple_optimism_lower_confidence_bound,
+    NegativeLowerConfidenceBound,
     ProbabilityOfFeasibility,
     augmented_expected_improvement,
     expected_improvement,
     lower_confidence_bound,
+    multiple_optimism_lower_confidence_bound,
     probability_of_feasibility,
 )
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.objectives import BRANIN_MINIMUM, branin
-from trieste.types import TensorType
 from trieste.space import Box
+from trieste.types import TensorType
+
 
 def test_expected_improvement_builder_builds_expected_improvement_using_best_from_model() -> None:
     dataset = Dataset(
@@ -653,26 +654,18 @@ def test_batch_monte_carlo_expected_improvement_updates_without_retracing() -> N
     assert batch_ei.__call__._get_tracing_count() == 1  # type: ignore
 
 
-
-
-
-
-
-
-
-
-
-
-def test_multiple_optimism_negative_lower_confidence_bound_builder_builds_negative_lower_confidence_bound() -> None:
+def test_multiple_optimism_builder_builds_negative_lower_confidence_bound() -> None:
     model = QuadraticMeanAndRBFKernel()
     search_space = Box([0, 0], [1, 1])
-    acq_fn = MultipleOptimismNegativeLowerConfidenceBound(search_space).prepare_acquisition_function(model)
-    query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [10,5,2])
+    acq_fn = MultipleOptimismNegativeLowerConfidenceBound(
+        search_space
+    ).prepare_acquisition_function(model)
+    query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [10, 5, 2])
     expected = multiple_optimism_lower_confidence_bound(model, search_space.dimension)(query_at)
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
 
 
-# def test_multiple_optimism_negative_lower_confidence_bound_builder_updates_without_retracing() -> None:
+# def test_multiple_optimism_builder_updates_without_retracing() -> None:
 #     model = QuadraticMeanAndRBFKernel()
 #     beta = 1.96
 #     search_space = Box([0, 0], [1, 1])
@@ -690,19 +683,19 @@ def test_multiple_optimism_negative_lower_confidence_bound_builder_builds_negati
 #     assert acq_fn._get_tracing_count() == 1  # type: ignore
 
 
-
-def test_multiple_optimism_negative_lower_confidence_bound_builder_raises_when_update_with_wrong_function() -> None:
+def test_multiple_optimism_builder_raises_when_update_with_wrong_function() -> None:
     model = QuadraticMeanAndRBFKernel()
     search_space = Box([0, 0], [1, 1])
     builder = MultipleOptimismNegativeLowerConfidenceBound(search_space)
-    acq_fn = builder.prepare_acquisition_function(model)
+    builder.prepare_acquisition_function(model)
     with pytest.raises(tf.errors.InvalidArgumentError):
-        builder.update_acquisition_function(lower_confidence_bound(model, 0.1),model)
+        builder.update_acquisition_function(lower_confidence_bound(model, 0.1), model)
 
 
-
-@pytest.mark.parametrize("d", [0,-5])
-def test_multiple_optimism_negative_confidence_bound_raises_for_negative_search_space_dim(d: float) -> None:
+@pytest.mark.parametrize("d", [0, -5])
+def test_multiple_optimism_negative_confidence_bound_raises_for_negative_search_space_dim(
+    d: int,
+) -> None:
     with pytest.raises(tf.errors.InvalidArgumentError):
         multiple_optimism_lower_confidence_bound(QuadraticMeanAndRBFKernel(), d)
 
@@ -710,16 +703,14 @@ def test_multiple_optimism_negative_confidence_bound_raises_for_negative_search_
 def test_multiple_optimism_negative_confidence_bound_raises_for_changing_batch_size() -> None:
     model = QuadraticMeanAndRBFKernel()
     search_space = Box([0, 0], [1, 1])
-    acq_fn = MultipleOptimismNegativeLowerConfidenceBound(search_space).prepare_acquisition_function(model)
-    query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [10,5,2])
+    acq_fn = MultipleOptimismNegativeLowerConfidenceBound(
+        search_space
+    ).prepare_acquisition_function(model)
+    query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [10, 5, 2])
     acq_fn(query_at)
     with pytest.raises(tf.errors.InvalidArgumentError):
-        query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [5,10,2])
+        query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [5, 10, 2])
         acq_fn(query_at)
 
 
-
-
-
-
-#check builder update with different acq
+# check builder update with different acq

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -25,13 +25,20 @@ from trieste.acquisition.optimizer import (
     AcquisitionOptimizer,
     FailedOptimizationError,
     automatic_optimizer_selector,
-    batchify,
+    batchify_joint,
+    batchify_vectorize,
     generate_continuous_optimizer,
     generate_random_search_optimizer,
     get_bounds_of_box_relaxation_around_point,
     optimize_discrete,
 )
 from trieste.objectives import (
+    BRANIN_MINIMUM,
+    BRANIN_SEARCH_SPACE,
+    branin,
+    scaled_branin,
+    SCALED_BRANIN_MINIMUM,
+    SIMPLE_QUADRATIC_MINIMUM,
     ACKLEY_5_MINIMIZER,
     ACKLEY_5_SEARCH_SPACE,
     HARTMANN_3_MINIMIZER,
@@ -40,6 +47,7 @@ from trieste.objectives import (
     HARTMANN_6_SEARCH_SPACE,
     ackley_5,
     hartmann_3,
+    simple_quadratic,
     hartmann_6,
 )
 from trieste.space import Box, DiscreteSearchSpace, SearchSpace, TaggedProductSearchSpace
@@ -116,6 +124,10 @@ def test_discrete_and_random_optimizer_on_quadratic(
             npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-4)
         else:
             npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-1)
+
+
+
+
 
 
 @random_seed
@@ -377,6 +389,14 @@ def test_continuous_optimizer_on_toy_problems(
     npt.assert_allclose(maximizer, expected_maximizer, rtol=1e-1)
 
 
+
+
+
+
+
+
+
+
 @pytest.mark.parametrize(
     "search_space, point",
     [
@@ -456,10 +476,10 @@ def test_get_bounds_of_box_relaxation_around_point(
     npt.assert_array_equal(bounds.ub, upper)
 
 
-def test_optimize_batch_raises_with_invalid_batch_size() -> None:
+def test_batchify_joint_raises_with_invalid_batch_size() -> None:
     batch_size_one_optimizer = generate_continuous_optimizer()
     with pytest.raises(ValueError):
-        batchify(batch_size_one_optimizer, -5)
+        batchify_joint(batch_size_one_optimizer, -5)
 
 
 @random_seed
@@ -471,15 +491,106 @@ def test_optimize_batch_raises_with_invalid_batch_size() -> None:
         (Box([-1, -1, -1], [1, 1, 1]), _quadratic_sum([0.5, -0.5, 0.2]), ([[0.5, -0.5, 0.2]])),
     ],
 )
-def test_optimize_batch(
+def test_batchify_joint(
     search_space: Box, acquisition: AcquisitionFunction, maximizer: TensorType, batch_size: int
 ) -> None:
     batch_size_one_optimizer = generate_continuous_optimizer(num_optimization_runs=5)
-    batch_optimizer = batchify(batch_size_one_optimizer, batch_size)
+    batch_optimizer = batchify_joint(batch_size_one_optimizer, batch_size)
     points = batch_optimizer(search_space, acquisition)
     assert points.shape == [batch_size] + search_space.lower.shape
     for point in points:
         npt.assert_allclose(tf.expand_dims(point, 0), maximizer, rtol=2e-4)
+
+
+
+
+
+
+def test_batchify_vectorized_raises_with_invalid_batch_size() -> None:
+    batch_size_one_optimizer = generate_continuous_optimizer()
+    with pytest.raises(ValueError):
+        batchify_vectorize(batch_size_one_optimizer, -5)
+
+
+@random_seed
+@pytest.mark.parametrize("optimizer", [generate_random_search_optimizer(10_000), generate_continuous_optimizer()])
+def test_batchify_vectorized_for_random_and_continuous_optimizers_on_vectorized_quadratic(optimizer: AcquisitionOptimizer) -> None:
+    search_space = Box([-1, -2], [1.5, 2.5])
+    shifts = [[0.3, -0.4],[1.0, 4]]
+    expected_maximizers = [[0.3, -0.4], [1.0, 2.5]]
+    vectorized_batch_size=2
+
+    def vectorized_target(x: TensorType) -> TensorType: # [N, V, D] -> [N,V]
+        individual_func =  [_quadratic_sum(shifts[i])(x[:,i:i+1,:]) for i in range(vectorized_batch_size)]  
+        return tf.concat(individual_func, axis=-1)
+        
+    batched_optimizer =batchify_vectorize(optimizer, batch_size=vectorized_batch_size)
+    maximizers = batched_optimizer(search_space, vectorized_target)
+    npt.assert_allclose(maximizers, expected_maximizers, rtol=1e-1)
+    
+    maximizers = optimizer(search_space, vectorized_target, vectorized_batch_size=vectorized_batch_size)
+    npt.assert_allclose(maximizers, expected_maximizers, rtol=1e-1)
+
+def test_batchify_vectorized_for_discrete_optimizer_on_vectorized_quadratic() -> None:
+    search_space = DiscreteSearchSpace(tf.constant([[0.3, -0.4], [1.0, 2.5], [0.2,0.5], [0.5,2.0],[2.0,0.1]]))
+    shifts = [[0.3, -0.4],[1.0, 4]]
+    expected_maximizers = [[0.3, -0.4], [1.0, 2.5]]
+    vectorized_batch_size=2
+
+    def vectorized_target(x: TensorType) -> TensorType: # [N, V, D] -> [N,V]
+        individual_func =  [_quadratic_sum(shifts[i])(x[:,i:i+1,:]) for i in range(vectorized_batch_size)]  
+        return tf.concat(individual_func, axis=-1)
+        
+    batched_optimizer =batchify_vectorize(optimize_discrete, batch_size=vectorized_batch_size)
+    maximizers = batched_optimizer(search_space, vectorized_target)
+    npt.assert_allclose(maximizers, expected_maximizers, rtol=1e-1)
+    
+    maximizers = optimize_discrete(search_space, vectorized_target, vectorized_batch_size=vectorized_batch_size)
+    npt.assert_allclose(maximizers, expected_maximizers, rtol=1e-1)
+
+
+@random_seed
+@pytest.mark.parametrize("vectorization", [1,5])
+@pytest.mark.parametrize(
+    "neg_function, expected_maximizer, search_space",
+    [
+        (ackley_5, ACKLEY_5_MINIMIZER, ACKLEY_5_SEARCH_SPACE),
+        (hartmann_3, HARTMANN_3_MINIMIZER, HARTMANN_3_SEARCH_SPACE),
+        (hartmann_6, HARTMANN_6_MINIMIZER, HARTMANN_6_SEARCH_SPACE),
+    ],
+)
+def test_batchify_vectorized_for_continuous_optimizer_on_duplicated_toy_problems(
+    vectorization: int,
+    neg_function: Callable[[TensorType], TensorType],
+    expected_maximizer: TensorType,
+    search_space: Box,
+) -> None:
+    def target_function(x: TensorType) -> TensorType: # [N,V,D] -> [N, V]
+        individual_func =  [-1 * neg_function(x[:,i,:]) for i in range(vectorization)]  
+        return tf.concat(individual_func, axis=-1) # vectorize by repeating same function
+
+    optimizer = batchify_vectorize(generate_continuous_optimizer(num_initial_samples=1_000, num_optimization_runs=10), batch_size=vectorization)
+    maximizer = optimizer(search_space, target_function)
+    npt.assert_allclose(maximizer, tf.tile(expected_maximizer,[vectorization,1]), rtol=1e-1)
+
+
+@random_seed
+def test_batchify_vectorized_for_continuous_optimizer_on_vectorized_toy_problems() -> None:
+    search_space = BRANIN_SEARCH_SPACE
+    functions = [branin, scaled_branin, simple_quadratic]
+    expected_maximimums = [-BRANIN_MINIMUM, -SCALED_BRANIN_MINIMUM, -SIMPLE_QUADRATIC_MINIMUM]
+    vectorized_batch_size=3
+
+    def target_function(x: TensorType) -> TensorType: # [N,V,D] -> [N, V]
+        individual_func =  [-1 * functions[i](x[:,i,:]) for i in range(vectorized_batch_size)]  
+        return tf.concat(individual_func, axis=-1) # vectorize by concatenating three functions
+
+    optimizer = batchify_vectorize(generate_continuous_optimizer(num_initial_samples=1_000, num_optimization_runs=10), batch_size=vectorized_batch_size)
+    maximizer = optimizer(search_space, target_function)
+    npt.assert_allclose(target_function(maximizer[None,:,:]), tf.transpose(expected_maximimums), rtol=1e-5)
+
+
+
 
 
 @random_seed
@@ -513,3 +624,12 @@ def test_automatic_optimizer_selector(
     optimizer = automatic_optimizer_selector
     point = optimizer(search_space, acquisition)
     npt.assert_allclose(point, maximizer, rtol=2e-4)
+
+
+
+
+
+
+
+
+

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -67,6 +67,22 @@ def test_generate_random_search_optimizer_raises_with_invalid_sample_size() -> N
         generate_random_search_optimizer(num_samples=-5)
 
 
+@pytest.mark.parametrize("batch_size", [0, -2])
+def test_optimize_discrete_raises_with_invalid_vectorized_batch_size(batch_size: int) -> None:
+    search_space = DiscreteSearchSpace(tf.constant([[-0.5], [0.2], [1.2], [1.7]]))
+    acq_fn = _quadratic_sum([1.0])
+    with pytest.raises(ValueError):
+        optimize_discrete(search_space, (acq_fn, batch_size))
+
+
+@pytest.mark.parametrize("batch_size", [0, -2])
+def test_random_optimizer_raises_with_invalid_vectorized_batch_size(batch_size: int) -> None:
+    search_space = Box([-1], [2])
+    acq_fn = _quadratic_sum([1.0])
+    with pytest.raises(ValueError):
+        generate_random_search_optimizer()(search_space, (acq_fn, batch_size))
+
+
 SP = TypeVar("SP", bound=SearchSpace)
 
 
@@ -177,6 +193,14 @@ def test_optimize_continuous_raises_for_impossible_optimization(
                     even after {num_recovery_runs + num_optimization_runs} restarts.
                     """
     )
+
+
+@pytest.mark.parametrize("batch_size", [0, -2])
+def test_optimize_continuous_raises_with_invalid_vectorized_batch_size(batch_size: int) -> None:
+    search_space = Box([-1], [2])
+    acq_fn = _quadratic_sum([1.0])
+    with pytest.raises(ValueError):
+        generate_continuous_optimizer()(search_space, (acq_fn, batch_size))
 
 
 @pytest.mark.parametrize("num_optimization_runs", [1, 10])
@@ -470,6 +494,16 @@ def test_batchify_joint_raises_with_invalid_batch_size() -> None:
         batchify_joint(batch_size_one_optimizer, -5)
 
 
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 5])
+def test_batchify_joint_raises_with_vectorized_acquisition_function(batch_size: int) -> None:
+    batch_size_one_optimizer = generate_continuous_optimizer()
+    optimizer = batchify_joint(batch_size_one_optimizer, 5)
+    search_space = Box([-1], [1])
+    acq_fn = _quadratic_sum([0.5])
+    with pytest.raises(ValueError):
+        optimizer(search_space, (acq_fn, batch_size))
+
+
 @random_seed
 @pytest.mark.parametrize("batch_size", [1, 2, 3, 5])
 @pytest.mark.parametrize(
@@ -494,6 +528,16 @@ def test_batchify_vectorized_raises_with_invalid_batch_size() -> None:
     batch_size_one_optimizer = generate_continuous_optimizer()
     with pytest.raises(ValueError):
         batchify_vectorize(batch_size_one_optimizer, -5)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 5])
+def test_batchify_vectorize_raises_with_vectorized_acquisition_function(batch_size: int) -> None:
+    batch_size_one_optimizer = generate_continuous_optimizer()
+    optimizer = batchify_vectorize(batch_size_one_optimizer, 5)
+    search_space = Box([-1], [1])
+    acq_fn = _quadratic_sum([0.5])
+    with pytest.raises(ValueError):
+        optimizer(search_space, (acq_fn, batch_size))
 
 
 @random_seed

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -518,11 +518,6 @@ def test_batchify_vectorized_for_random_and_continuous_optimizers_on_vectorized_
     maximizers = batched_optimizer(search_space, vectorized_target)
     npt.assert_allclose(maximizers, expected_maximizers, rtol=1e-1)
 
-    maximizers = optimizer(
-        search_space, vectorized_target, vectorized_batch_size=vectorized_batch_size
-    )
-    npt.assert_allclose(maximizers, expected_maximizers, rtol=1e-1)
-
 
 def test_batchify_vectorized_for_discrete_optimizer_on_vectorized_quadratic() -> None:
     search_space = DiscreteSearchSpace(
@@ -540,11 +535,6 @@ def test_batchify_vectorized_for_discrete_optimizer_on_vectorized_quadratic() ->
 
     batched_optimizer = batchify_vectorize(optimize_discrete, batch_size=vectorized_batch_size)
     maximizers = batched_optimizer(search_space, vectorized_target)
-    npt.assert_allclose(maximizers, expected_maximizers, rtol=1e-1)
-
-    maximizers = optimize_discrete(
-        search_space, vectorized_target, vectorized_batch_size=vectorized_batch_size
-    )
     npt.assert_allclose(maximizers, expected_maximizers, rtol=1e-1)
 
 

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -33,7 +33,7 @@ from trieste.acquisition import (
     NegativeLowerConfidenceBound,
     SingleModelAcquisitionBuilder,
     SingleModelGreedyAcquisitionBuilder,
-    VectorizedAcquisitionFunctionBuilder
+    VectorizedAcquisitionFunctionBuilder,
 )
 from trieste.acquisition.optimizer import AcquisitionOptimizer
 from trieste.acquisition.rule import (
@@ -314,7 +314,6 @@ class _GreedyBatchModelMinusMeanMaximumSingleBuilder(
         )
 
 
-
 @random_seed
 @pytest.mark.parametrize(
     "rule_fn",
@@ -363,20 +362,15 @@ def test_greedy_batch_acquisition_rule_acquire(
     assert acq._update_count == 2 * num_query_points - 1
 
 
-
-
-
-
-
-
-
-class _VectorizedBatchModelMinusMeanMaximumSingleBuilder(VectorizedAcquisitionFunctionBuilder[ProbabilisticModel]):
+class _VectorizedBatchModelMinusMeanMaximumSingleBuilder(
+    VectorizedAcquisitionFunctionBuilder[ProbabilisticModel]
+):
     def prepare_acquisition_function(
         self,
         models: Mapping[str, ProbabilisticModel],
         datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
-        return lambda at: tf.squeeze(-models[OBJECTIVE].predict(at)[0],-1)
+        return lambda at: tf.squeeze(-models[OBJECTIVE].predict(at)[0], -1)
 
 
 @random_seed
@@ -384,7 +378,9 @@ def test_vectorized_batch_acquisition_rule_acquire() -> None:
     search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
     num_query_points = 4
     acq = _VectorizedBatchModelMinusMeanMaximumSingleBuilder()
-    acq_rule =  EfficientGlobalOptimization(acq, num_query_points=num_query_points)
+    acq_rule: AcquisitionRule[TensorType, Box] = EfficientGlobalOptimization(
+        acq, num_query_points=num_query_points
+    )
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
     points_or_stateful = acq_rule.acquire_single(
         search_space, QuadraticMeanAndRBFKernel(), dataset=dataset
@@ -394,7 +390,6 @@ def test_vectorized_batch_acquisition_rule_acquire() -> None:
     else:
         query_point = points_or_stateful
     npt.assert_allclose(query_point, [[0.0, 0.0]] * num_query_points, atol=1e-3)
-
 
 
 def test_async_greedy_raises_for_non_greedy_function() -> None:

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -33,6 +33,7 @@ from trieste.acquisition import (
     NegativeLowerConfidenceBound,
     SingleModelAcquisitionBuilder,
     SingleModelGreedyAcquisitionBuilder,
+    VectorizedAcquisitionFunctionBuilder
 )
 from trieste.acquisition.optimizer import AcquisitionOptimizer
 from trieste.acquisition.rule import (
@@ -313,6 +314,7 @@ class _GreedyBatchModelMinusMeanMaximumSingleBuilder(
         )
 
 
+
 @random_seed
 @pytest.mark.parametrize(
     "rule_fn",
@@ -359,6 +361,40 @@ def test_greedy_batch_acquisition_rule_acquire(
         query_points = points_or_stateful
     npt.assert_allclose(query_points, [[0.0, 0.0]] * num_query_points, atol=1e-3)
     assert acq._update_count == 2 * num_query_points - 1
+
+
+
+
+
+
+
+
+
+class _VectorizedBatchModelMinusMeanMaximumSingleBuilder(VectorizedAcquisitionFunctionBuilder[ProbabilisticModel]):
+    def prepare_acquisition_function(
+        self,
+        models: Mapping[str, ProbabilisticModel],
+        datasets: Optional[Mapping[str, Dataset]] = None,
+    ) -> AcquisitionFunction:
+        return lambda at: tf.squeeze(-models[OBJECTIVE].predict(at)[0],-1)
+
+
+@random_seed
+def test_vectorized_batch_acquisition_rule_acquire() -> None:
+    search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
+    num_query_points = 4
+    acq = _VectorizedBatchModelMinusMeanMaximumSingleBuilder()
+    acq_rule =  EfficientGlobalOptimization(acq, num_query_points=num_query_points)
+    dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))
+    points_or_stateful = acq_rule.acquire_single(
+        search_space, QuadraticMeanAndRBFKernel(), dataset=dataset
+    )
+    if callable(points_or_stateful):
+        _, query_point = points_or_stateful(None)
+    else:
+        query_point = points_or_stateful
+    npt.assert_allclose(query_point, [[0.0, 0.0]] * num_query_points, atol=1e-3)
+
 
 
 def test_async_greedy_raises_for_non_greedy_function() -> None:

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -892,4 +892,4 @@ def test_product_search_space_deepcopy() -> None:
     copied_space = copy.deepcopy(product_space)
     npt.assert_allclose(copied_space.get_subspace("A").lower, space_A.lower)
     npt.assert_allclose(copied_space.get_subspace("A").upper, space_A.upper)
-    npt.assert_allclose(copied_space.get_subspace("B").points, space_B.points) # type: ignore
+    npt.assert_allclose(copied_space.get_subspace("B").points, space_B.points)  # type: ignore

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -81,27 +81,23 @@ def test_discrete_search_space_points() -> None:
     npt.assert_array_equal(space.points, _points_in_2D_search_space())
 
 
-
 def test_discrete_search_space_initial_vectorized_batch_size() -> None:
     space = DiscreteSearchSpace(_points_in_2D_search_space())
     assert space.vectorized_batch_size == 1
 
 
-
-@pytest.mark.parametrize("batch_size", [-5,0])
+@pytest.mark.parametrize("batch_size", [-5, 0])
 def test_discrete_search_space_raises_with_negative_batch_size(batch_size: int) -> None:
     space = DiscreteSearchSpace(_points_in_2D_search_space())
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        space.set_vectorized_batch_size(batch_size)   
+        space.set_vectorized_batch_size(batch_size)
 
 
-@pytest.mark.parametrize("batch_size", [5,100])
+@pytest.mark.parametrize("batch_size", [5, 100])
 def test_discrete_search_space_set_vectorized_batch_size(batch_size: int) -> None:
     space = DiscreteSearchSpace(_points_in_2D_search_space())
     space.set_vectorized_batch_size(batch_size)
-    assert space.vectorized_batch_size==batch_size
-
-
+    assert space.vectorized_batch_size == batch_size
 
 
 @pytest.mark.parametrize("point", list(_points_in_2D_search_space()))
@@ -338,31 +334,26 @@ def test_box_bounds_attributes() -> None:
     npt.assert_array_equal(box.upper, upper)
 
 
-
-
 def test_box_initial_vectorized_batch_size() -> None:
     lower, upper = tf.zeros([2]), tf.ones([2])
     space = Box(lower, upper)
     assert space.vectorized_batch_size == 1
 
 
-
-@pytest.mark.parametrize("batch_size", [-5,0])
+@pytest.mark.parametrize("batch_size", [-5, 0])
 def test_box_raises_with_negative_batch_size(batch_size: int) -> None:
     lower, upper = tf.zeros([2]), tf.ones([2])
     space = Box(lower, upper)
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        space.set_vectorized_batch_size(batch_size)   
+        space.set_vectorized_batch_size(batch_size)
 
 
-@pytest.mark.parametrize("batch_size", [5,100])
+@pytest.mark.parametrize("batch_size", [5, 100])
 def test_box_set_vectorized_batch_size(batch_size: int) -> None:
     lower, upper = tf.zeros([2]), tf.ones([2])
     space = Box(lower, upper)
     space.set_vectorized_batch_size(batch_size)
-    assert space.vectorized_batch_size==batch_size
-
-
+    assert space.vectorized_batch_size == batch_size
 
 
 @pytest.mark.parametrize(
@@ -569,7 +560,6 @@ def test_product_space_subspace_tags_default_behaviour() -> None:
     npt.assert_array_equal(product_space.subspace_tags, ["0", "1"])
 
 
-
 def test_product_space_initial_vectorized_batch_size() -> None:
     decision_space = Box([-1, -2], [2, 3])
     context_space = DiscreteSearchSpace(tf.constant([[-0.5, 0.5]]))
@@ -577,28 +567,22 @@ def test_product_space_initial_vectorized_batch_size() -> None:
     assert space.vectorized_batch_size == 1
 
 
-
-@pytest.mark.parametrize("batch_size", [-5,0])
+@pytest.mark.parametrize("batch_size", [-5, 0])
 def test_product_space_raises_with_negative_batch_size(batch_size: int) -> None:
     decision_space = Box([-1, -2], [2, 3])
     context_space = DiscreteSearchSpace(tf.constant([[-0.5, 0.5]]))
     space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        space.set_vectorized_batch_size(batch_size)   
+        space.set_vectorized_batch_size(batch_size)
 
 
-@pytest.mark.parametrize("batch_size", [5,100])
+@pytest.mark.parametrize("batch_size", [5, 100])
 def test_product_space_set_vectorized_batch_size(batch_size: int) -> None:
     decision_space = Box([-1, -2], [2, 3])
     context_space = DiscreteSearchSpace(tf.constant([[-0.5, 0.5]]))
     space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
     space.set_vectorized_batch_size(batch_size)
-    assert space.vectorized_batch_size==batch_size
-
-
-
-
-
+    assert space.vectorized_batch_size == batch_size
 
 
 @pytest.mark.parametrize(
@@ -898,3 +882,14 @@ def test_product_space___mul___() -> None:
     subspace_1_D = subspace_1.get_subspace("D")  # type: ignore
     assert isinstance(subspace_1_D, DiscreteSearchSpace)
     npt.assert_array_equal(subspace_1_D.points, tf.ones([5, 3], dtype=tf.float64))
+
+
+def test_product_search_space_deepcopy() -> None:
+    space_A = Box([-1], [2])
+    space_B = DiscreteSearchSpace(tf.ones([100, 2], dtype=tf.float64))
+    product_space = TaggedProductSearchSpace(spaces=[space_A, space_B], tags=["A", "B"])
+
+    copied_space = copy.deepcopy(product_space)
+    npt.assert_allclose(copied_space.get_subspace("A").lower, space_A.lower)
+    npt.assert_allclose(copied_space.get_subspace("A").upper, space_A.upper)
+    npt.assert_allclose(copied_space.get_subspace("B").points, space_B.points) # type: ignore

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -81,25 +81,6 @@ def test_discrete_search_space_points() -> None:
     npt.assert_array_equal(space.points, _points_in_2D_search_space())
 
 
-def test_discrete_search_space_initial_vectorized_batch_size() -> None:
-    space = DiscreteSearchSpace(_points_in_2D_search_space())
-    assert space.vectorized_batch_size == 1
-
-
-@pytest.mark.parametrize("batch_size", [-5, 0])
-def test_discrete_search_space_raises_with_negative_batch_size(batch_size: int) -> None:
-    space = DiscreteSearchSpace(_points_in_2D_search_space())
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        space.set_vectorized_batch_size(batch_size)
-
-
-@pytest.mark.parametrize("batch_size", [5, 100])
-def test_discrete_search_space_set_vectorized_batch_size(batch_size: int) -> None:
-    space = DiscreteSearchSpace(_points_in_2D_search_space())
-    space.set_vectorized_batch_size(batch_size)
-    assert space.vectorized_batch_size == batch_size
-
-
 @pytest.mark.parametrize("point", list(_points_in_2D_search_space()))
 def test_discrete_search_space_contains_all_its_points(point: tf.Tensor) -> None:
     assert point in DiscreteSearchSpace(_points_in_2D_search_space())
@@ -334,28 +315,6 @@ def test_box_bounds_attributes() -> None:
     npt.assert_array_equal(box.upper, upper)
 
 
-def test_box_initial_vectorized_batch_size() -> None:
-    lower, upper = tf.zeros([2]), tf.ones([2])
-    space = Box(lower, upper)
-    assert space.vectorized_batch_size == 1
-
-
-@pytest.mark.parametrize("batch_size", [-5, 0])
-def test_box_raises_with_negative_batch_size(batch_size: int) -> None:
-    lower, upper = tf.zeros([2]), tf.ones([2])
-    space = Box(lower, upper)
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        space.set_vectorized_batch_size(batch_size)
-
-
-@pytest.mark.parametrize("batch_size", [5, 100])
-def test_box_set_vectorized_batch_size(batch_size: int) -> None:
-    lower, upper = tf.zeros([2]), tf.ones([2])
-    space = Box(lower, upper)
-    space.set_vectorized_batch_size(batch_size)
-    assert space.vectorized_batch_size == batch_size
-
-
 @pytest.mark.parametrize(
     "point",
     [
@@ -558,31 +517,6 @@ def test_product_space_subspace_tags_default_behaviour() -> None:
     product_space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
 
     npt.assert_array_equal(product_space.subspace_tags, ["0", "1"])
-
-
-def test_product_space_initial_vectorized_batch_size() -> None:
-    decision_space = Box([-1, -2], [2, 3])
-    context_space = DiscreteSearchSpace(tf.constant([[-0.5, 0.5]]))
-    space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
-    assert space.vectorized_batch_size == 1
-
-
-@pytest.mark.parametrize("batch_size", [-5, 0])
-def test_product_space_raises_with_negative_batch_size(batch_size: int) -> None:
-    decision_space = Box([-1, -2], [2, 3])
-    context_space = DiscreteSearchSpace(tf.constant([[-0.5, 0.5]]))
-    space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        space.set_vectorized_batch_size(batch_size)
-
-
-@pytest.mark.parametrize("batch_size", [5, 100])
-def test_product_space_set_vectorized_batch_size(batch_size: int) -> None:
-    decision_space = Box([-1, -2], [2, 3])
-    context_space = DiscreteSearchSpace(tf.constant([[-0.5, 0.5]]))
-    space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
-    space.set_vectorized_batch_size(batch_size)
-    assert space.vectorized_batch_size == batch_size
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -81,6 +81,29 @@ def test_discrete_search_space_points() -> None:
     npt.assert_array_equal(space.points, _points_in_2D_search_space())
 
 
+
+def test_discrete_search_space_initial_vectorized_batch_size() -> None:
+    space = DiscreteSearchSpace(_points_in_2D_search_space())
+    assert space.vectorized_batch_size == 1
+
+
+
+@pytest.mark.parametrize("batch_size", [-5,0])
+def test_discrete_search_space_raises_with_negative_batch_size(batch_size: int) -> None:
+    space = DiscreteSearchSpace(_points_in_2D_search_space())
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        space.set_vectorized_batch_size(batch_size)   
+
+
+@pytest.mark.parametrize("batch_size", [5,100])
+def test_discrete_search_space_set_vectorized_batch_size(batch_size: int) -> None:
+    space = DiscreteSearchSpace(_points_in_2D_search_space())
+    space.set_vectorized_batch_size(batch_size)
+    assert space.vectorized_batch_size==batch_size
+
+
+
+
 @pytest.mark.parametrize("point", list(_points_in_2D_search_space()))
 def test_discrete_search_space_contains_all_its_points(point: tf.Tensor) -> None:
     assert point in DiscreteSearchSpace(_points_in_2D_search_space())
@@ -315,6 +338,33 @@ def test_box_bounds_attributes() -> None:
     npt.assert_array_equal(box.upper, upper)
 
 
+
+
+def test_box_initial_vectorized_batch_size() -> None:
+    lower, upper = tf.zeros([2]), tf.ones([2])
+    space = Box(lower, upper)
+    assert space.vectorized_batch_size == 1
+
+
+
+@pytest.mark.parametrize("batch_size", [-5,0])
+def test_box_raises_with_negative_batch_size(batch_size: int) -> None:
+    lower, upper = tf.zeros([2]), tf.ones([2])
+    space = Box(lower, upper)
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        space.set_vectorized_batch_size(batch_size)   
+
+
+@pytest.mark.parametrize("batch_size", [5,100])
+def test_box_set_vectorized_batch_size(batch_size: int) -> None:
+    lower, upper = tf.zeros([2]), tf.ones([2])
+    space = Box(lower, upper)
+    space.set_vectorized_batch_size(batch_size)
+    assert space.vectorized_batch_size==batch_size
+
+
+
+
 @pytest.mark.parametrize(
     "point",
     [
@@ -517,6 +567,38 @@ def test_product_space_subspace_tags_default_behaviour() -> None:
     product_space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
 
     npt.assert_array_equal(product_space.subspace_tags, ["0", "1"])
+
+
+
+def test_product_space_initial_vectorized_batch_size() -> None:
+    decision_space = Box([-1, -2], [2, 3])
+    context_space = DiscreteSearchSpace(tf.constant([[-0.5, 0.5]]))
+    space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
+    assert space.vectorized_batch_size == 1
+
+
+
+@pytest.mark.parametrize("batch_size", [-5,0])
+def test_product_space_raises_with_negative_batch_size(batch_size: int) -> None:
+    decision_space = Box([-1, -2], [2, 3])
+    context_space = DiscreteSearchSpace(tf.constant([[-0.5, 0.5]]))
+    space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        space.set_vectorized_batch_size(batch_size)   
+
+
+@pytest.mark.parametrize("batch_size", [5,100])
+def test_product_space_set_vectorized_batch_size(batch_size: int) -> None:
+    decision_space = Box([-1, -2], [2, 3])
+    context_space = DiscreteSearchSpace(tf.constant([[-0.5, 0.5]]))
+    space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
+    space.set_vectorized_batch_size(batch_size)
+    assert space.vectorized_batch_size==batch_size
+
+
+
+
+
 
 
 @pytest.mark.parametrize(

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -48,8 +48,8 @@ from .function import (
     Fantasizer,
     LocalPenalization,
     MinValueEntropySearch,
-    NegativeLowerConfidenceBound,
     MultipleOptimismNegativeLowerConfidenceBound,
+    NegativeLowerConfidenceBound,
     NegativePredictiveMean,
     PredictiveVariance,
     ProbabilityOfFeasibility,
@@ -72,12 +72,12 @@ from .interface import (
     AcquisitionFunctionBuilder,
     AcquisitionFunctionClass,
     GreedyAcquisitionFunctionBuilder,
-    VectorizedAcquisitionFunctionBuilder,
     PenalizationFunction,
     SingleModelAcquisitionBuilder,
     SingleModelGreedyAcquisitionBuilder,
     SingleModelVectorizedAcquisitionBuilder,
     UpdatablePenalizationFunction,
+    VectorizedAcquisitionFunctionBuilder,
 )
 from .sampler import (
     ExactThompsonSampler,

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -49,6 +49,7 @@ from .function import (
     LocalPenalization,
     MinValueEntropySearch,
     NegativeLowerConfidenceBound,
+    MultipleOptimismNegativeLowerConfidenceBound,
     NegativePredictiveMean,
     PredictiveVariance,
     ProbabilityOfFeasibility,
@@ -61,6 +62,7 @@ from .function import (
     hard_local_penalizer,
     lower_confidence_bound,
     min_value_entropy_search,
+    multiple_optimism_lower_confidence_bound,
     predictive_variance,
     probability_of_feasibility,
     soft_local_penalizer,
@@ -70,9 +72,11 @@ from .interface import (
     AcquisitionFunctionBuilder,
     AcquisitionFunctionClass,
     GreedyAcquisitionFunctionBuilder,
+    VectorizedAcquisitionFunctionBuilder,
     PenalizationFunction,
     SingleModelAcquisitionBuilder,
     SingleModelGreedyAcquisitionBuilder,
+    SingleModelVectorizedAcquisitionBuilder,
     UpdatablePenalizationFunction,
 )
 from .sampler import (

--- a/trieste/acquisition/function/__init__.py
+++ b/trieste/acquisition/function/__init__.py
@@ -39,8 +39,8 @@ from .function import (
     augmented_expected_improvement,
     expected_improvement,
     lower_confidence_bound,
-    probability_of_feasibility,
     multiple_optimism_lower_confidence_bound,
+    probability_of_feasibility,
 )
 from .greedy_batch import Fantasizer, LocalPenalization, hard_local_penalizer, soft_local_penalizer
 from .multi_objective import (

--- a/trieste/acquisition/function/__init__.py
+++ b/trieste/acquisition/function/__init__.py
@@ -32,6 +32,7 @@ from .function import (
     BatchMonteCarloExpectedImprovement,
     ExpectedConstrainedImprovement,
     ExpectedImprovement,
+    MultipleOptimismNegativeLowerConfidenceBound,
     NegativeLowerConfidenceBound,
     NegativePredictiveMean,
     ProbabilityOfFeasibility,
@@ -39,6 +40,7 @@ from .function import (
     expected_improvement,
     lower_confidence_bound,
     probability_of_feasibility,
+    multiple_optimism_lower_confidence_bound,
 )
 from .greedy_batch import Fantasizer, LocalPenalization, hard_local_penalizer, soft_local_penalizer
 from .multi_objective import (

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -711,7 +711,7 @@ class MultipleOptimismNegativeLowerConfidenceBound(
     A simple parallelization of the lower confidence bound acquisition function that produces
     a vectorized acquisition function which can efficiently optimized even for large batches.
 
-    See :cite:`torossian2020bayesian` for details. 
+    See :cite:`torossian2020bayesian` for details.
     """
 
     def __init__(self, search_space: SearchSpace):
@@ -756,11 +756,11 @@ class multiple_optimism_lower_confidence_bound(AcquisitionFunctionClass):
     The multiple optimism lower confidence bound (MOLCB) acquisition function for single-objective
     global optimization.
 
-    Each batch dimension of this acquisiton function correponds to a lower confidence bound acquisition
-    function with different beta values, i.e. each point in a batch chosen by this acquisition function
-    lies on a gradient of exploration/exploitation trade-offs.
+    Each batch dimension of this acquisiton function correponds to a lower confidence bound
+    acquisition function with different beta values, i.e. each point in a batch chosen by this
+    acquisition function lies on a gradient of exploration/exploitation trade-offs.
 
-    We choose the different beta values following the cdf method of :cite:`torossian2020bayesian`. 
+    We choose the different beta values following the cdf method of :cite:`torossian2020bayesian`.
     See their paper for more details.
     """
 
@@ -806,4 +806,4 @@ class multiple_optimism_lower_confidence_bound(AcquisitionFunctionClass):
 
         mean, variance = self._model.predict(x)  # [..., B, 1]
         mean, variance = tf.squeeze(mean, -1), tf.squeeze(variance, -1)
-        return -mean + tf.sqrt(variance) * self._betas  # [..., B] 
+        return -mean + tf.sqrt(variance) * self._betas  # [..., B]

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -33,7 +33,6 @@ from ..interface import (
     AcquisitionFunctionClass,
     SingleModelAcquisitionBuilder,
     SingleModelVectorizedAcquisitionBuilder,
-    VectorizedAcquisitionFunction,
 )
 
 
@@ -728,7 +727,7 @@ class MultipleOptimismNegativeLowerConfidenceBound(
         self,
         model: ProbabilisticModel,
         dataset: Optional[Dataset] = None,
-    ) -> VectorizedAcquisitionFunction:
+    ) -> AcquisitionFunction:
         """
         :param model: The model.
         :param dataset: Unused.
@@ -738,10 +737,10 @@ class MultipleOptimismNegativeLowerConfidenceBound(
 
     def update_acquisition_function(
         self,
-        function: VectorizedAcquisitionFunction,
+        function: AcquisitionFunction,
         model: ProbabilisticModel,
         dataset: Optional[Dataset] = None,
-    ) -> VectorizedAcquisitionFunction:
+    ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
         :param model: The model.

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -53,9 +53,6 @@ with a batch dimension, i.e. an input of shape `[..., 1, D]`.
 """
 
 
-
-
-
 class AcquisitionFunctionClass(ABC):
     """An :class:`AcquisitionFunctionClass` is an acquisition function represented using a class
     rather than as a standalone function. Using a class to represent an acquisition function
@@ -65,9 +62,6 @@ class AcquisitionFunctionClass(ABC):
     @abstractmethod
     def __call__(self, x: TensorType) -> TensorType:
         """Call acquisition function."""
-
-
-
 
 
 T = TypeVar("T", bound=ProbabilisticModel)
@@ -325,7 +319,6 @@ class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
         )
 
 
-
 class VectorizedAcquisitionFunctionBuilder(Generic[T], ABC):
     """An :class:`AcquisitionFunctionBuilder` builds and updates an acquisition function. TODO"""
 
@@ -431,9 +424,6 @@ class SingleModelVectorizedAcquisitionBuilder(Generic[T], ABC):
         :return: The updated acquisition function.
         """
         return self.prepare_acquisition_function(model, dataset=dataset)
-
-
-
 
 
 PenalizationFunction = Callable[[TensorType], TensorType]

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -41,6 +41,8 @@ VectorizedAcquisitionFunction = Callable[[TensorType], TensorType]
 """
 Type alias for acquisition functions.
 
+TODO add batch_size
+
 An :const:`AcquisitionFunction` maps a set of `B` query points (each of dimension `D`) to a single
 value that describes how useful it would be evaluate all these points together (to our goal of
 optimizing the objective function). Thus, with leading dimensions, an :const:`AcquisitionFunction`
@@ -49,7 +51,6 @@ takes input shape `[..., B, D]` and returns shape `[..., B]`.
 Note that :const:`AcquisitionFunction`s which do not support batch optimization still expect inputs
 with a batch dimension, i.e. an input of shape `[..., 1, D]`.
 """
-
 
 
 
@@ -64,6 +65,7 @@ class AcquisitionFunctionClass(ABC):
     @abstractmethod
     def __call__(self, x: TensorType) -> TensorType:
         """Call acquisition function."""
+
 
 
 T = TypeVar("T", bound=ProbabilisticModel)

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -37,6 +37,23 @@ Note that :const:`AcquisitionFunction`s which do not support batch optimization 
 with a batch dimension, i.e. an input of shape `[..., 1, D]`.
 """
 
+VectorizedAcquisitionFunction = Callable[[TensorType], TensorType]
+"""
+Type alias for acquisition functions.
+
+An :const:`AcquisitionFunction` maps a set of `B` query points (each of dimension `D`) to a single
+value that describes how useful it would be evaluate all these points together (to our goal of
+optimizing the objective function). Thus, with leading dimensions, an :const:`AcquisitionFunction`
+takes input shape `[..., B, D]` and returns shape `[..., B]`.
+
+Note that :const:`AcquisitionFunction`s which do not support batch optimization still expect inputs
+with a batch dimension, i.e. an input of shape `[..., 1, D]`.
+"""
+
+
+
+
+
 
 class AcquisitionFunctionClass(ABC):
     """An :class:`AcquisitionFunctionClass` is an acquisition function represented using a class

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -160,8 +160,8 @@ class GreedyAcquisitionFunctionBuilder(Generic[T], ABC):
     """
     A :class:`GreedyAcquisitionFunctionBuilder` builds an acquisition function
     suitable for greedily building batches for batch Bayesian
-    Optimization. :class:`GreedyAcquisitionFunctionBuilder` differs
-    from :class:`AcquisitionFunctionBuilder` by requiring that a set
+    Optimization. A :class:`GreedyAcquisitionFunctionBuilder` differs
+    from an :class:`AcquisitionFunctionBuilder` by requiring that a set
     of pending points is passed to the builder. Note that this acquisition function
     is typically called `B` times each Bayesian optimization step, when building batches
     of size `B`.
@@ -308,7 +308,7 @@ class VectorizedAcquisitionFunctionBuilder(AcquisitionFunctionBuilder[T]):
     """
     An :class:`VectorizedAcquisitionFunctionBuilder` builds and updates a vectorized
     acquisition function These differ from normal acquisition functions only by their output shape:
-    rather than returng a single value, they return one value per potential query point.
+    rather than returning a single value, they return one value per potential query point.
     Thus, with leading dimensions, they take input shape `[..., B, D]` and returns shape `[..., B]`.
     """
 

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -39,17 +39,14 @@ with a batch dimension, i.e. an input of shape `[..., 1, D]`.
 
 VectorizedAcquisitionFunction = Callable[[TensorType], TensorType]
 """
-Type alias for acquisition functions.
+Type alias for vectorized acquisition functions.
 
-TODO add batch_size
+An :const:`VectorizedAcquisitionFunction` differs from an :const:`AcquisitionFunction` only by its
+output shape. An :const:`VectorizedAcquisitionFunction` maps a set of maps a set of `B` query points
+(each of dimension `D`) to a `B` values that describes how useful it would be evaluate each of these
+points (to our goal of optimizing the objective function). Thus, with leading dimensions, a
+:const:`VectorizedAcquisitionFunction` takes input shape `[..., B, D]` and returns shape `[..., B]`.
 
-An :const:`AcquisitionFunction` maps a set of `B` query points (each of dimension `D`) to a single
-value that describes how useful it would be evaluate all these points together (to our goal of
-optimizing the objective function). Thus, with leading dimensions, an :const:`AcquisitionFunction`
-takes input shape `[..., B, D]` and returns shape `[..., B]`.
-
-Note that :const:`AcquisitionFunction`s which do not support batch optimization still expect inputs
-with a batch dimension, i.e. an input of shape `[..., 1, D]`.
 """
 
 
@@ -320,7 +317,7 @@ class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
 
 
 class VectorizedAcquisitionFunctionBuilder(Generic[T], ABC):
-    """An :class:`AcquisitionFunctionBuilder` builds and updates an acquisition function. TODO"""
+    """An :class:`VectorizedAcquisitionFunctionBuilder` builds and updates a vectorized acquisition function."""
 
     @abstractmethod
     def prepare_acquisition_function(
@@ -329,13 +326,12 @@ class VectorizedAcquisitionFunctionBuilder(Generic[T], ABC):
         datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> VectorizedAcquisitionFunction:
         """
-        TODO
-        Prepare an acquisition function. We assume that this requires at least models, but
+        Prepare a vectorized acquisition function. We assume that this requires at least models, but
         it may sometimes also need data.
 
         :param models: The models for each tag.
         :param datasets: The data from the observer (optional).
-        :return: An acquisition function.
+        :return: An vectorized acquisition function.
         """
 
     def update_acquisition_function(
@@ -345,30 +341,28 @@ class VectorizedAcquisitionFunctionBuilder(Generic[T], ABC):
         datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> VectorizedAcquisitionFunction:
         """
-        TODO
-        Update an acquisition function. By default this generates a new acquisition function each
-        time. However, if the function is decorated with `@tf.function`, then you can override
+        Update a vectorized acquisition function. By default this generates a new acquisition function
+        each time. However, if the function is decorated with `@tf.function`, then you can override
         this method to update its variables instead and avoid retracing the acquisition function on
         every optimization loop.
 
-        :param function: The acquisition function to update.
+        :param function: The vectorized acquisition function to update.
         :param models: The models for each tag.
         :param datasets: The data from the observer (optional).
-        :return: The updated acquisition function.
+        :return: The updated vectorized acquisition function.
         """
         return self.prepare_acquisition_function(models, datasets=datasets)
 
 
 class SingleModelVectorizedAcquisitionBuilder(Generic[T], ABC):
     """
-    TODO
-    Convenience acquisition function builder for an acquisition function (or component of a
-    composite acquisition function) that requires only one model, dataset pair.
+    Convenience acquisition function builder for a vectorized acquisition function (or component of a
+    composite vectorized acquisition function) that requires only one model, dataset pair.
     """
 
     def using(self, tag: str) -> VectorizedAcquisitionFunctionBuilder[T]:
         """
-        :param tag: The tag for the model, dataset pair to use to build this acquisition function.
+        :param tag: The tag for the model, dataset pair used to build this vectorized acquisition function.
         :return: An acquisition function builder that selects the model and dataset specified by
             ``tag``, as defined in :meth:`prepare_acquisition_function`.
         """
@@ -407,7 +401,7 @@ class SingleModelVectorizedAcquisitionBuilder(Generic[T], ABC):
     ) -> VectorizedAcquisitionFunction:
         """
         :param model: The model.
-        :param dataset: The data to use to build the acquisition function (optional).
+        :param dataset: The data to use to build the vectorized acquisition function (optional).
         :return: An acquisition function.
         """
 
@@ -418,10 +412,10 @@ class SingleModelVectorizedAcquisitionBuilder(Generic[T], ABC):
         dataset: Optional[Dataset] = None,
     ) -> VectorizedAcquisitionFunction:
         """
-        :param function: The acquisition function to update.
+        :param function: The vectorized acquisition function to update.
         :param model: The model.
         :param dataset: The data from the observer (optional).
-        :return: The updated acquisition function.
+        :return: The updated vectorized acquisition function.
         """
         return self.prepare_acquisition_function(model, dataset=dataset)
 

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -317,7 +317,10 @@ class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
 
 
 class VectorizedAcquisitionFunctionBuilder(Generic[T], ABC):
-    """An :class:`VectorizedAcquisitionFunctionBuilder` builds and updates a vectorized acquisition function."""
+    """
+    An :class:`VectorizedAcquisitionFunctionBuilder` builds and updates a vectorized
+    acquisition function.
+    """
 
     @abstractmethod
     def prepare_acquisition_function(
@@ -341,10 +344,10 @@ class VectorizedAcquisitionFunctionBuilder(Generic[T], ABC):
         datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> VectorizedAcquisitionFunction:
         """
-        Update a vectorized acquisition function. By default this generates a new acquisition function
-        each time. However, if the function is decorated with `@tf.function`, then you can override
-        this method to update its variables instead and avoid retracing the acquisition function on
-        every optimization loop.
+        Update a vectorized acquisition function. By default this generates a new acquisition
+        function each time. However, if the function is decorated with `@tf.function`, then you
+        can override this method to update its variables instead and avoid retracing the acquisition
+        function on every optimization loop.
 
         :param function: The vectorized acquisition function to update.
         :param models: The models for each tag.
@@ -356,13 +359,14 @@ class VectorizedAcquisitionFunctionBuilder(Generic[T], ABC):
 
 class SingleModelVectorizedAcquisitionBuilder(Generic[T], ABC):
     """
-    Convenience acquisition function builder for a vectorized acquisition function (or component of a
-    composite vectorized acquisition function) that requires only one model, dataset pair.
+    Convenience acquisition function builder for a vectorized acquisition function (or component
+    of a composite vectorized acquisition function) that requires only one model, dataset pair.
     """
 
     def using(self, tag: str) -> VectorizedAcquisitionFunctionBuilder[T]:
         """
-        :param tag: The tag for the model, dataset pair used to build this vectorized acquisition function.
+        :param tag: The tag for the model, dataset pair used to build this vectorized
+            acquisition function.
         :return: An acquisition function builder that selects the model and dataset specified by
             ``tag``, as defined in :meth:`prepare_acquisition_function`.
         """

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -315,8 +315,8 @@ class VectorizedAcquisitionFunctionBuilder(AcquisitionFunctionBuilder[T]):
 
 class SingleModelVectorizedAcquisitionBuilder(SingleModelAcquisitionBuilder[T]):
     """
-    Convenience acquisition function builder for a vectorized acquisition function (or component
-    of a composite vectorized acquisition function) that requires only one model, dataset pair. TODO
+    Convenience acquisition function builder for vectorized acquisition functions (or component
+    of a composite vectorized acquisition function) that requires only one model, dataset pair.
     """
 
     def using(self, tag: str) -> AcquisitionFunctionBuilder[T]:

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -184,9 +184,7 @@ def generate_continuous_optimizer(
         raise ValueError(f"num_initial_samples must be positive, got {num_initial_samples}")
 
     if num_optimization_runs < 0:
-        raise ValueError(
-            f"num_initial_samples must be positive, got {num_initial_samples}"
-        )
+        raise ValueError(f"num_initial_samples must be positive, got {num_initial_samples}")
 
     if num_initial_samples < num_optimization_runs:
         raise ValueError(
@@ -335,7 +333,7 @@ def _perform_parallel_continuous_optimization(
     optimize over a continuous :class:'Box' relaxation of the discrete subspaces
     which has equal upper and lower bounds, i.e. we specify an equality constraint
     for this dimension in the scipy optimizer.
-    
+
     This function also support the maximization of vectorized target functions (with
     vectorization V).
 
@@ -361,13 +359,13 @@ def _perform_parallel_continuous_optimization(
 
     vectorized_starting_points = tf.reshape(
         starting_points, [-1, D]
-    )  # [num_optimization_runs*V, D] 
+    )  # [num_optimization_runs*V, D]
 
     def _objective_value(vectorized_x: TensorType) -> TensorType:  # [N, D] -> [N, 1]
         vectorized_x = vectorized_x[:, None, :]  # [N, 1, D]
         x = tf.reshape(vectorized_x, [-1, V, D])  # [N/V, V, D]
         evals = -target_func(x)  # [N/V, V]
-        vectorized_evals = tf.reshape(evals, [-1, 1])  # [N, 1] 
+        vectorized_evals = tf.reshape(evals, [-1, 1])  # [N, 1]
         return vectorized_evals
 
     def _objective_value_and_gradient(x: TensorType) -> Tuple[TensorType, TensorType]:
@@ -430,15 +428,9 @@ def _perform_parallel_continuous_optimization(
         [result.x for result in vectorized_child_results], dtype=tf_dtype
     )  # [num_optimization_runs, D]
 
-    successes = tf.reshape(
-        vectorized_successes, [-1, V]
-    )  # [num_optimization_runs, V] 
-    fun_values = tf.reshape(
-        vectorized_fun_values, [-1, V]
-    )  # [num_optimization_runs, V] 
-    chosen_x = tf.reshape(
-        vectorized_chosen_x, [-1, V, D]
-    )  # [num_optimization_runs, V, D] 
+    successes = tf.reshape(vectorized_successes, [-1, V])  # [num_optimization_runs, V]
+    fun_values = tf.reshape(vectorized_fun_values, [-1, V])  # [num_optimization_runs, V]
+    chosen_x = tf.reshape(vectorized_chosen_x, [-1, V, D])  # [num_optimization_runs, V, D]
 
     return (successes, fun_values, chosen_x)
 
@@ -552,7 +544,7 @@ def batchify_vectorize(
 
     Unlike :meth:`batchify_joint`, :meth:`batchify_vectorize` is suitiable
     for :class:`VectorizedAcquisitionFunction`s who's individual batch element can be
-    optimized independetely (i.e. they can be vectorized). 
+    optimized independetely (i.e. they can be vectorized).
 
     :param batch_size_one_optimizer: An optimizer that returns only batch size one, i.e. produces a
             single point with shape [1, D].

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -70,8 +70,6 @@ Type alias for a function that returns the single point that maximizes an acquis
 a search space. For a search space with points of shape [D], and acquisition function with input
 shape [..., B, D] output shape [..., 1], the :const:`AcquisitionOptimizer` return shape should be
 [B, D].
-
-TODO
 """
 
 
@@ -125,7 +123,7 @@ def optimize_discrete(
     :return: The **one** point in ``space`` that maximises ``target_func``, with shape [1, D].
     """
 
-    if isinstance(target_func, tuple):  # TODO
+    if isinstance(target_func, tuple):  # check if we need a vectorized optimizer
         V = target_func[1]
         target_func = target_func[0]
     else:
@@ -224,7 +222,7 @@ def generate_continuous_optimizer(
         :return: The `V` points in ``space`` that maximises``target_func``, with shape [V, D].
         """
 
-        if isinstance(target_func, tuple):  # TODO
+        if isinstance(target_func, tuple):  # check if we need a vectorized optimizer
             V = target_func[1]
             target_func = target_func[0]
         else:
@@ -536,7 +534,7 @@ def batchify_joint(
     ) -> TensorType:
         expanded_search_space = search_space ** batch_size  # points have shape [B * D]
 
-        if isinstance(f, tuple):  # TODO check
+        if isinstance(f, tuple):
             raise ValueError(
                 "batchify_joint cannot be applied to a vectorized acquisition function"
             )
@@ -577,7 +575,7 @@ def batchify_vectorize(
     def optimizer(
         search_space: SP, f: Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]
     ) -> TensorType:
-        if isinstance(f, tuple):  # TODO check
+        if isinstance(f, tuple):
             raise ValueError(
                 "batchify_vectorize cannot be applied to an already vectorized acquisition function"
             )
@@ -622,7 +620,7 @@ def generate_random_search_optimizer(
                 [..., 1].
         :return: The **one** point in ``space`` that maximises ``target_func``, with shape [1, D].
         """
-        if isinstance(target_func, tuple):  # TODO
+        if isinstance(target_func, tuple):  # check if we need a vectorized optimizer
             V = target_func[1]
             target_func = target_func[0]
         else:

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -192,7 +192,7 @@ def generate_continuous_optimizer(
         raise ValueError(f"num_initial_samples must be positive, got {num_initial_samples}")
 
     if num_optimization_runs < 0:
-        raise ValueError(f"num_optimization_runs must be positive, got {num_initial_samples}")
+        raise ValueError(f"num_optimization_runs must be positive, got {num_optimization_runs}")
 
     if num_initial_samples < num_optimization_runs:
         raise ValueError(
@@ -566,8 +566,8 @@ def batchify_vectorize(
     A wrapper around our :const:`AcquisitionOptimizer`s. This class wraps a
     :const:`AcquisitionOptimizer` to allow it to optimize batch acquisition functions.
 
-    Unlike :meth:`batchify_joint`, :meth:`batchify_vectorize` is suitable
-    for a :class:`AcquisitionFunction whose individual batch element can be
+    Unlike :func:`batchify_joint`, :func:`batchify_vectorize` is suitable
+    for a :class:`AcquisitionFunction` whose individual batch element can be
     optimized independently (i.e. they can be vectorized).
 
     :param batch_size_one_optimizer: An optimizer that returns only batch size one, i.e. produces a

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -131,6 +131,9 @@ def optimize_discrete(
     else:
         V = 1
 
+    if V < 0:
+        raise ValueError(f"vectorization must be positive, got {V}")
+
     points = space.points[:, None, :]
     tiled_points = tf.tile(points, [1, V, 1])
     target_func_values = target_func(tiled_points)
@@ -226,6 +229,9 @@ def generate_continuous_optimizer(
             target_func = target_func[0]
         else:
             V = 1
+
+        if V < 0:
+            raise ValueError(f"vectorization must be positive, got {V}")
 
         candidates = space.sample(num_initial_samples)[:, None, :]  # [num_initial_samples, 1, D]
         tiled_candidates = tf.tile(candidates, [1, V, 1])  # [num_initial_samples, V, D]
@@ -621,6 +627,9 @@ def generate_random_search_optimizer(
             target_func = target_func[0]
         else:
             V = 1
+
+        if V < 0:
+            raise ValueError(f"vectorization must be positive, got {V}")
 
         points = space.sample(num_samples)[:, None, :]
         tiled_points = tf.tile(points, [1, V, 1])

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -62,8 +62,9 @@ class FailedOptimizationError(Exception):
     """Raised when an acquisition optimizer fails to optimize"""
 
 
-
-AcquisitionOptimizer = Callable[[SP, Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]], TensorType]
+AcquisitionOptimizer = Callable[
+    [SP, Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]], TensorType
+]
 """
 Type alias for a function that returns the single point that maximizes an acquisition function over
 a search space. For a search space with points of shape [D], and acquisition function with input

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -538,11 +538,6 @@ def batchify_vectorize(
 
 
 
-
-
-
-
-
 def generate_random_search_optimizer(
     num_samples: int = NUM_SAMPLES_MIN,
 ) -> AcquisitionOptimizer[SP]:

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -19,7 +19,7 @@ This module contains functionality for optimizing
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union, cast
+from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
 
 import greenlet as gr
 import numpy as np
@@ -62,8 +62,9 @@ class FailedOptimizationError(Exception):
     """Raised when an acquisition optimizer fails to optimize"""
 
 
-
-AcquisitionOptimizer = Callable[[SP, Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]], TensorType]
+AcquisitionOptimizer = Callable[
+    [SP, Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]], TensorType
+]
 """
 Type alias for a function that returns the single point that maximizes an acquisition function over
 a search space. For a search space with points of shape [D], and acquisition function with input
@@ -524,11 +525,15 @@ def batchify_joint(
     if batch_size <= 0:
         raise ValueError(f"batch_size must be positive, got {batch_size}")
 
-    def optimizer(search_space: SP, f: Union[AcquisitionFunction,Tuple[AcquisitionFunction, int]]) -> TensorType:
+    def optimizer(
+        search_space: SP, f: Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]
+    ) -> TensorType:
         expanded_search_space = search_space ** batch_size  # points have shape [B * D]
-        
+
         if isinstance(f, tuple):  # TODO check
-                raise ValueError("batchify_joint cannot be applied to a vectorized acquisition function")
+            raise ValueError(
+                "batchify_joint cannot be applied to a vectorized acquisition function"
+            )
 
         def target_func_with_vectorized_inputs(
             x: TensorType,
@@ -563,9 +568,13 @@ def batchify_vectorize(
     if batch_size <= 0:
         raise ValueError(f"batch_size must be positive, got {batch_size}")
 
-    def optimizer(search_space: SP, f: Union[AcquisitionFunction,Tuple[AcquisitionFunction, int]]) -> TensorType:
+    def optimizer(
+        search_space: SP, f: Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]
+    ) -> TensorType:
         if isinstance(f, tuple):  # TODO check
-                raise ValueError("batchify_vectorize cannot be applied to an already vectorized acquisition function")
+            raise ValueError(
+                "batchify_vectorize cannot be applied to an already vectorized acquisition function"
+            )
 
         return batch_size_one_optimizer(search_space, (f, batch_size))
 

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -173,12 +173,12 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
             builder = builder.using(OBJECTIVE)
 
         if num_query_points > 1:  # need to build batches of points
-            if isinstance(builder, AcquisitionFunctionBuilder):
-                # optimize batch elements jointly
-                optimizer = batchify_joint(optimizer, num_query_points)
-            elif isinstance(builder, VectorizedAcquisitionFunctionBuilder):
+            if isinstance(builder, VectorizedAcquisitionFunctionBuilder):
                 # optimize batch elements independently
                 optimizer = batchify_vectorize(optimizer, num_query_points)
+            elif isinstance(builder, AcquisitionFunctionBuilder):
+                # optimize batch elements jointly
+                optimizer = batchify_joint(optimizer, num_query_points)
             elif isinstance(builder, GreedyAcquisitionFunctionBuilder):
                 # optimize batch elements sequentially using the logic in acquire.
                 pass

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -39,10 +39,15 @@ from .interface import (
     GreedyAcquisitionFunctionBuilder,
     SingleModelAcquisitionBuilder,
     SingleModelGreedyAcquisitionBuilder,
-    VectorizedAcquisitionFunctionBuilder,
     SingleModelVectorizedAcquisitionBuilder,
+    VectorizedAcquisitionFunctionBuilder,
 )
-from .optimizer import AcquisitionOptimizer, automatic_optimizer_selector, batchify_joint, batchify_vectorize
+from .optimizer import (
+    AcquisitionOptimizer,
+    automatic_optimizer_selector,
+    batchify_joint,
+    batchify_vectorize,
+)
 from .sampler import ExactThompsonSampler, ThompsonSampler
 
 T_co = TypeVar("T_co", covariant=True)
@@ -158,24 +163,30 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
             optimizer = automatic_optimizer_selector
 
         if isinstance(
-            builder, (SingleModelAcquisitionBuilder, SingleModelGreedyAcquisitionBuilder, SingleModelVectorizedAcquisitionBuilder)
+            builder,
+            (
+                SingleModelAcquisitionBuilder,
+                SingleModelGreedyAcquisitionBuilder,
+                SingleModelVectorizedAcquisitionBuilder,
+            ),
         ):
             builder = builder.using(OBJECTIVE)
 
-        if num_query_points > 1: # need to build batches of points
+        if num_query_points > 1:  # need to build batches of points
             if isinstance(builder, AcquisitionFunctionBuilder):
                 # optimize batch elements jointly
-                optimizer = batchify_joint(optimizer, num_query_points) 
+                optimizer = batchify_joint(optimizer, num_query_points)
             elif isinstance(builder, VectorizedAcquisitionFunctionBuilder):
                 # optimize batch elements independently
-                optimizer = batchify_vectorize(optimizer, num_query_points) 
+                optimizer = batchify_vectorize(optimizer, num_query_points)
             elif isinstance(builder, GreedyAcquisitionFunctionBuilder):
                 # optimize batch elements sequentially using the logic in acquire.
-                pass 
+                pass
 
         self._builder: Union[
             AcquisitionFunctionBuilder[ProbabilisticModel],
             GreedyAcquisitionFunctionBuilder[ProbabilisticModel],
+            VectorizedAcquisitionFunctionBuilder[ProbabilisticModel],
         ] = builder
         self._optimizer = optimizer
         self._num_query_points = num_query_points

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -39,8 +39,10 @@ from .interface import (
     GreedyAcquisitionFunctionBuilder,
     SingleModelAcquisitionBuilder,
     SingleModelGreedyAcquisitionBuilder,
+    VectorizedAcquisitionFunctionBuilder,
+    SingleModelVectorizedAcquisitionBuilder,
 )
-from .optimizer import AcquisitionOptimizer, automatic_optimizer_selector, batchify_joint
+from .optimizer import AcquisitionOptimizer, automatic_optimizer_selector, batchify_joint, batchify_vectorize
 from .sampler import ExactThompsonSampler, ThompsonSampler
 
 T_co = TypeVar("T_co", covariant=True)
@@ -120,8 +122,10 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
         builder: Optional[
             AcquisitionFunctionBuilder[ProbabilisticModel]
             | GreedyAcquisitionFunctionBuilder[ProbabilisticModel]
+            | VectorizedAcquisitionFunctionBuilder[ProbabilisticModel]
             | SingleModelAcquisitionBuilder[ProbabilisticModel]
             | SingleModelGreedyAcquisitionBuilder[ProbabilisticModel]
+            | SingleModelVectorizedAcquisitionBuilder[ProbabilisticModel]
         ] = None,
         optimizer: AcquisitionOptimizer[SP_contra] | None = None,
         num_query_points: int = 1,
@@ -154,13 +158,20 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
             optimizer = automatic_optimizer_selector
 
         if isinstance(
-            builder, (SingleModelAcquisitionBuilder, SingleModelGreedyAcquisitionBuilder)
+            builder, (SingleModelAcquisitionBuilder, SingleModelGreedyAcquisitionBuilder, SingleModelVectorizedAcquisitionBuilder)
         ):
             builder = builder.using(OBJECTIVE)
 
-        if isinstance(builder, AcquisitionFunctionBuilder) and num_query_points > 1:
-            # Joint batch acquisitions require batch optimizers
-            optimizer = batchify_joint(optimizer, num_query_points)
+        if num_query_points > 1: # need to build batches of points
+            if isinstance(builder, AcquisitionFunctionBuilder):
+                # optimize batch elements jointly
+                optimizer = batchify_joint(optimizer, num_query_points) 
+            elif isinstance(builder, VectorizedAcquisitionFunctionBuilder):
+                # optimize batch elements independently
+                optimizer = batchify_vectorize(optimizer, num_query_points) 
+            elif isinstance(builder, GreedyAcquisitionFunctionBuilder):
+                # optimize batch elements sequentially using the logic in acquire.
+                pass 
 
         self._builder: Union[
             AcquisitionFunctionBuilder[ProbabilisticModel],

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -40,7 +40,7 @@ from .interface import (
     SingleModelAcquisitionBuilder,
     SingleModelGreedyAcquisitionBuilder,
 )
-from .optimizer import AcquisitionOptimizer, automatic_optimizer_selector, batchify
+from .optimizer import AcquisitionOptimizer, automatic_optimizer_selector, batchify_joint
 from .sampler import ExactThompsonSampler, ThompsonSampler
 
 T_co = TypeVar("T_co", covariant=True)
@@ -160,7 +160,7 @@ class EfficientGlobalOptimization(AcquisitionRule[TensorType, SP_contra]):
 
         if isinstance(builder, AcquisitionFunctionBuilder) and num_query_points > 1:
             # Joint batch acquisitions require batch optimizers
-            optimizer = batchify(optimizer, num_query_points)
+            optimizer = batchify_joint(optimizer, num_query_points)
 
         self._builder: Union[
             AcquisitionFunctionBuilder[ProbabilisticModel],
@@ -382,9 +382,9 @@ class AsynchronousOptimization(
             builder = builder.using(OBJECTIVE)
 
         # even though we are only using batch acquisition functions
-        # there is no need to batchify the optimizer if our batch size is 1
+        # there is no need to batchify_joint the optimizer if our batch size is 1
         if num_query_points > 1:
-            optimizer = batchify(optimizer, num_query_points)
+            optimizer = batchify_joint(optimizer, num_query_points)
 
         self._builder: AcquisitionFunctionBuilder[ProbabilisticModel] = builder
         self._optimizer = optimizer

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -582,3 +582,6 @@ class TaggedProductSearchSpace(SearchSpace):
         :return: The Cartesian product of this search space with the ``other``.
         """
         return TaggedProductSearchSpace(spaces=[self, other])
+
+    def __deepcopy__(self, memo: dict[int, object]) -> TaggedProductSearchSpace:
+        return self

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -34,9 +34,6 @@ class SearchSpace(ABC):
     A :class:`SearchSpace` represents the domain over which an objective function is optimized.
     """
 
-    def __init__(self) -> None:
-        self._vectorized_batch_size = 1  # TODO
-
     @abstractmethod
     def sample(self, num_samples: int) -> TensorType:
         """
@@ -90,15 +87,6 @@ class SearchSpace(ABC):
         tf.debugging.assert_positive(other, message="Exponent must be strictly positive")
         return reduce(operator.mul, [self] * other)
 
-    @property
-    def vectorized_batch_size(self) -> int:
-        return self._vectorized_batch_size
-
-    def set_vectorized_batch_size(self, batch_size: int) -> None:
-        if batch_size <= 0:
-            raise ValueError(f"vectorized_batch_size must be positive, got {batch_size}")
-        self._vectorized_batch_size = batch_size
-
 
 class DiscreteSearchSpace(SearchSpace):
     r"""
@@ -120,7 +108,6 @@ class DiscreteSearchSpace(SearchSpace):
         :raise ValueError (or tf.errors.InvalidArgumentError): If ``points`` has an invalid shape.
         """
 
-        super().__init__()
         tf.debugging.assert_shapes([(points, ("N", "D"))])
         self._points = points
         self._dimension = tf.shape(self._points)[-1]
@@ -233,7 +220,6 @@ class Box(SearchSpace):
             - ``upper`` is not greater than ``lower`` across all dimensions.
         """
 
-        super().__init__()
         tf.debugging.assert_shapes([(lower, ["D"]), (upper, ["D"])])
         tf.assert_rank(lower, 1)
         tf.assert_rank(upper, 1)
@@ -412,7 +398,6 @@ class TaggedProductSearchSpace(SearchSpace):
             length to ``tags`` when ``tags`` is provided or if ``tags`` contains duplicates.
         """
 
-        super().__init__()
         number_of_subspaces = len(spaces)
         if tags is None:
             tags = [str(index) for index in range(number_of_subspaces)]


### PR DESCRIPTION
We now support vectorizable batch acquisition functions, i.e. those for which acquisition function maximisation can be embarrassingly parallelised across a batch --- imagine a separate acquisition function for each batch element.  Therefore, I have included a `VectorizedAcquisitionFunction` and a `VectorizedAcquisitionFunctionBuilder`.

The desired use-case for this functionality is batch Thompson sampling for very large batches. However, we are still lacking a little functionality (see next PR), so I have implemented the parallel UCB from https://arxiv.org/pdf/2001.04833.pdf as a test case. Therefore, this PR also contains a new acquisition function that allows a nice integration test to check that everything is working as planned. 

I have updated all our acquisition functions to be able to maximize `VectorizedAcquisitionFunction` in parallel.

A subtle detail is that I have had to add a new attribute to search spaces. We can now store batch size as a attribute of search space. This is important as search spaces are how we have previously passed batch size info to our acq functions (i.e. via the optimzier). For traditional batch acq functions (which must be optimized in parallel), wejust pass the extended search space with B*d inputs, however, for  `VectorizedAcquisitionFunction` we need access to both B and d when optimising. 