### PR TITLE
removed equal rank check in Dataset

### DIFF
--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -43,8 +43,7 @@ def test_dataset_raises_for_zero_dimensional_data(
     [
         ((1,), (2,)),
         ((2,), (1,)),
-        ((5, 6), (5, 4)),
-        ((5, 6), (4, 6)),
+        ((5, 6), (4,)),
         ((5, 6), (4, 4)),
     ],
 )
@@ -64,28 +63,11 @@ def test_dataset_raises_for_different_leading_shapes(
 @pytest.mark.parametrize(
     "query_points_shape, observations_shape",
     [
-        ((1, 2), (1,)),
-        ((1, 2), (1, 2, 3)),
-    ],
-)
-def test_dataset_raises_for_different_ranks(
-    query_points_shape: ShapeLike, observations_shape: ShapeLike
-) -> None:
-    query_points = tf.zeros(query_points_shape)
-    observations = tf.ones(observations_shape)
-
-    with pytest.raises(ValueError):
-        Dataset(query_points, observations)
-
-
-@pytest.mark.parametrize(
-    "query_points_shape, observations_shape",
-    [
         ((), ()),
         ((), (10,)),
         ((10,), (10,)),
         ((1, 2), (1,)),
-        ((1, 2), (1, 2, 3)),
+        ((1,), (1, 2)),
     ],
 )
 def test_dataset_raises_for_invalid_ranks(

--- a/tests/unit/test_observer.py
+++ b/tests/unit/test_observer.py
@@ -70,10 +70,8 @@ def test_filter_finite(query_points: tf.Tensor, expected: Dataset) -> None:
 @pytest.mark.parametrize(
     "qp_shape, obs_shape",
     [
-        ([3, 4], [3, 2]),  # observations not N x 1
-        ([3, 4], [4, 1]),  # different leading dims
-        ([3], [3, 1]),  # query_points missing a dimension
-        ([3, 4, 2], [3, 1]),  # query_points have too many dimensions
+        ([3, 4], [3, 2]),
+        ([3, 4], [3,]),
     ],
 )
 def test_filter_finite_raises_for_invalid_shapes(qp_shape: ShapeLike, obs_shape: ShapeLike) -> None:

--- a/trieste/data.py
+++ b/trieste/data.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Trieste Contributors
+# Copyright 2021 The Trieste Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """ This module contains utilities for :class:`~trieste.observer.Observer` data. """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -37,7 +39,7 @@ class Dataset:
     def __post_init__(self) -> None:
         """
         :raise ValueError (or InvalidArgumentError): If ``query_points`` or ``observations`` have \
-            rank less than two, or they have unequal shape in any but their last dimension.
+            rank less than two, or they have unequal shape in their first dimension.
         """
         tf.debugging.assert_rank_at_least(self.query_points, 2)
         tf.debugging.assert_rank_at_least(self.observations, 2)
@@ -49,7 +51,7 @@ class Dataset:
             )
 
         if (
-            self.query_points.shape[:-1] != self.observations.shape[:-1]
+            self.query_points.shape[0] != self.observations.shape[0]
             # can't check dynamic shapes, so trust that they're ok (if not, they'll fail later)
             and None not in self.query_points.shape[:-1]
         ):


### PR DESCRIPTION
Dataset currently checks that `query_points` and `observations` have the same rank, this shouldn't be enforced I think - e.g. you could have images as data that could have rank > 2 but observations could still be rank = 2. 

I have modified the check such that only leading dimension is checked for inequality (number of observations), this will make the Dataset more flexible while still performing some checks. Tests had to be modified as well.