### PR TITLE
Fix MRO on Python 3.8+

### DIFF
--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -95,7 +95,7 @@ model = build_model(initial_data)
 from trieste.models.gpflow import build_gpr
 
 gpflow_model = build_gpr(initial_data, search_space, likelihood_variance=1e-7)
-model =  GaussianProcessRegression(gpflow_model, num_kernel_samples=100)
+model = GaussianProcessRegression(gpflow_model, num_kernel_samples=100)
 
 
 # %% [markdown]

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -91,8 +91,12 @@ initial_data = observer(search_space.sample(num_init_points))
 # %%
 from trieste.models.gpflow import build_gpr, build_vgp_classifier
 
-regression_model = build_gpr(initial_data[OBJECTIVE], search_space, likelihood_variance=1e-7)
-classification_model = build_vgp_classifier(initial_data[FAILURE], search_space, noise_free=True)
+regression_model = build_gpr(
+    initial_data[OBJECTIVE], search_space, likelihood_variance=1e-7
+)
+classification_model = build_vgp_classifier(
+    initial_data[FAILURE], search_space, noise_free=True
+)
 
 
 # %% [markdown]

--- a/docs/notebooks/feasible_sets.pct.py
+++ b/docs/notebooks/feasible_sets.pct.py
@@ -130,6 +130,7 @@ result = bo.optimize(num_steps, initial_data, model, rule)
 from util.plotting import plot_bo_points, plot_function_2d
 import tensorflow_probability as tfp
 
+
 def excursion_probability(x, model, threshold=80):
     mean, variance = model.model.predict_f(x)
     normal = tfp.distributions.Normal(tf.cast(0, x.dtype), tf.cast(1, x.dtype))

--- a/docs/notebooks/model_config.pct.py
+++ b/docs/notebooks/model_config.pct.py
@@ -58,6 +58,7 @@ from gpflow.models import GPR
 from trieste.models.gpflow import GaussianProcessRegression
 from trieste.models.optimizer import Optimizer
 
+
 def build_model(data):
     variance = tf.math.reduce_variance(data.observations)
     kernel = gpflow.kernels.Matern52(variance=variance, lengthscales=[0.2, 0.2])

--- a/docs/notebooks/multi_objective_ehvi.pct.py
+++ b/docs/notebooks/multi_objective_ehvi.pct.py
@@ -111,7 +111,9 @@ def build_stacked_independent_objectives_model(
 
 
 # %%
-model = build_stacked_independent_objectives_model(initial_data, num_objective, search_space)
+model = build_stacked_independent_objectives_model(
+    initial_data, num_objective, search_space
+)
 
 # %% [markdown]
 # ## Define the acquisition function
@@ -214,7 +216,9 @@ plt.show()
 # EHVI can be extended to the case of batches (i.e. query several points at a time) using the `Fantasizer`. `Fantasizer` works by greedily optimising a base acquisition function, then "fantasizing" the observations at the chosen query points and updating the predictive equations of the models as if the fantasized data was added to the models. The only changes that need to be done here are to wrap the `ExpectedHypervolumeImprovement` in a `Fantasizer` object, and set the rule argument `num_query_points` to a value greater than one. Here, we choose 10 batches of size 3, so the observation budget is the same as before.
 
 # %%
-model = build_stacked_independent_objectives_model(initial_data, num_objective, search_space)
+model = build_stacked_independent_objectives_model(
+    initial_data, num_objective, search_space
+)
 
 from trieste.acquisition.function import Fantasizer
 
@@ -340,7 +344,9 @@ objective_model = build_stacked_independent_objectives_model(
 # We also create a single model of the constraint. Note that we set the likelihood variance to a small number because we are dealing with a noise-free problem.
 
 # %%
-gpflow_model = build_gpr(initial_data_with_cst[CONSTRAINT], search_space, likelihood_variance=1e-7)
+gpflow_model = build_gpr(
+    initial_data_with_cst[CONSTRAINT], search_space, likelihood_variance=1e-7
+)
 constraint_model = GaussianProcessRegression(gpflow_model)
 
 

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -250,7 +250,7 @@ class FastUpdateModel(ProbabilisticModel, Protocol):
         )
 
 
-class ModelStack(Generic[T], ProbabilisticModel):
+class ModelStack(ProbabilisticModel, Generic[T]):
     r"""
     A :class:`ModelStack` is a wrapper around a number of :class:`ProbabilisticModel`\ s of type
     :class:`T`. It combines the outputs of each model for predictions and sampling.

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -25,7 +25,6 @@ from typing import Any, Sequence, Union
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
-from tensorflow_probability.python.distributions import distribution as tfd
 
 from ...data import Dataset
 from .utils import get_tensor_spec_from_data
@@ -221,7 +220,7 @@ class GaussianNetwork(KerasEnsembleNetwork):
 
         distribution = dist_layer(
             self.flattened_output_shape,
-            tfd.Distribution.mean,
+            lambda s: s.mean(),
             name=self.output_layer_name,
         )(parameter_layer)
 

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -25,6 +25,7 @@ from typing import Any, Sequence, Union
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
+from tensorflow_probability.python.distributions import distribution as tfd
 
 from ...data import Dataset
 from .utils import get_tensor_spec_from_data
@@ -220,7 +221,7 @@ class GaussianNetwork(KerasEnsembleNetwork):
 
         distribution = dist_layer(
             self.flattened_output_shape,
-            lambda s: s.mean(),
+            tfd.Distribution.mean,
             name=self.output_layer_name,
         )(parameter_layer)
 


### PR DESCRIPTION
The recent Protocol changes seem to have broken trieste on Python 3.8+. This fixes that.

The issue seems to be connected to MRO and the Protocol definition in typing_extensions (which we use since we're officially on 3.7). The rest of the changes are unrelated formatting changes (which should probably be caught by the format tests, I'll investigate).