### PR TITLE
Rename TypeVars to something more novice-friendly

### DIFF
--- a/trieste/acquisition/function/entropy.py
+++ b/trieste/acquisition/function/entropy.py
@@ -32,6 +32,7 @@ from ..interface import (
     AcquisitionFunction,
     AcquisitionFunctionClass,
     PenalizationFunction,
+    ProbabilisticModelType,
     SingleModelAcquisitionBuilder,
     SingleModelGreedyAcquisitionBuilder,
     UpdatablePenalizationFunction,
@@ -39,12 +40,6 @@ from ..interface import (
 from ..sampler import ExactThompsonSampler, ThompsonSampler
 
 CLAMP_LB = 1e-8
-
-
-ProbabilisticModelType = TypeVar(
-    "ProbabilisticModelType", bound=ProbabilisticModel, contravariant=True
-)
-""" Contravariant type variable bound to :class:`~trieste.models.ProbabilisticModel`. """
 
 
 class MinValueEntropySearch(SingleModelAcquisitionBuilder[ProbabilisticModelType]):

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -36,7 +36,9 @@ from ..interface import (
     SingleModelVectorizedAcquisitionBuilder,
 )
 
-M_contra = TypeVar("M_contra", bound=ProbabilisticModel, contravariant=True)
+ProbabilisticModelType = TypeVar(
+    "ProbabilisticModelType", bound=ProbabilisticModel, contravariant=True
+)
 
 
 class ExpectedImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel]):
@@ -422,7 +424,7 @@ def probability_of_feasibility(
     return acquisition
 
 
-class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[M_contra]):
+class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticModelType]):
     """
     Builder for the *expected constrained improvement* acquisition function defined in
     :cite:`gardner14`. The acquisition function computes the expected improvement from the best
@@ -433,7 +435,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[M_contra]):
     def __init__(
         self,
         objective_tag: str,
-        constraint_builder: AcquisitionFunctionBuilder[M_contra],
+        constraint_builder: AcquisitionFunctionBuilder[ProbabilisticModelType],
         min_feasibility_probability: float | TensorType = 0.5,
     ):
         """
@@ -470,7 +472,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[M_contra]):
 
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, M_contra],
+        models: Mapping[str, ProbabilisticModelType],
         datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
@@ -519,7 +521,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[M_contra]):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, M_contra],
+        models: Mapping[str, ProbabilisticModelType],
         datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
@@ -567,7 +569,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[M_contra]):
         return self._constrained_improvement_fn
 
     def _update_expected_improvement_fn(
-        self, objective_model: M_contra, feasible_mean: TensorType
+        self, objective_model: ProbabilisticModelType, feasible_mean: TensorType
     ) -> None:
         """
         Set or update the unconstrained expected improvement function.

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -17,7 +17,7 @@ functions --- functions that estimate the utility of evaluating sets of candidat
 """
 from __future__ import annotations
 
-from typing import Mapping, Optional, TypeVar, cast
+from typing import Mapping, Optional, cast
 
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -32,14 +32,10 @@ from ..interface import (
     AcquisitionFunction,
     AcquisitionFunctionBuilder,
     AcquisitionFunctionClass,
+    ProbabilisticModelType,
     SingleModelAcquisitionBuilder,
     SingleModelVectorizedAcquisitionBuilder,
 )
-
-ProbabilisticModelType = TypeVar(
-    "ProbabilisticModelType", bound=ProbabilisticModel, contravariant=True
-)
-""" Contravariant type variable bound to :class:`~trieste.models.ProbabilisticModel`. """
 
 
 class ExpectedImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel]):

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -34,7 +34,9 @@ from ..multi_objective.pareto import (
 )
 from .function import ExpectedConstrainedImprovement
 
-M_contra = TypeVar("M_contra", bound=ProbabilisticModel, contravariant=True)
+ProbabilisticModelType = TypeVar(
+    "ProbabilisticModelType", bound=ProbabilisticModel, contravariant=True
+)
 
 
 class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel]):
@@ -335,7 +337,9 @@ def batch_ehvi(
     return acquisition
 
 
-class ExpectedConstrainedHypervolumeImprovement(ExpectedConstrainedImprovement[M_contra]):
+class ExpectedConstrainedHypervolumeImprovement(
+    ExpectedConstrainedImprovement[ProbabilisticModelType]
+):
     """
     Builder for the constrained expected hypervolume improvement acquisition function.
     This function essentially combines ExpectedConstrainedImprovement and
@@ -351,7 +355,7 @@ class ExpectedConstrainedHypervolumeImprovement(ExpectedConstrainedImprovement[M
         )
 
     def _update_expected_improvement_fn(
-        self, objective_model: M_contra, feasible_mean: TensorType
+        self, objective_model: ProbabilisticModelType, feasible_mean: TensorType
     ) -> None:
         """
         Set or update the unconstrained expected improvement function.

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -17,7 +17,7 @@ This module contains multi-objective acquisition function builders.
 from __future__ import annotations
 
 from itertools import combinations, product
-from typing import Optional, TypeVar, cast
+from typing import Optional, cast
 
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -27,18 +27,18 @@ from ...models import ProbabilisticModel, ReparametrizationSampler
 from ...models.interfaces import HasReparamSampler
 from ...types import TensorType
 from ...utils import DEFAULTS
-from ..interface import AcquisitionFunction, AcquisitionFunctionClass, SingleModelAcquisitionBuilder
+from ..interface import (
+    AcquisitionFunction,
+    AcquisitionFunctionClass,
+    ProbabilisticModelType,
+    SingleModelAcquisitionBuilder,
+)
 from ..multi_objective.pareto import (
     Pareto,
     get_reference_point,
     prepare_default_non_dominated_partition_bounds,
 )
 from .function import ExpectedConstrainedImprovement
-
-ProbabilisticModelType = TypeVar(
-    "ProbabilisticModelType", bound=ProbabilisticModel, contravariant=True
-)
-""" Contravariant type variable bound to :class:`~trieste.models.ProbabilisticModel`. """
 
 
 class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel]):

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -18,10 +18,10 @@ the utility of evaluating sets of candidate points.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Callable, Generic, Mapping, Optional, TypeVar
+from typing import Callable, Generic, Mapping, Optional
 
 from ..data import Dataset
-from ..models import ProbabilisticModel
+from ..models.interfaces import ProbabilisticModelType
 from ..types import TensorType
 
 AcquisitionFunction = Callable[[TensorType], TensorType]
