### PR TITLE
Use to_numpy on TensorType

### DIFF
--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -125,8 +125,10 @@ dataset = result.try_get_final_dataset()
 # We can now get the best point found by the optimizer. Note this isn't necessarily the point that was last evaluated.
 
 # %%
-query_points = dataset.query_points.numpy()
-observations = dataset.observations.numpy()
+from trieste.utils import to_numpy
+
+query_points = to_numpy(dataset.query_points)
+observations = to_numpy(dataset.observations)
 
 arg_min_idx = tf.squeeze(tf.argmin(observations, axis=0))
 

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -29,6 +29,7 @@ import tensorflow_probability as tfp
 
 from ..space import Box, DiscreteSearchSpace, SearchSpace, TaggedProductSearchSpace
 from ..types import TensorType
+from ..utils import to_numpy
 from .interface import AcquisitionFunction
 
 SP = TypeVar("SP", bound=SearchSpace)
@@ -426,8 +427,8 @@ def _perform_parallel_continuous_optimization(
         # Batch evaluate query `x`s from all children.
         batch_x = tf.constant(np_batch_x, dtype=tf_dtype)  # [num_optimization_runs, d]
         batch_y, batch_dy_dx = _objective_value_and_gradient(batch_x)
-        np_batch_y = batch_y.numpy().astype("float64")
-        np_batch_dy_dx = batch_dy_dx.numpy().astype("float64")
+        np_batch_y = to_numpy(batch_y).astype("float64")
+        np_batch_dy_dx = to_numpy(batch_dy_dx).astype("float64")
 
         for i, greenlet in enumerate(child_greenlets):  # Feed `y` and `dy_dx` back to children.
             if greenlet.dead:  # Allow for crashed greenlets

--- a/trieste/models/gpflux/architectures.py
+++ b/trieste/models/gpflux/architectures.py
@@ -29,6 +29,7 @@ from gpflux.models import DeepGP
 
 from ...space import Box
 from ...types import TensorType
+from ...utils import to_numpy
 
 
 def build_vanilla_deep_gp(
@@ -66,7 +67,9 @@ def build_vanilla_deep_gp(
                     f"Currently only `Box` instances are supported for `search_space`,"
                     f" received {type(search_space)}."
                 )
-            additional_points = search_space.sample_sobol(num_inducing - len(query_points)).numpy()
+            additional_points = to_numpy(
+                search_space.sample_sobol(num_inducing - len(query_points))
+            )
         else:
             additional_points = np.random.randn(
                 num_inducing - len(query_points), *query_points.shape[1:]


### PR DESCRIPTION
As noted in https://github.com/secondmind-labs/trieste/issues/347, we currently don't properly check numpy-related types since numpy 1.19 (required by TensorFlow 2.4 and 2.5) doesn't yet have type stubs . Looking at the typing issues caught in numpy 1.20, it seems most are the result of us using a TensorType result from e.g. a sample call as if it must be a tf.Tensor (which it will be in practice, but is not what the type says). We have two options on how to fix this:

1. Continue to return TensorType but call trieste.utils.to_numpy rather than calling .numpy()
2. Continue to accept TensorType for our inputs but only return tf.Tensors.

This PR shows what option 1 looks like in the code and in one of the notebooks. If it looks ok then I'll make it for the other notebooks too.