### PR TITLE
Victor/gpfluxmonitoring

### DIFF
--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import tensorflow as tf
 from gpflow.inducing_variables import InducingPoints
@@ -145,6 +145,11 @@ class DeepGaussianProcess(GPfluxPredictor, TrainableProbabilisticModel):
         :param dataset: The data with which to optimize the `model`.
         """
         fit_args = dict(self._fit_args)
+
+        # Tell optimizer how many epochs have been used before: the optimizer will "continue"
+        # optimization across multiple BO iterations rather than start fresh at each iteration.
+        # This allows us to monitor training across iterations.
+
         if "epochs" in fit_args:
             fit_args["epochs"] = fit_args["epochs"] + self.absolute_epochs
 
@@ -155,6 +160,7 @@ class DeepGaussianProcess(GPfluxPredictor, TrainableProbabilisticModel):
         )
 
         self.absolute_epochs = self.absolute_epochs + len(hist.history["loss"])
+
         # Reset lr in case there was an lr schedule: a schedule will have change the learning rate,
         # so that the next time we call `optimize` the starting learning rate would be different.
         # Therefore we make sure the learning rate is set back to its initial value.

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -56,8 +56,8 @@ class DeepGaussianProcess(GPfluxPredictor, TrainableProbabilisticModel):
             https://keras.io/api/models/model_training_apis/#fit-method for a list of possible
             arguments.
         :param continuous_optimisation: if True (default), the optimizer will keep track of the
-        number of epochs across BO iterations and use this number as initial_epoch. This is
-        essential to allow monitoring of model training across BO iterations.
+            number of epochs across BO iterations and use this number as initial_epoch. This is
+            essential to allow monitoring of model training across BO iterations.
         """
         for layer in model.f_layers:
             if not isinstance(layer, (GPLayer, LatentVariableLayer)):

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -145,8 +145,8 @@ class DeepGaussianProcess(GPfluxPredictor, TrainableProbabilisticModel):
         :param dataset: The data with which to optimize the `model`.
         """
         fit_args = self._fit_args
-        if "epochs" in fit_args:
-            fit_args["epochs"] = self._fit_args["epochs"] + self.absolute_epochs
+        if fit_args is not None and "epochs" in fit_args:
+            fit_args["epochs"] = fit_args["epochs"] + self.absolute_epochs
 
         hist = self.model_keras.fit(
             {"inputs": dataset.query_points, "targets": dataset.observations},

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -145,11 +145,12 @@ class DeepGaussianProcess(GPfluxPredictor, TrainableProbabilisticModel):
         :param dataset: The data with which to optimize the `model`.
         """
         fit_args = self._fit_args
-        if 'epochs' in fit_args:
-            fit_args['epochs'] = self._fit_args['epochs'] + self.absolute_epochs
+        if "epochs" in fit_args:
+            fit_args["epochs"] = self._fit_args["epochs"] + self.absolute_epochs
 
         hist = self.model_keras.fit(
-            {"inputs": dataset.query_points, "targets": dataset.observations}, **fit_args,
+            {"inputs": dataset.query_points, "targets": dataset.observations},
+            **fit_args,
             initial_epoch=self.absolute_epochs,
         )
 

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -145,7 +145,9 @@ class DeepGaussianProcess(GPfluxPredictor, TrainableProbabilisticModel):
         :param dataset: The data with which to optimize the `model`.
         """
         fit_args = self._fit_args
-        fit_args['epochs'] = self._fit_args['epochs'] + self.absolute_epochs
+        if 'epochs' in fit_args:
+            fit_args['epochs'] = self._fit_args['epochs'] + self.absolute_epochs
+
         hist = self.model_keras.fit(
             {"inputs": dataset.query_points, "targets": dataset.observations}, **fit_args,
             initial_epoch=self.absolute_epochs,

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -70,7 +70,7 @@ class DeepGaussianProcess(GPfluxPredictor, TrainableProbabilisticModel):
         self.original_lr = self.optimizer.optimizer.lr.numpy()
 
         if not self.optimizer.minimize_args:
-            self._fit_args: Optional[Dict[str, Any]] = {
+            self._fit_args: Dict[str, Any] = {
                 "verbose": 0,
                 "epochs": 100,
                 "batch_size": 100,
@@ -144,8 +144,8 @@ class DeepGaussianProcess(GPfluxPredictor, TrainableProbabilisticModel):
         Optimize the model with the specified `dataset`.
         :param dataset: The data with which to optimize the `model`.
         """
-        fit_args = self._fit_args
-        if fit_args is not None and "epochs" in fit_args:
+        fit_args = dict(self._fit_args)
+        if "epochs" in fit_args:
             fit_args["epochs"] = fit_args["epochs"] + self.absolute_epochs
 
         hist = self.model_keras.fit(


### PR DESCRIPTION
This is a very short PR that will enable monitoring the training of gpflux models. Incidentally this also seems to have a positive effect on training.

In short, with this PR we keep track of the number of epochs across the BO iterations, and set the parameter `initial_epoch` to this number whenever we call keras.fit.

This PR will be followed by another one illustrating monitoring gpflux model training with tensorboard.