@@ -47,12 +47,6 @@ class AcquisitionFunctionClass(ABC):
     @abstractmethod
     def __call__(self, x: TensorType) -> TensorType:
         """Call acquisition function."""
-
-
-ProbabilisticModelType = TypeVar(
-    "ProbabilisticModelType", bound=ProbabilisticModel, contravariant=True
-)
-""" Contravariant type variable bound to :class:`~trieste.models.ProbabilisticModel`. """
 
 
 class AcquisitionFunctionBuilder(Generic[ProbabilisticModelType], ABC):

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -49,16 +49,18 @@ class AcquisitionFunctionClass(ABC):
         """Call acquisition function."""
 
 
-T = TypeVar("T", bound=ProbabilisticModel, contravariant=True)
+ProbabilisticModelType = TypeVar(
+    "ProbabilisticModelType", bound=ProbabilisticModel, contravariant=True
+)
 
 
-class AcquisitionFunctionBuilder(Generic[T], ABC):
+class AcquisitionFunctionBuilder(Generic[ProbabilisticModelType], ABC):
     """An :class:`AcquisitionFunctionBuilder` builds and updates an acquisition function."""
 
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, T],
+        models: Mapping[str, ProbabilisticModelType],
         datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
@@ -73,7 +75,7 @@ class AcquisitionFunctionBuilder(Generic[T], ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, T],
+        models: Mapping[str, ProbabilisticModelType],
         datasets: Optional[Mapping[str, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
@@ -90,13 +92,13 @@ class AcquisitionFunctionBuilder(Generic[T], ABC):
         return self.prepare_acquisition_function(models, datasets=datasets)
 
 
-class SingleModelAcquisitionBuilder(Generic[T], ABC):
+class SingleModelAcquisitionBuilder(Generic[ProbabilisticModelType], ABC):
     """
     Convenience acquisition function builder for an acquisition function (or component of a
     composite acquisition function) that requires only one model, dataset pair.
     """
 
-    def using(self, tag: str) -> AcquisitionFunctionBuilder[T]:
+    def using(self, tag: str) -> AcquisitionFunctionBuilder[ProbabilisticModelType]:
         """
         :param tag: The tag for the model, dataset pair to use to build this acquisition function.
         :return: An acquisition function builder that selects the model and dataset specified by
@@ -104,10 +106,10 @@ class SingleModelAcquisitionBuilder(Generic[T], ABC):
         """
         single_builder = self
 
-        class _Anon(AcquisitionFunctionBuilder[T]):
+        class _Anon(AcquisitionFunctionBuilder[ProbabilisticModelType]):
             def prepare_acquisition_function(
                 self,
-                models: Mapping[str, T],
+                models: Mapping[str, ProbabilisticModelType],
                 datasets: Optional[Mapping[str, Dataset]] = None,
             ) -> AcquisitionFunction:
                 return single_builder.prepare_acquisition_function(
@@ -117,7 +119,7 @@ class SingleModelAcquisitionBuilder(Generic[T], ABC):
             def update_acquisition_function(
                 self,
                 function: AcquisitionFunction,
-                models: Mapping[str, T],
+                models: Mapping[str, ProbabilisticModelType],
                 datasets: Optional[Mapping[str, Dataset]] = None,
             ) -> AcquisitionFunction:
                 return single_builder.update_acquisition_function(
@@ -132,7 +134,7 @@ class SingleModelAcquisitionBuilder(Generic[T], ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        model: T,
+        model: ProbabilisticModelType,
         dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
@@ -144,7 +146,7 @@ class SingleModelAcquisitionBuilder(Generic[T], ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        model: T,
+        model: ProbabilisticModelType,
         dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         """
@@ -156,7 +158,7 @@ class SingleModelAcquisitionBuilder(Generic[T], ABC):
         return self.prepare_acquisition_function(model, dataset=dataset)
 
 
-class GreedyAcquisitionFunctionBuilder(Generic[T], ABC):
+class GreedyAcquisitionFunctionBuilder(Generic[ProbabilisticModelType], ABC):
     """
     A :class:`GreedyAcquisitionFunctionBuilder` builds an acquisition function
     suitable for greedily building batches for batch Bayesian
@@ -170,7 +172,7 @@ class GreedyAcquisitionFunctionBuilder(Generic[T], ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, T],
+        models: Mapping[str, ProbabilisticModelType],
         datasets: Optional[Mapping[str, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
@@ -189,7 +191,7 @@ class GreedyAcquisitionFunctionBuilder(Generic[T], ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, T],
+        models: Mapping[str, ProbabilisticModelType],
         datasets: Optional[Mapping[str, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
@@ -215,13 +217,13 @@ class GreedyAcquisitionFunctionBuilder(Generic[T], ABC):
         )
 
 
-class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
+class SingleModelGreedyAcquisitionBuilder(Generic[ProbabilisticModelType], ABC):
     """
     Convenience acquisition function builder for a greedy acquisition function (or component of a
     composite greedy acquisition function) that requires only one model, dataset pair.
     """
 
-    def using(self, tag: str) -> GreedyAcquisitionFunctionBuilder[T]:
+    def using(self, tag: str) -> GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]:
         """
         :param tag: The tag for the model, dataset pair to use to build this acquisition function.
         :return: An acquisition function builder that selects the model and dataset specified by
@@ -229,10 +231,10 @@ class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
         """
         single_builder = self
 
-        class _Anon(GreedyAcquisitionFunctionBuilder[T]):
+        class _Anon(GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]):
             def prepare_acquisition_function(
                 self,
-                models: Mapping[str, T],
+                models: Mapping[str, ProbabilisticModelType],
                 datasets: Optional[Mapping[str, Dataset]] = None,
                 pending_points: Optional[TensorType] = None,
             ) -> AcquisitionFunction:
@@ -245,7 +247,7 @@ class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
             def update_acquisition_function(
                 self,
                 function: AcquisitionFunction,
-                models: Mapping[str, T],
+                models: Mapping[str, ProbabilisticModelType],
                 datasets: Optional[Mapping[str, Dataset]] = None,
                 pending_points: Optional[TensorType] = None,
                 new_optimization_step: bool = True,
@@ -266,7 +268,7 @@ class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        model: T,
+        model: ProbabilisticModelType,
         dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
@@ -281,7 +283,7 @@ class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        model: T,
+        model: ProbabilisticModelType,
         dataset: Optional[Dataset] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
@@ -304,7 +306,7 @@ class SingleModelGreedyAcquisitionBuilder(Generic[T], ABC):
         )
 
 
-class VectorizedAcquisitionFunctionBuilder(AcquisitionFunctionBuilder[T]):
+class VectorizedAcquisitionFunctionBuilder(AcquisitionFunctionBuilder[ProbabilisticModelType]):
     """
     An :class:`VectorizedAcquisitionFunctionBuilder` builds and updates a vectorized
     acquisition function These differ from normal acquisition functions only by their output shape:
@@ -313,13 +315,15 @@ class VectorizedAcquisitionFunctionBuilder(AcquisitionFunctionBuilder[T]):
     """
 
 
-class SingleModelVectorizedAcquisitionBuilder(SingleModelAcquisitionBuilder[T]):
+class SingleModelVectorizedAcquisitionBuilder(
+    SingleModelAcquisitionBuilder[ProbabilisticModelType]
+):
     """
     Convenience acquisition function builder for vectorized acquisition functions (or component
     of a composite vectorized acquisition function) that requires only one model, dataset pair.
     """
 
-    def using(self, tag: str) -> AcquisitionFunctionBuilder[T]:
+    def using(self, tag: str) -> AcquisitionFunctionBuilder[ProbabilisticModelType]:
         """
         :param tag: The tag for the model, dataset pair to use to build this acquisition function.
         :return: An acquisition function builder that selects the model and dataset specified by
@@ -327,10 +331,10 @@ class SingleModelVectorizedAcquisitionBuilder(SingleModelAcquisitionBuilder[T]):
         """
         single_builder = self
 
-        class _Anon(VectorizedAcquisitionFunctionBuilder[T]):
+        class _Anon(VectorizedAcquisitionFunctionBuilder[ProbabilisticModelType]):
             def prepare_acquisition_function(
                 self,
-                models: Mapping[str, T],
+                models: Mapping[str, ProbabilisticModelType],
                 datasets: Optional[Mapping[str, Dataset]] = None,
             ) -> AcquisitionFunction:
                 return single_builder.prepare_acquisition_function(
@@ -340,7 +344,7 @@ class SingleModelVectorizedAcquisitionBuilder(SingleModelAcquisitionBuilder[T]):
             def update_acquisition_function(
                 self,
                 function: AcquisitionFunction,
-                models: Mapping[str, T],
+                models: Mapping[str, ProbabilisticModelType],
                 datasets: Optional[Mapping[str, Dataset]] = None,
             ) -> AcquisitionFunction:
                 return single_builder.update_acquisition_function(

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -31,7 +31,7 @@ from ..space import Box, DiscreteSearchSpace, SearchSpace, TaggedProductSearchSp
 from ..types import TensorType
 from .interface import AcquisitionFunction
 
-SP = TypeVar("SP", bound=SearchSpace)
+SearchSpaceType = TypeVar("SearchSpaceType", bound=SearchSpace)
 """ Type variable bound to :class:`~trieste.space.SearchSpace`. """
 
 
@@ -63,7 +63,7 @@ class FailedOptimizationError(Exception):
 
 
 AcquisitionOptimizer = Callable[
-    [SP, Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]], TensorType
+    [SearchSpaceType, Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]], TensorType
 ]
 """
 Type alias for a function that returns the single point that maximizes an acquisition function over
@@ -518,9 +518,9 @@ def get_bounds_of_box_relaxation_around_point(
 
 
 def batchify_joint(
-    batch_size_one_optimizer: AcquisitionOptimizer[SP],
+    batch_size_one_optimizer: AcquisitionOptimizer[SearchSpaceType],
     batch_size: int,
-) -> AcquisitionOptimizer[SP]:
+) -> AcquisitionOptimizer[SearchSpaceType]:
     """
     A wrapper around our :const:`AcquisitionOptimizer`s. This class wraps a
     :const:`AcquisitionOptimizer` to allow it to jointly optimize the batch elements considered
@@ -535,7 +535,8 @@ def batchify_joint(
         raise ValueError(f"batch_size must be positive, got {batch_size}")
 
     def optimizer(
-        search_space: SP, f: Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]
+        search_space: SearchSpaceType,
+        f: Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]],
     ) -> TensorType:
         expanded_search_space = search_space ** batch_size  # points have shape [B * D]
 
@@ -559,9 +560,9 @@ def batchify_joint(
 
 
 def batchify_vectorize(
-    batch_size_one_optimizer: AcquisitionOptimizer[SP],
+    batch_size_one_optimizer: AcquisitionOptimizer[SearchSpaceType],
     batch_size: int,
-) -> AcquisitionOptimizer[SP]:
+) -> AcquisitionOptimizer[SearchSpaceType]:
     """
     A wrapper around our :const:`AcquisitionOptimizer`s. This class wraps a
     :const:`AcquisitionOptimizer` to allow it to optimize batch acquisition functions.
@@ -579,7 +580,8 @@ def batchify_vectorize(
         raise ValueError(f"batch_size must be positive, got {batch_size}")
 
     def optimizer(
-        search_space: SP, f: Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]]
+        search_space: SearchSpaceType,
+        f: Union[AcquisitionFunction, Tuple[AcquisitionFunction, int]],
     ) -> TensorType:
         if isinstance(f, tuple):
             raise ValueError(

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -19,7 +19,7 @@ This module contains functionality for optimizing
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import greenlet as gr
 import numpy as np
@@ -27,13 +27,9 @@ import scipy.optimize as spo
 import tensorflow as tf
 import tensorflow_probability as tfp
 
-from ..space import Box, DiscreteSearchSpace, SearchSpace, TaggedProductSearchSpace
+from ..space import Box, DiscreteSearchSpace, SearchSpace, SearchSpaceType, TaggedProductSearchSpace
 from ..types import TensorType
 from .interface import AcquisitionFunction
-
-SearchSpaceType = TypeVar("SearchSpaceType", bound=SearchSpace)
-""" Type variable bound to :class:`~trieste.space.SearchSpace`. """
-
 
 NUM_SAMPLES_MIN: int = 5000
 """

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -29,7 +29,7 @@ from .. import types
 from ..data import Dataset
 from ..logging import get_step_number, get_tensorboard_writer
 from ..models import ProbabilisticModel
-from ..models.interfaces import HasReparamSampler
+from ..models.interfaces import HasReparamSampler, ProbabilisticModelType
 from ..observer import OBJECTIVE
 from ..space import Box, SearchSpace
 from ..types import State, TensorType
@@ -56,11 +56,6 @@ ResultType = TypeVar("ResultType", covariant=True)
 
 SearchSpaceType = TypeVar("SearchSpaceType", bound=SearchSpace, contravariant=True)
 """ Contravariant type variable bound to :class:`~trieste.space.SearchSpace`. """
-
-ProbabilisticModelType = TypeVar(
-    "ProbabilisticModelType", bound=ProbabilisticModel, contravariant=True
-)
-""" Contravariant type variable bound to :class:`~trieste.models.ProbabilisticModel`. """
 
 
 class AcquisitionRule(ABC, Generic[ResultType, SearchSpaceType, ProbabilisticModelType]):

--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -19,20 +19,15 @@ acquisition functions.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic
 
 import tensorflow as tf
 import tensorflow_probability as tfp
 from scipy.optimize import bisect
 
 from ..models import ProbabilisticModel
-from ..models.interfaces import HasTrajectorySampler
+from ..models.interfaces import HasTrajectorySampler, ProbabilisticModelType
 from ..types import TensorType
-
-ProbabilisticModelType = TypeVar(
-    "ProbabilisticModelType", bound=ProbabilisticModel, contravariant=True
-)
-""" Contravariant type variable bound to :class:`~trieste.models.ProbabilisticModel`. """
 
 
 class ThompsonSampler(ABC, Generic[ProbabilisticModelType]):

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -37,17 +37,19 @@ from .space import SearchSpace
 from .types import State, TensorType
 from .utils import Ok, map_values
 
-S = TypeVar("S")
+StateType = TypeVar("StateType")
 """ Unbound type variable. """
 
-SP = TypeVar("SP", bound=SearchSpace)
+SearchSpaceType = TypeVar("SearchSpaceType", bound=SearchSpace)
 """ Type variable bound to :class:`SearchSpace`. """
 
-M_contra = TypeVar("M_contra", bound=TrainableProbabilisticModel, contravariant=True)
+TrainableProbabilisticModelType = TypeVar(
+    "TrainableProbabilisticModelType", bound=TrainableProbabilisticModel, contravariant=True
+)
 """ Type variable bound to :class:`TrainableProbabilisticModel`. """
 
 
-class AskTellOptimizer(Generic[SP]):
+class AskTellOptimizer(Generic[SearchSpaceType]):
     """
     This class provides Ask/Tell optimization interface. It is designed for those use cases
     when control of the optimization loop by Trieste is impossible or not desirable.
@@ -57,9 +59,9 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Mapping[str, Dataset],
-        model_specs: Mapping[str, M_contra],
+        model_specs: Mapping[str, TrainableProbabilisticModelType],
         *,
         fit_model: bool = True,
     ):
@@ -68,33 +70,9 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
-        datasets: Mapping[str, Dataset],
-        model_specs: Mapping[str, ModelConfigType],
-        *,
-        fit_model: bool = True,
-    ):
-        ...
-
-    @overload
-    def __init__(
-        self,
-        search_space: SP,
-        datasets: Mapping[str, Dataset],
-        model_specs: Mapping[str, M_contra],
-        acquisition_rule: AcquisitionRule[TensorType, SP, M_contra],
-        *,
-        fit_model: bool = True,
-    ):
-        ...
-
-    @overload
-    def __init__(
-        self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Mapping[str, Dataset],
         model_specs: Mapping[str, ModelConfigType],
-        acquisition_rule: AcquisitionRule[TensorType, SP, M_contra],
         *,
         fit_model: bool = True,
     ):
@@ -103,11 +81,12 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Mapping[str, Dataset],
-        model_specs: Mapping[str, M_contra],
-        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP, M_contra],
-        acquisition_state: S | None,
+        model_specs: Mapping[str, TrainableProbabilisticModelType],
+        acquisition_rule: AcquisitionRule[
+            TensorType, SearchSpaceType, TrainableProbabilisticModelType
+        ],
         *,
         fit_model: bool = True,
     ):
@@ -116,11 +95,12 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Mapping[str, Dataset],
         model_specs: Mapping[str, ModelConfigType],
-        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP, M_contra],
-        acquisition_state: S | None = None,
+        acquisition_rule: AcquisitionRule[
+            TensorType, SearchSpaceType, TrainableProbabilisticModelType
+        ],
         *,
         fit_model: bool = True,
     ):
@@ -129,9 +109,39 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
+        datasets: Mapping[str, Dataset],
+        model_specs: Mapping[str, TrainableProbabilisticModelType],
+        acquisition_rule: AcquisitionRule[
+            State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
+        ],
+        acquisition_state: StateType | None,
+        *,
+        fit_model: bool = True,
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self,
+        search_space: SearchSpaceType,
+        datasets: Mapping[str, Dataset],
+        model_specs: Mapping[str, ModelConfigType],
+        acquisition_rule: AcquisitionRule[
+            State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
+        ],
+        acquisition_state: StateType | None = None,
+        *,
+        fit_model: bool = True,
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self,
+        search_space: SearchSpaceType,
         datasets: Dataset,
-        model_specs: M_contra,
+        model_specs: TrainableProbabilisticModelType,
         *,
         fit_model: bool = True,
     ):
@@ -140,7 +150,7 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Dataset,
         model_specs: ModelConfigType,
         *,
@@ -151,10 +161,12 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Dataset,
-        model_specs: M_contra,
-        acquisition_rule: AcquisitionRule[TensorType, SP, M_contra],
+        model_specs: TrainableProbabilisticModelType,
+        acquisition_rule: AcquisitionRule[
+            TensorType, SearchSpaceType, TrainableProbabilisticModelType
+        ],
         *,
         fit_model: bool = True,
     ):
@@ -163,10 +175,12 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Dataset,
-        model_specs: M_contra,
-        acquisition_rule: AcquisitionRule[TensorType, SP, M_contra],
+        model_specs: TrainableProbabilisticModelType,
+        acquisition_rule: AcquisitionRule[
+            TensorType, SearchSpaceType, TrainableProbabilisticModelType
+        ],
         *,
         fit_model: bool = True,
     ):
@@ -175,11 +189,13 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Dataset,
-        model_specs: M_contra,
-        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP, M_contra],
-        acquisition_state: S | None = None,
+        model_specs: TrainableProbabilisticModelType,
+        acquisition_rule: AcquisitionRule[
+            State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
+        ],
+        acquisition_state: StateType | None = None,
         *,
         fit_model: bool = True,
     ):
@@ -188,11 +204,13 @@ class AskTellOptimizer(Generic[SP]):
     @overload
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Dataset,
         model_specs: ModelConfigType,
-        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP, M_contra],
-        acquisition_state: S | None,
+        acquisition_rule: AcquisitionRule[
+            State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
+        ],
+        acquisition_state: StateType | None,
         *,
         fit_model: bool = True,
     ):
@@ -200,12 +218,16 @@ class AskTellOptimizer(Generic[SP]):
 
     def __init__(
         self,
-        search_space: SP,
+        search_space: SearchSpaceType,
         datasets: Mapping[str, Dataset] | Dataset,
         model_specs: Mapping[str, ModelSpec] | ModelSpec,
-        acquisition_rule: AcquisitionRule[TensorType | State[S | None, TensorType], SP, M_contra]
+        acquisition_rule: AcquisitionRule[
+            TensorType | State[StateType | None, TensorType],
+            SearchSpaceType,
+            TrainableProbabilisticModelType,
+        ]
         | None = None,
-        acquisition_state: S | None = None,
+        acquisition_state: StateType | None = None,
         *,
         fit_model: bool = True,
     ):
@@ -248,7 +270,9 @@ class AskTellOptimizer(Generic[SP]):
             )
 
         self._datasets = datasets
-        self._models = cast(Dict[str, M_contra], map_values(create_model, model_specs))
+        self._models = cast(
+            Dict[str, TrainableProbabilisticModelType], map_values(create_model, model_specs)
+        )
 
         if acquisition_rule is None:
             if self._datasets.keys() != {OBJECTIVE}:
@@ -258,7 +282,8 @@ class AskTellOptimizer(Generic[SP]):
                 )
 
             self._acquisition_rule = cast(
-                AcquisitionRule[TensorType, SP, M_contra], EfficientGlobalOptimization()
+                AcquisitionRule[TensorType, SearchSpaceType, TrainableProbabilisticModelType],
+                EfficientGlobalOptimization(),
             )
         else:
             self._acquisition_rule = acquisition_rule
@@ -278,11 +303,15 @@ class AskTellOptimizer(Generic[SP]):
     @classmethod
     def from_record(
         cls,
-        record: Record[S],
-        search_space: SP,
-        acquisition_rule: AcquisitionRule[TensorType | State[S | None, TensorType], SP, M_contra]
+        record: Record[StateType],
+        search_space: SearchSpaceType,
+        acquisition_rule: AcquisitionRule[
+            TensorType | State[StateType | None, TensorType],
+            SearchSpaceType,
+            TrainableProbabilisticModelType,
+        ]
         | None = None,
-    ) -> AskTellOptimizer[SP]:
+    ) -> AskTellOptimizer[SearchSpaceType]:
         """Creates new :class:`~AskTellOptimizer` instance from provided optimization state.
         Model training isn't triggered upon creation of the instance.
 
@@ -302,13 +331,13 @@ class AskTellOptimizer(Generic[SP]):
         return cls(
             search_space,
             record.datasets,
-            cast(Mapping[str, M_contra], record.models),
+            cast(Mapping[str, TrainableProbabilisticModelType], record.models),
             acquisition_rule=acquisition_rule,  # type: ignore
             acquisition_state=record.acquisition_state,
             fit_model=False,
         )
 
-    def to_record(self) -> Record[S]:
+    def to_record(self) -> Record[StateType]:
         """Collects the current state of the optimization, which includes datasets,
         models and acquisition state (if applicable).
 
@@ -320,10 +349,10 @@ class AskTellOptimizer(Generic[SP]):
             datasets=self._datasets, models=models_copy, acquisition_state=acquisition_state_copy
         )
 
-    def to_result(self) -> OptimizationResult[S]:
+    def to_result(self) -> OptimizationResult[StateType]:
         """Converts current state of the optimization
         into a :class:`~trieste.data.OptimizationResult` object."""
-        record: Record[S] = self.to_record()
+        record: Record[StateType] = self.to_record()
         return OptimizationResult(Ok(record), [])
 
     def ask(self) -> TensorType:

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -38,18 +38,20 @@ from .space import SearchSpace
 from .types import State, TensorType
 from .utils import Err, Ok, Result, map_values
 
-S = TypeVar("S")
+StateType = TypeVar("StateType")
 """ Unbound type variable. """
 
-SP = TypeVar("SP", bound=SearchSpace)
+SearchSpaceType = TypeVar("SearchSpaceType", bound=SearchSpace)
 """ Type variable bound to :class:`SearchSpace`. """
 
-M_contra = TypeVar("M_contra", bound=TrainableProbabilisticModel, contravariant=True)
+TrainableProbabilisticModelType = TypeVar(
+    "TrainableProbabilisticModelType", bound=TrainableProbabilisticModel, contravariant=True
+)
 """ Type variable bound to :class:`TrainableProbabilisticModel`. """
 
 
 @dataclass(frozen=True)
-class Record(Generic[S]):
+class Record(Generic[StateType]):
     """Container to record the state of each step of the optimization process."""
 
     datasets: Mapping[str, Dataset]
@@ -58,7 +60,7 @@ class Record(Generic[S]):
     models: Mapping[str, TrainableProbabilisticModel]
     """ The models over the :attr:`datasets`. """
 
-    acquisition_state: S | None
+    acquisition_state: StateType | None
     """ The acquisition state. """
 
     @property
@@ -81,23 +83,23 @@ class Record(Generic[S]):
 # this should be a generic NamedTuple, but mypy doesn't support them
 #  https://github.com/python/mypy/issues/685
 @dataclass(frozen=True)
-class OptimizationResult(Generic[S]):
+class OptimizationResult(Generic[StateType]):
     """The final result, and the historical data of the optimization process."""
 
-    final_result: Result[Record[S]]
+    final_result: Result[Record[StateType]]
     """
     The final result of the optimization process. This contains either a :class:`Record` or an
     exception.
     """
 
-    history: list[Record[S]]
+    history: list[Record[StateType]]
     r"""
     The history of the :class:`Record`\ s from each step of the optimization process. These
     :class:`Record`\ s are created at the *start* of each loop, and as such will never include the
     :attr:`final_result`.
     """
 
-    def astuple(self) -> tuple[Result[Record[S]], list[Record[S]]]:
+    def astuple(self) -> tuple[Result[Record[StateType]], list[Record[StateType]]]:
         """
         **Note:** In contrast to the standard library function :func:`dataclasses.astuple`, this
         method does *not* deepcopy instance attributes.
@@ -153,14 +155,14 @@ class OptimizationResult(Generic[S]):
             raise ValueError(f"Expected single model, found {len(models)}")
 
 
-class BayesianOptimizer(Generic[SP]):
+class BayesianOptimizer(Generic[SearchSpaceType]):
     """
     This class performs Bayesian optimization, the data-efficient optimization of an expensive
     black-box *objective function* over some *search space*. Since we may not have access to the
     objective function itself, we speak instead of an *observer* that observes it.
     """
 
-    def __init__(self, observer: Observer, search_space: SP):
+    def __init__(self, observer: Observer, search_space: SearchSpaceType):
         """
         :param observer: The observer of the objective function.
         :param search_space: The space over which to search. Must be a
@@ -190,8 +192,10 @@ class BayesianOptimizer(Generic[SP]):
         self,
         num_steps: int,
         datasets: Mapping[str, Dataset],
-        model_specs: Mapping[str, M_contra],
-        acquisition_rule: AcquisitionRule[TensorType, SP, M_contra],
+        model_specs: Mapping[str, TrainableProbabilisticModelType],
+        acquisition_rule: AcquisitionRule[
+            TensorType, SearchSpaceType, TrainableProbabilisticModelType
+        ],
         *,
         track_state: bool = True,
         fit_initial_model: bool = True,
@@ -208,7 +212,9 @@ class BayesianOptimizer(Generic[SP]):
         datasets: Mapping[str, Dataset],
         # there's no way to statically check config-based models
         model_specs: Mapping[str, ModelConfigType],
-        acquisition_rule: AcquisitionRule[TensorType, SP, M_contra],
+        acquisition_rule: AcquisitionRule[
+            TensorType, SearchSpaceType, TrainableProbabilisticModelType
+        ],
         *,
         track_state: bool = True,
         fit_initial_model: bool = True,
@@ -223,13 +229,15 @@ class BayesianOptimizer(Generic[SP]):
         self,
         num_steps: int,
         datasets: Mapping[str, Dataset],
-        model_specs: Mapping[str, M_contra],
-        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP, M_contra],
-        acquisition_state: S | None = None,
+        model_specs: Mapping[str, TrainableProbabilisticModelType],
+        acquisition_rule: AcquisitionRule[
+            State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
+        ],
+        acquisition_state: StateType | None = None,
         *,
         track_state: bool = True,
         fit_initial_model: bool = True,
-    ) -> OptimizationResult[S]:
+    ) -> OptimizationResult[StateType]:
         ...
 
     @overload
@@ -239,12 +247,14 @@ class BayesianOptimizer(Generic[SP]):
         datasets: Mapping[str, Dataset],
         # there's no way to statically check config-based models
         model_specs: Mapping[str, ModelConfigType],
-        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP, M_contra],
-        acquisition_state: S | None = None,
+        acquisition_rule: AcquisitionRule[
+            State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
+        ],
+        acquisition_state: StateType | None = None,
         *,
         track_state: bool = True,
         fit_initial_model: bool = True,
-    ) -> OptimizationResult[S]:
+    ) -> OptimizationResult[StateType]:
         ...
 
     @overload
@@ -264,8 +274,10 @@ class BayesianOptimizer(Generic[SP]):
         self,
         num_steps: int,
         datasets: Dataset,
-        model_specs: M_contra,
-        acquisition_rule: AcquisitionRule[TensorType, SP, M_contra],
+        model_specs: TrainableProbabilisticModelType,
+        acquisition_rule: AcquisitionRule[
+            TensorType, SearchSpaceType, TrainableProbabilisticModelType
+        ],
         *,
         track_state: bool = True,
         fit_initial_model: bool = True,
@@ -278,7 +290,9 @@ class BayesianOptimizer(Generic[SP]):
         num_steps: int,
         datasets: Dataset,
         model_specs: ModelConfigType,
-        acquisition_rule: AcquisitionRule[TensorType, SP, M_contra],
+        acquisition_rule: AcquisitionRule[
+            TensorType, SearchSpaceType, TrainableProbabilisticModelType
+        ],
         *,
         track_state: bool = True,
         fit_initial_model: bool = True,
@@ -290,13 +304,15 @@ class BayesianOptimizer(Generic[SP]):
         self,
         num_steps: int,
         datasets: Dataset,
-        model_specs: M_contra,
-        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP, M_contra],
-        acquisition_state: S | None = None,
+        model_specs: TrainableProbabilisticModelType,
+        acquisition_rule: AcquisitionRule[
+            State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
+        ],
+        acquisition_state: StateType | None = None,
         *,
         track_state: bool = True,
         fit_initial_model: bool = True,
-    ) -> OptimizationResult[S]:
+    ) -> OptimizationResult[StateType]:
         ...
 
     @overload
@@ -305,26 +321,35 @@ class BayesianOptimizer(Generic[SP]):
         num_steps: int,
         datasets: Dataset,
         model_specs: ModelConfigType,
-        acquisition_rule: AcquisitionRule[State[S | None, TensorType], SP, M_contra],
-        acquisition_state: S | None = None,
+        acquisition_rule: AcquisitionRule[
+            State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
+        ],
+        acquisition_state: StateType | None = None,
         *,
         track_state: bool = True,
         fit_initial_model: bool = True,
-    ) -> OptimizationResult[S]:
+    ) -> OptimizationResult[StateType]:
         ...
 
     def optimize(
         self,
         num_steps: int,
         datasets: Mapping[str, Dataset] | Dataset,
-        model_specs: Mapping[str, M_contra] | Mapping[str, ModelSpec] | M_contra | ModelConfigType,
-        acquisition_rule: AcquisitionRule[TensorType | State[S | None, TensorType], SP, M_contra]
+        model_specs: Mapping[str, TrainableProbabilisticModelType]
+        | Mapping[str, ModelSpec]
+        | TrainableProbabilisticModelType
+        | ModelConfigType,
+        acquisition_rule: AcquisitionRule[
+            TensorType | State[StateType | None, TensorType],
+            SearchSpaceType,
+            TrainableProbabilisticModelType,
+        ]
         | None = None,
-        acquisition_state: S | None = None,
+        acquisition_state: StateType | None = None,
         *,
         track_state: bool = True,
         fit_initial_model: bool = True,
-    ) -> OptimizationResult[S] | OptimizationResult[None]:
+    ) -> OptimizationResult[StateType] | OptimizationResult[None]:
         """
         Attempt to find the minimizer of the ``observer`` in the ``search_space`` (both specified at
         :meth:`__init__`). This is the central implementation of the Bayesian optimization loop.
@@ -410,12 +435,16 @@ class BayesianOptimizer(Generic[SP]):
                     f" {OBJECTIVE!r}, got keys {datasets.keys()}"
                 )
 
-            acquisition_rule = EfficientGlobalOptimization[SP, M_contra]()
+            acquisition_rule = EfficientGlobalOptimization[
+                SearchSpaceType, TrainableProbabilisticModelType
+            ]()
 
         # note that this cast is justified for explicit models but not for models created
         # from config, which can't be statically type checked; those will fail at runtime instead
-        models = cast(Dict[str, M_contra], map_values(create_model, model_specs))
-        history: list[Record[S]] = []
+        models = cast(
+            Dict[str, TrainableProbabilisticModelType], map_values(create_model, model_specs)
+        )
+        history: list[Record[StateType]] = []
 
         for step in range(num_steps):
             set_step_number(step)

--- a/trieste/models/__init__.py
+++ b/trieste/models/__init__.py
@@ -23,6 +23,7 @@ from .interfaces import (
     FastUpdateModel,
     ModelStack,
     ProbabilisticModel,
+    ProbabilisticModelType,
     ReparametrizationSampler,
     TrainableModelStack,
     TrainableProbabilisticModel,

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -25,7 +25,9 @@ from ..data import Dataset
 from ..types import TensorType
 from ..utils import DEFAULTS
 
-T = TypeVar("T", bound="ProbabilisticModel", contravariant=True)
+ProbabilisticModelType = TypeVar(
+    "ProbabilisticModelType", bound="ProbabilisticModel", contravariant=True
+)
 
 
 @runtime_checkable
@@ -85,7 +87,9 @@ class ProbabilisticModel(Protocol):
             f"Model {self!r} does not support predicting observations, just the latent function"
         )
 
-    def reparam_sampler(self: T, num_samples: int) -> ReparametrizationSampler[T]:
+    def reparam_sampler(
+        self: ProbabilisticModelType, num_samples: int
+    ) -> ReparametrizationSampler[ProbabilisticModelType]:
         """
         Return a reparametrization sampler providing `num_samples` samples.
 
@@ -96,7 +100,9 @@ class ProbabilisticModel(Protocol):
         """
         raise NotImplementedError(f"Model {self!r} does not have a reparametrization sampler")
 
-    def trajectory_sampler(self: T) -> TrajectorySampler[T]:
+    def trajectory_sampler(
+        self: ProbabilisticModelType,
+    ) -> TrajectorySampler[ProbabilisticModelType]:
         """
         Return a trajectory sampler.
 
@@ -264,7 +270,7 @@ class FastUpdateModel(ProbabilisticModel, Protocol):
         )
 
 
-class ModelStack(ProbabilisticModel, Generic[T]):
+class ModelStack(ProbabilisticModel, Generic[ProbabilisticModelType]):
     r"""
     A :class:`ModelStack` is a wrapper around a number of :class:`ProbabilisticModel`\ s of type
     :class:`T`. It combines the outputs of each model for predictions and sampling.
@@ -280,8 +286,8 @@ class ModelStack(ProbabilisticModel, Generic[T]):
 
     def __init__(
         self,
-        model_with_event_size: tuple[T, int],
-        *models_with_event_sizes: tuple[T, int],
+        model_with_event_size: tuple[ProbabilisticModelType, int],
+        *models_with_event_sizes: tuple[ProbabilisticModelType, int],
     ):
         r"""
         The order of individual models specified at :meth:`__init__` determines the order of the
@@ -438,14 +444,14 @@ class TrainablePredictJointModelStack(
     pass
 
 
-class ReparametrizationSampler(ABC, Generic[T]):
+class ReparametrizationSampler(ABC, Generic[ProbabilisticModelType]):
     r"""
     These samplers employ the *reparameterization trick* to draw samples from a
     :class:`ProbabilisticModel`\ 's predictive distribution  across a discrete set of
     points. See :cite:`wilson2018maximizing` for details.
     """
 
-    def __init__(self, sample_size: int, model: T):
+    def __init__(self, sample_size: int, model: ProbabilisticModelType):
         r"""
         Note that our :class:`TrainableModelStack` currently assumes that
         all :class:`ReparametrizationSampler` constructors have **only** these inputs
@@ -509,7 +515,7 @@ class TrajectoryFunctionClass(ABC):
         """Call trajectory function."""
 
 
-class TrajectorySampler(ABC, Generic[T]):
+class TrajectorySampler(ABC, Generic[ProbabilisticModelType]):
     r"""
     This class builds functions that approximate a trajectory sampled from an
     underlying :class:`ProbabilisticModel`.
@@ -519,7 +525,7 @@ class TrajectorySampler(ABC, Generic[T]):
     of a particular trajectory function).
     """
 
-    def __init__(self, model: T):
+    def __init__(self, model: ProbabilisticModelType):
         """
         :param model: The model to sample from.
         """

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -28,6 +28,7 @@ from ..utils import DEFAULTS
 ProbabilisticModelType = TypeVar(
     "ProbabilisticModelType", bound="ProbabilisticModel", contravariant=True
 )
+""" Contravariant type variable bound to :class:`~trieste.models.ProbabilisticModel`. """
 
 
 @runtime_checkable

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -28,7 +28,9 @@ from ..utils import DEFAULTS
 ProbabilisticModelType = TypeVar(
     "ProbabilisticModelType", bound="ProbabilisticModel", contravariant=True
 )
-""" Contravariant type variable bound to :class:`~trieste.models.ProbabilisticModel`. """
+""" Contravariant type variable bound to :class:`~trieste.models.ProbabilisticModel`.
+This is used to specify classes such as samplers and acquisition function builders that
+take models as input parameters and might ony support models with certain features. """
 
 
 @runtime_checkable

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -25,7 +25,7 @@ import tensorflow_probability as tfp
 from .types import TensorType
 from .utils import shapes_equal
 
-SP = TypeVar("SP", bound="SearchSpace")
+SearchSpaceType = TypeVar("SearchSpaceType", bound="SearchSpace")
 """ A type variable bound to :class:`SearchSpace`. """
 
 
@@ -67,13 +67,13 @@ class SearchSpace(ABC):
         """The highest value taken by each search space dimension."""
 
     @abstractmethod
-    def __mul__(self: SP, other: SP) -> SP:
+    def __mul__(self: SearchSpaceType, other: SearchSpaceType) -> SearchSpaceType:
         """
         :param other: A search space of the same type as this search space.
         :return: The Cartesian product of this search space with the ``other``.
         """
 
-    def __pow__(self: SP, other: int) -> SP:
+    def __pow__(self: SearchSpaceType, other: int) -> SearchSpaceType:
         """
         Return the Cartesian product of ``other`` instances of this search space. For example, for
         an exponent of `3`, and search space `s`, this is `s ** 3`, which is equivalent to

--- a/trieste/utils/__init__.py
+++ b/trieste/utils/__init__.py
@@ -14,7 +14,7 @@
 """ This package contains library utilities. """
 from typing import Callable, Mapping, TypeVar
 
-from .misc import DEFAULTS, Err, Ok, Result, T_co, jit, shapes_equal, to_numpy
+from .misc import DEFAULTS, Err, Ok, Result, ResultType, jit, shapes_equal, to_numpy
 
 K = TypeVar("K")
 """ An unbound type variable. """

--- a/trieste/utils/__init__.py
+++ b/trieste/utils/__init__.py
@@ -12,35 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ This package contains library utilities. """
-from typing import Callable, Mapping, TypeVar
-
-from .misc import DEFAULTS, Err, Ok, Result, ResultType, jit, shapes_equal, to_numpy
-
-K = TypeVar("K")
-""" An unbound type variable. """
-
-U = TypeVar("U")
-""" An unbound type variable. """
-
-V = TypeVar("V")
-""" An unbound type variable. """
-
-
-def map_values(f: Callable[[U], V], mapping: Mapping[K, U]) -> Mapping[K, V]:
-    """
-    Apply ``f`` to each value in ``mapping`` and return the result. If ``f`` does not modify its
-    argument, :func:`map_values` does not modify ``mapping``. For example:
-
-    >>> import math
-    >>> squares = {'a': 1, 'b': 4, 'c': 9}
-    >>> map_values(math.sqrt, squares)['b']
-    2.0
-    >>> squares
-    {'a': 1, 'b': 4, 'c': 9}
-
-    :param f: The function to apply to the values in ``mapping``.
-    :param mapping: A mapping.
-    :return: A new mapping, whose keys are the same as ``mapping``, and values are the result of
-        applying ``f`` to each value in ``mapping``.
-    """
-    return {k: f(u) for k, u in mapping.items()}
+from .misc import (
+    DEFAULTS,
+    Err,
+    K,
+    Ok,
+    Result,
+    ResultType,
+    U,
+    V,
+    jit,
+    map_values,
+    shapes_equal,
+    to_numpy,
+)

--- a/trieste/utils/misc.py
+++ b/trieste/utils/misc.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Generic, NoReturn, TypeVar
+from typing import Any, Callable, Generic, Mapping, NoReturn, TypeVar
 
 import numpy as np
 import tensorflow as tf
@@ -180,3 +180,33 @@ class DEFAULTS:
     The default jitter, typically used to stabilise computations near singular points, such as in
     Cholesky decomposition.
     """
+
+
+K = TypeVar("K")
+""" An unbound type variable. """
+
+U = TypeVar("U")
+""" An unbound type variable. """
+
+V = TypeVar("V")
+""" An unbound type variable. """
+
+
+def map_values(f: Callable[[U], V], mapping: Mapping[K, U]) -> Mapping[K, V]:
+    """
+    Apply ``f`` to each value in ``mapping`` and return the result. If ``f`` does not modify its
+    argument, :func:`map_values` does not modify ``mapping``. For example:
+
+    >>> import math
+    >>> squares = {'a': 1, 'b': 4, 'c': 9}
+    >>> map_values(math.sqrt, squares)['b']
+    2.0
+    >>> squares
+    {'a': 1, 'b': 4, 'c': 9}
+
+    :param f: The function to apply to the values in ``mapping``.
+    :param mapping: A mapping.
+    :return: A new mapping, whose keys are the same as ``mapping``, and values are the result of
+        applying ``f`` to each value in ``mapping``.
+    """
+    return {k: f(u) for k, u in mapping.items()}

--- a/trieste/utils/misc.py
+++ b/trieste/utils/misc.py
@@ -61,11 +61,11 @@ def to_numpy(t: TensorType) -> np.ndarray:
     return t
 
 
-T_co = TypeVar("T_co", covariant=True)
+ResultType = TypeVar("ResultType", covariant=True)
 """ An unbounded covariant type variable. """
 
 
-class Result(Generic[T_co], ABC):
+class Result(Generic[ResultType], ABC):
     """
     Represents the result of an operation that can fail with an exception. It contains either the
     operation return value (in an :class:`Ok`), or the exception raised (in an :class:`Err`).
@@ -113,7 +113,7 @@ class Result(Generic[T_co], ABC):
         return not self.is_ok
 
     @abstractmethod
-    def unwrap(self) -> T_co:
+    def unwrap(self) -> ResultType:
         """
         :return: The contained value, if it exists.
         :raise Exception: If there is no contained value.
@@ -121,10 +121,10 @@ class Result(Generic[T_co], ABC):
 
 
 @final
-class Ok(Result[T_co]):
+class Ok(Result[ResultType]):
     """Wraps the result of a successful evaluation."""
 
-    def __init__(self, value: T_co):
+    def __init__(self, value: ResultType):
         """
         :param value: The result of a successful evaluation.
         """
@@ -139,7 +139,7 @@ class Ok(Result[T_co]):
         """`True` always."""
         return True
 
-    def unwrap(self) -> T_co:
+    def unwrap(self) -> ResultType:
         """
         :return: The wrapped value.
         """


### PR DESCRIPTION
To make the function signatures less confusing for beginners, I've renamed nearly all of TypeVars to something more descriptive:

* `SearchSpaceType` (a type var bound to SearchSpace)
* `ProbabilisticModelType` (a type var bound to ProbabilisticModels)
* `TrainableProbabilisticModelType` (a type var bound to TrainableProbabilisticModel)
* `GIBBONModelType` (a type var bound to SupportsCovarianceObservationNoise used by GIBBON)
* `ResultType` (unbound type var used by AcquisitionRule)
* `StateType` (unbound type var used by Records and the BO loop)

Note that I've not included whether the types are contravariant in the type name as is sometimes done (e.g. `ProbabilisticModelType_contra`) as that makes them unweildy and is meaningless to beginners. However, I make sure to mention this in the type var docstrings.