### PR TITLE
Use GPflow posterior objects to speed up acquisition.

### DIFF
--- a/tests/unit/models/conftest.py
+++ b/tests/unit/models/conftest.py
@@ -49,6 +49,7 @@ from trieste.types import TensorType
         (VariationalGaussianProcess, vgp_model),
         (SparseVariational, svgp_model),
     ],
+    ids=lambda mf: mf[1].__name__,
 )
 def _gpflow_interface_factory(request: Any) -> ModelFactoryType:
     def model_interface_factory(

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -26,6 +26,7 @@ trieste model).
 from __future__ import annotations
 
 import unittest.mock
+from time import time
 from typing import Any, cast
 
 import gpflow
@@ -57,7 +58,6 @@ from trieste.models.gpflow import (
     SparseVariational,
     VariationalGaussianProcess,
 )
-from trieste.models.gpflow.models import NumDataPropertyMixin
 from trieste.models.gpflow.sampler import (
     DecoupledTrajectorySampler,
     RandomFourierFeatureTrajectorySampler,
@@ -391,6 +391,7 @@ def test_gaussian_process_regression_trajectory_sampler_has_correct_samples(
         gpr_model(x, _3x_plus_gaussian_noise(x)), use_decoupled_sampler=use_decoupled_sampler
     )
     model.model.likelihood.variance.assign(1e-3)
+    model._posterior.update_cache()
 
     num_samples = 100
     trajectory_sampler = model.trajectory_sampler()
@@ -484,12 +485,12 @@ def test_variational_gaussian_process_update_updates_num_data() -> None:
     x = tf.convert_to_tensor(x_np, x_np.dtype)
     y = fnc_3x_plus_10(x)
     m = VariationalGaussianProcess(vgp_model(x, y))
-    num_data = m.model.num_data
+    num_data = m.model.num_data.numpy()
 
     x_new = tf.concat([x, [[10.0], [11.0]]], 0)
     y_new = fnc_3x_plus_10(x_new)
     m.update(Dataset(x_new, y_new))
-    new_num_data = m.model.num_data
+    new_num_data = m.model.num_data.numpy()
     assert new_num_data - num_data == 2
 
 
@@ -611,6 +612,71 @@ def test_gaussian_process_regression_optimize(compile: bool) -> None:
 
 
 @random_seed
+@pytest.mark.parametrize("after_model_optimize", [True, False])
+@pytest.mark.parametrize("after_model_update", [True, False])
+def test_gaussian_process_cached_predictions_correct(
+    after_model_optimize: bool,
+    after_model_update: bool,
+    gpflow_interface_factory: ModelFactoryType,
+) -> None:
+    x = np.linspace(0, 5, 10).reshape((-1, 1))
+    y = fnc_2sin_x_over_3(x)
+    data = x, y
+    dataset = Dataset(*data)
+    model, _ = gpflow_interface_factory(x, y)
+
+    if after_model_optimize:
+        model._optimizer = BatchOptimizer(tf.optimizers.SGD(), max_iter=1)
+        model.optimize(dataset)
+
+    if after_model_update:
+        new_x = np.linspace(0, 5, 3).reshape((-1, 1))
+        new_y = fnc_2sin_x_over_3(new_x)
+        new_dataset = Dataset(new_x, new_y)
+        model.update(new_dataset)
+
+    x_predict = np.linspace(0, 5, 2).reshape((-1, 1))
+
+    # get cached predictions
+    cached_fmean, cached_fvar = model.predict(x_predict)
+    cached_joint_mean, cached_joint_var = model.predict_joint(x_predict)
+    cached_ymean, cached_yvar = model.predict_y(x_predict)
+
+    # get reference (slow) predictions from underlying model
+    reference_fmean, reference_fvar = model.model.predict_f(x_predict)
+    reference_joint_mean, reference_joint_var = model.model.predict_f(x_predict, full_cov=True)
+    reference_ymean, reference_yvar = model.model.predict_y(x_predict)
+
+    npt.assert_allclose(cached_fmean, reference_fmean)
+    npt.assert_allclose(cached_ymean, reference_ymean)
+    npt.assert_allclose(cached_joint_mean, reference_joint_mean)
+    npt.assert_allclose(cached_fvar, reference_fvar, atol=1e-5)
+    npt.assert_allclose(cached_yvar, reference_yvar, atol=1e-5)
+    npt.assert_allclose(cached_joint_var, reference_joint_var, atol=1e-5)
+    npt.assert_allclose(cached_yvar - model.get_observation_noise(), cached_fvar, atol=5e-5)
+
+
+@random_seed
+def test_gaussian_process_cached_predictions_faster(
+    gpflow_interface_factory: ModelFactoryType,
+) -> None:
+    x = np.linspace(0, 10, 10).reshape((-1, 1))
+    y = fnc_2sin_x_over_3(x)
+    model, _ = gpflow_interface_factory(x, y)
+    n_calls = 100
+
+    x_predict = np.linspace(0, 5, 2).reshape((-1, 1))
+    t_0 = time()
+    [model.predict(x_predict) for _ in range(n_calls)]
+    time_with_cache = time() - t_0
+    t_0 = time()
+    [model.model.predict_f(x_predict) for _ in range(n_calls)]
+    time_without_cache = time() - t_0
+
+    npt.assert_array_less(time_with_cache, time_without_cache)
+
+
+@random_seed
 def test_variational_gaussian_process_predict() -> None:
     x_observed = tf.constant(np.arange(3).reshape((-1, 1)), dtype=gpflow.default_float())
     y_observed = _3x_plus_gaussian_noise(x_observed)
@@ -621,6 +687,7 @@ def test_variational_gaussian_process_predict() -> None:
         internal_model.training_loss_closure(),
         internal_model.trainable_variables,
     )
+    model._posterior.update_cache()
     x_predict = tf.constant([[1.5]], gpflow.default_float())
     mean, variance = model.predict(x_predict)
     mean_y, variance_y = model.predict_y(x_predict)
@@ -646,7 +713,7 @@ def test_variational_gaussian_process_predict() -> None:
     )
     reference_mean, reference_variance = reference_model.predict_f(x_predict)
 
-    npt.assert_allclose(mean, reference_mean)
+    npt.assert_allclose(mean, reference_mean, atol=2e-5)
     npt.assert_allclose(variance, reference_variance, atol=1e-3)
     npt.assert_allclose(variance_y - model.get_observation_noise(), variance, atol=5e-5)
 
@@ -656,7 +723,6 @@ def test_sparse_variational_model_attribute() -> None:
     sv = SparseVariational(model)
     assert sv.model is model
     assert isinstance(sv.model, SVGP)
-    assert isinstance(sv.model, NumDataPropertyMixin)
 
 
 def test_sparse_variational_model_num_data_mixin_supports_subclasses() -> None:
@@ -671,7 +737,6 @@ def test_sparse_variational_model_num_data_mixin_supports_subclasses() -> None:
     )
     sv = SparseVariational(model)
     assert sv.model is model
-    assert isinstance(sv.model, NumDataPropertyMixin)
     assert isinstance(sv.model, SVGPSubclass)
     assert sv.model.mol == 42
 
@@ -753,6 +818,7 @@ def test_sparse_variational_trajectory_sampler_has_correct_samples(whiten: bool)
     # for speed just pretend update rather than optimize
     model.model.q_sqrt.assign(tf.expand_dims(tf.eye(len(x)) * tf.math.sqrt(1e-5), 0))
     model.model.q_mu.assign(y)
+    model._posterior.update_cache()
 
     num_samples = 100
     trajectory_sampler = model.trajectory_sampler()
@@ -1049,6 +1115,7 @@ def test_gpflow_models_pairwise_covariance(gpflow_interface_factory: ModelFactor
         num_inducing_points = tf.shape(model.model.q_sqrt)[1]
         sampled_q_sqrt = tfp.distributions.WishartTriL(5, tf.eye(num_inducing_points)).sample(1)
         model.model.q_sqrt.assign(sampled_q_sqrt)
+        model._posterior.update_cache()
 
     query_points_1 = tf.concat([0.5 * x, 0.5 * x], 0)  # shape: [8, 1]
     query_points_2 = tf.concat([2 * x, 2 * x, 2 * x], 0)  # shape: [12, 1]
@@ -1076,10 +1143,8 @@ def test_sparse_variational_pairwise_covariance_for_non_whitened(
     y1 = fnc_3x_plus_10(x)
     y2 = y1 * 0.5
 
-    svgp = two_output_svgp_model(x, mo_type)
-
+    svgp = two_output_svgp_model(x, mo_type, whiten)
     model = SparseVariational(svgp, BatchOptimizer(tf.optimizers.Adam(), max_iter=3, batch_size=10))
-    model.model.whiten = whiten
 
     model.optimize(Dataset(x, tf.concat([y1, y2], axis=-1)))
 

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -335,7 +335,7 @@ def vgp_matern_model(x: tf.Tensor, y: tf.Tensor) -> VGP:
     return m
 
 
-def two_output_svgp_model(x: tf.Tensor, type: str) -> SVGP:
+def two_output_svgp_model(x: tf.Tensor, type: str, whiten: bool) -> SVGP:
 
     ker1 = gpflow.kernels.Matern32()
     ker2 = gpflow.kernels.Matern52()
@@ -359,7 +359,9 @@ def two_output_svgp_model(x: tf.Tensor, type: str) -> SVGP:
         kernel = ker1
         iv = x[:3]
 
-    return SVGP(kernel, gpflow.likelihoods.Gaussian(), iv, num_data=len(x), num_latent_gps=2)
+    return SVGP(
+        kernel, gpflow.likelihoods.Gaussian(), iv, num_data=len(x), num_latent_gps=2, whiten=whiten
+    )
 
 
 def vgp_model_bernoulli(x: tf.Tensor, y: tf.Tensor) -> VGP:

--- a/trieste/models/config.py
+++ b/trieste/models/config.py
@@ -253,5 +253,6 @@ def create_model(
     elif isinstance(config, dict):
         return ModelConfig(**config).build_model()
     elif isinstance(config, TrainableProbabilisticModel):
+        config.after_load()
         return config
     raise NotImplementedError("Unknown format passed to create a TrainableProbabilisticModel.")

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -14,25 +14,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import gpflow
 import tensorflow as tf
 import tensorflow_probability as tfp
-from gpflow.base import (
-    DType,
-    Prior,
-    PriorOn,
-    TensorData,
-    Transform,
-    _cast_to_dtype,
-    _validate_unconstrained_value,
-)
 from gpflow.conditionals.util import sample_mvn
 from gpflow.models import GPR, SGPR, SVGP, VGP
-from gpflow.utilities import multiple_assign, read_values
+from gpflow.models.vgp import update_vgp_data
+from gpflow.posteriors import PrecomputeCacheType
+from gpflow.utilities import is_variable, multiple_assign, read_values
 from gpflow.utilities.ops import leading_transpose
-from tensorflow_probability.python.util import TransformedVariable
 
 from ...data import Dataset
 from ...types import TensorType
@@ -67,6 +59,13 @@ class GaussianProcessRegression(
     """
     A :class:`TrainableProbabilisticModel` wrapper for a GPflow :class:`~gpflow.models.GPR`
     or :class:`~gpflow.models.SGPR`.
+
+    As Bayesian optimization requires a large number of sequential predictions (i.e. when maximizing
+    acquisition functions), rather than calling the model directly at prediction time we instead
+    call the posterior objects built by these models. These posterior objects store the
+    pre-computed Gram matrices, which can be reused to allow faster subsequent predictions. However,
+    note that these posterior objects need to be updated whenever the underlying model is changed
+    (i.e. after calling :meth:`update` or :meth:`optimize`).
     """
 
     def __init__(
@@ -111,6 +110,19 @@ class GaussianProcessRegression(
         self._use_decoupled_sampler = use_decoupled_sampler
         self._ensure_variable_model_data()
 
+        # Cache posterior for fast sequential predictions.
+        # It is important that we create the posterior *after* we ensure that the model data is
+        # variable.
+        self._posterior = model.posterior(PrecomputeCacheType.VARIABLE)
+
+    def after_load(self) -> None:
+        self._ensure_variable_model_data()
+
+        # Cache posterior for fast sequential predictions.
+        # It is important that we create the posterior *after* we ensure that the model data is
+        # variable.
+        self._posterior = self.model.posterior(PrecomputeCacheType.VARIABLE)
+
     def __repr__(self) -> str:
         """"""
         return f"GaussianProcessRegression({self.model!r}, {self.optimizer!r})"
@@ -126,7 +138,7 @@ class GaussianProcessRegression(
         # Sometimes, for instance after serialization-deserialization, the shape can be overridden
         # Thus here we ensure data is stored in dynamic shape Variables
 
-        if all(isinstance(x, tf.Variable) and x.shape[0] is None for x in self._model.data):
+        if all(is_variable(x) and x.shape[0] is None for x in self._model.data):
             # both query points and observations are in right shape
             # nothing to do
             return
@@ -139,6 +151,16 @@ class GaussianProcessRegression(
                 self._model.data[1], trainable=False, shape=[None, *self._model.data[1].shape[1:]]
             ),
         )
+
+    def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        return self._posterior.predict_f(query_points)
+
+    def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        return self._posterior.predict_f(query_points, full_cov=True)
+
+    def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        f_mean, f_var = self.predict(query_points)
+        return self.model.likelihood.predict_mean_and_var(f_mean, f_var)
 
     def update(self, dataset: Dataset) -> None:
         self._ensure_variable_model_data()
@@ -155,6 +177,7 @@ class GaussianProcessRegression(
 
         self.model.data[0].assign(dataset.query_points)
         self.model.data[1].assign(dataset.observations)
+        self._posterior.update_cache()
 
     def covariance_between_points(
         self, query_points_1: TensorType, query_points_2: TensorType
@@ -264,6 +287,7 @@ class GaussianProcessRegression(
             )
 
         self.optimizer.optimize(self.model, dataset)
+        self._posterior.update_cache()
 
     def find_best_model_initialization(self, num_kernel_samples: int) -> None:
         """
@@ -343,17 +367,17 @@ class GaussianProcessRegression(
         if isinstance(self.model, SGPR):
             raise NotImplementedError("Conditional predict f is not supported for SGPR.")
 
-        mean_add, cov_add = self.model.predict_f(
-            additional_data.query_points, full_cov=True
+        mean_add, cov_add = self.predict_joint(
+            additional_data.query_points
         )  # [..., N, L], [..., L, N, N]
-        mean_qp, var_qp = self.model.predict_f(query_points, full_cov=False)  # [M, L], [M, L]
+        mean_qp, var_qp = self.predict(query_points)  # [M, L], [M, L]
 
         cov_cross = self.covariance_between_points(
             additional_data.query_points, query_points
         )  # [..., L, N, M]
 
         cov_shape = tf.shape(cov_add)
-        noise = self.model.likelihood.variance * tf.eye(
+        noise = self.get_observation_noise() * tf.eye(
             cov_shape[-2], batch_shape=cov_shape[:-2], dtype=cov_add.dtype
         )
         L_add = tf.linalg.cholesky(cov_add + noise)  # [..., L, N, N]
@@ -418,7 +442,7 @@ class GaussianProcessRegression(
         query_points_r = tf.broadcast_to(query_points, new_shape)  # [..., M, D]
         points = tf.concat([additional_data.query_points, query_points_r], axis=-2)  # [..., N+M, D]
 
-        mean, cov = self.model.predict_f(points, full_cov=True)  # [..., N+M, L], [..., L, N+M, N+M]
+        mean, cov = self.predict_joint(points)  # [..., N+M, L], [..., L, N+M, N+M]
 
         N = tf.shape(additional_data.query_points)[-2]
 
@@ -430,7 +454,7 @@ class GaussianProcessRegression(
         cov_cross = cov[..., :N, N:]  # [..., L, N, M]
 
         cov_shape = tf.shape(cov_add)
-        noise = self.model.likelihood.variance * tf.eye(
+        noise = self.get_observation_noise() * tf.eye(
             cov_shape[-2], batch_shape=cov_shape[:-2], dtype=cov_add.dtype
         )
         L_add = tf.linalg.cholesky(cov_add + noise)  # [..., L, N, N]
@@ -501,93 +525,6 @@ class GaussianProcessRegression(
         return self.model.likelihood.predict_mean_and_var(f_mean, f_var)
 
 
-class NumDataPropertyMixin:
-    """Mixin class for exposing num_data as a property, stored in a tf.Variable. This is to work
-    around GPFlow storing it as a number, which prevents us from updating it without retracing.
-    The property is required due to the way num_data is used in the model elbo methods.
-
-    Note that this doesn't support a num_data value of None.
-
-    This should be removed once GPFlow is updated to support Variables as num_data.
-    """
-
-    _num_data: tf.Variable
-
-    @property
-    def num_data(self) -> TensorType:
-        return self._num_data.value()
-
-    @num_data.setter
-    def num_data(self, value: TensorType) -> None:
-        self._num_data.assign(value)
-
-
-class Parameter(gpflow.Parameter):
-    """A modified version of gpflow.Parameter that supports variable shapes."""
-
-    def __init__(
-        self,
-        value: TensorData,
-        *,
-        transform: Optional[Transform] = None,
-        prior: Optional[Prior] = None,
-        prior_on: Union[str, PriorOn] = PriorOn.CONSTRAINED,
-        trainable: bool = True,
-        dtype: Optional[DType] = None,
-        name: Optional[str] = None,
-        transformed_shape: Any = None,
-        pretransformed_shape: Any = None,
-    ):
-        """
-        A copy of gpflow.Parameter's init but with additional shape arguments that are passed
-        to a modified TransformedVariable.
-        """
-        if transform is None:
-            transform = tfp.bijectors.Identity()
-
-        value = _cast_to_dtype(value, dtype)
-        _validate_unconstrained_value(value, transform, dtype)
-
-        # An inlined, modified version of TransformedVariable's __init__ that also passes any shape
-        # parameter specified in kwargs to the DeferredTensor parent's __init__.
-        # (use same parameter names as TransformedVariable)
-        bijector = transform
-        initial_value = value
-
-        for attr in {
-            "forward",
-            "forward_event_shape",
-            "inverse",
-            "inverse_event_shape",
-            "name",
-            "dtype",
-        }:
-            if not hasattr(bijector, attr):
-                raise TypeError(
-                    "Argument `bijector` missing required `Bijector` "
-                    'attribute "{}".'.format(attr)
-                )
-
-        if callable(initial_value):
-            initial_value = initial_value()
-        initial_value = tf.convert_to_tensor(initial_value, dtype_hint=bijector.dtype, dtype=dtype)
-        super(TransformedVariable, self).__init__(  # type: ignore[call-arg]
-            pretransformed_input=tf.Variable(
-                initial_value=bijector.inverse(initial_value),
-                name=name,
-                dtype=dtype,
-                shape=pretransformed_shape,
-            ),
-            transform_fn=bijector,
-            shape=transformed_shape or initial_value.shape,
-            name=bijector.name,
-        )
-        self._bijector = bijector
-
-        self.prior = prior
-        self.prior_on = prior_on  # type: ignore  # see https://github.com/python/mypy/issues/3004
-
-
 class SparseVariational(
     GPflowPredictor,
     TrainableProbabilisticModel,
@@ -597,6 +534,13 @@ class SparseVariational(
 ):
     """
     A :class:`TrainableProbabilisticModel` wrapper for a GPflow :class:`~gpflow.models.SVGP`.
+
+    Similarly to our :class:`GaussianProcessRegression`, our :class:`~gpflow.models.SVGP` wrapper
+    directly calls the posterior objects built by these models at prediction
+    time. These posterior objects store the pre-computed Gram matrices, which can be reused to allow
+    faster subsequent predictions. However, note that these posterior objects need to be updated
+    whenever the underlying model is changed
+    (i.e. after calling :meth:`update` or :meth:`optimize`).
     """
 
     def __init__(
@@ -631,17 +575,29 @@ class SparseVariational(
 
         check_optimizer(optimizer)
 
-        # GPflow stores num_data as a number. However, since we want to be able to update it
-        # without having to retrace the acquisition functions, put it in a Variable instead.
-        # So that the elbo method doesn't fail we also need to turn it into a property.
-        if not isinstance(self._model, NumDataPropertyMixin):
+        self._ensure_variable_model_data()
 
-            class SVGPWrapper(type(self._model), NumDataPropertyMixin):  # type: ignore
-                """A wrapper around GPFlow's SVGP class that stores num_data in a tf.Variable and
-                exposes it as a property."""
+        # Cache posterior for fast sequential predictions:
+        # It is important that we create the posterior *after* we ensure that the model data is
+        # variable.
+        self._posterior = model.posterior(PrecomputeCacheType.VARIABLE)
 
-            self._model._num_data = tf.Variable(model.num_data, trainable=False, dtype=tf.float64)
-            self._model.__class__ = SVGPWrapper
+    def _ensure_variable_model_data(self) -> None:
+        # GPflow stores the data in Tensors. However, since we want to be able to update the data
+        # without having to retrace the acquisition functions, put it in Variables instead.
+        # Data has to be stored in variables with dynamic shape to allow for changes
+        # Sometimes, for instance after serialization-deserialization, the shape can be overridden
+        # Thus here we ensure data is stored in dynamic shape Variables
+        if not is_variable(self._model.num_data):
+            self._model.num_data = tf.Variable(self._model.num_data, trainable=False)
+
+    def after_load(self) -> None:
+        # Cache posterior for fast sequential predictions.
+        self._ensure_variable_model_data()
+
+        # It is important that we create the posterior *after* we ensure that the model data is
+        # variable.
+        self._posterior = self.model.posterior(PrecomputeCacheType.VARIABLE)
 
     def __repr__(self) -> str:
         """"""
@@ -651,7 +607,19 @@ class SparseVariational(
     def model(self) -> SVGP:
         return self._model
 
+    def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        return self._posterior.predict_f(query_points)
+
+    def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        return self._posterior.predict_f(query_points, full_cov=True)
+
+    def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        f_mean, f_var = self.predict(query_points)
+        return self.model.likelihood.predict_mean_and_var(f_mean, f_var)
+
     def update(self, dataset: Dataset) -> None:
+        self._ensure_variable_model_data()
+
         # Hard-code asserts from _assert_data_is_compatible because model doesn't store dataset
         if dataset.query_points.shape[-1] != self.model.inducing_variable.Z.shape[-1]:
             raise ValueError(
@@ -668,7 +636,17 @@ class SparseVariational(
             )
 
         num_data = dataset.query_points.shape[0]
-        self.model.num_data = num_data
+        self.model.num_data.assign(num_data)
+        self._posterior.update_cache()
+
+    def optimize(self, dataset: Dataset) -> None:
+        """
+        Optimize the model with the specified `dataset`.
+
+        :param dataset: The data with which to optimize the `model`.
+        """
+        self.optimizer.optimize(self.model, dataset)
+        self._posterior.update_cache()
 
     def get_inducing_variables(self) -> Tuple[TensorType, TensorType, TensorType, bool]:
         """
@@ -826,6 +804,11 @@ class VariationalGaussianProcess(
         self._natgrad_gamma = natgrad_gamma
         self._ensure_variable_model_data()
 
+        # Cache posterior for fast sequential predictions.
+        # It is important that we create the posterior *after* we ensure that the model data is
+        # variable.
+        self._posterior = self.model.posterior(PrecomputeCacheType.VARIABLE)
+
     def _ensure_variable_model_data(self) -> None:
         # GPflow stores the data in Tensors. However, since we want to be able to update the data
         # without having to retrace the acquisition functions, put it in Variables instead.
@@ -833,57 +816,27 @@ class VariationalGaussianProcess(
         # Sometimes, for instance after serialization-deserialization, the shape can be overridden
         # Thus here we ensure data is stored in dynamic shape Variables
 
-        if not all(isinstance(x, tf.Variable) and x.shape[0] is None for x in self._model.data):
-
-            self._model.data = (
+        model = self.model
+        if not all(isinstance(x, tf.Variable) and x.shape[0] is None for x in model.data):
+            variable_data = (
                 tf.Variable(
-                    self._model.data[0],
+                    model.data[0],
                     trainable=False,
-                    shape=[None, *self._model.data[0].shape[1:]],
+                    shape=[None, *model.data[0].shape[1:]],
                 ),
                 tf.Variable(
-                    self._model.data[1],
+                    model.data[1],
                     trainable=False,
-                    shape=[None, *self._model.data[1].shape[1:]],
+                    shape=[None, *model.data[1].shape[1:]],
                 ),
             )
-
-            self._model.q_mu = Parameter(
-                self._model.q_mu,
-                transform=self._model.q_mu.bijector,
-                prior=self._model.q_mu.prior,
-                prior_on=self._model.q_mu.prior_on,
-                dtype=self._model.q_mu.dtype,
-                name=self._model.q_mu.unconstrained_variable.name,
-                trainable=self._model.q_mu.trainable,
-                transformed_shape=[None, *self._model.q_mu.shape[1:]],
-                pretransformed_shape=[None, *self._model.q_mu.unconstrained_variable.shape[1:]],
+            model.__init__(
+                variable_data,
+                model.kernel,
+                model.likelihood,
+                model.mean_function,
+                model.num_latent_gps,
             )
-            self._model.q_sqrt = Parameter(
-                self._model.q_sqrt,
-                transform=self._model.q_sqrt.bijector,
-                prior=self._model.q_sqrt.prior,
-                prior_on=self._model.q_sqrt.prior_on,
-                dtype=self._model.q_sqrt.dtype,
-                name=self._model.q_sqrt.unconstrained_variable.name,
-                trainable=self._model.q_sqrt.trainable,
-                transformed_shape=[*self._model.q_sqrt.shape[:-2], None, None],
-                pretransformed_shape=[*self._model.q_sqrt.unconstrained_variable.shape[:-1], None],
-            )
-
-        # GPflow stores num_data as a number. However, since we want to be able to update it
-        # without having to retrace the acquisition functions, put it in a Variable instead.
-        # So that the elbo method doesn't fail we also need to turn it into a property.
-        if not isinstance(self._model, NumDataPropertyMixin):
-
-            class VGPWrapper(type(self._model), NumDataPropertyMixin):  # type: ignore
-                """A wrapper around GPFlow's VGP class that stores num_data in a tf.Variable and
-                exposes it as a property."""
-
-            self._model._num_data = tf.Variable(
-                self._model.num_data or 0, trainable=False, dtype=tf.float64
-            )
-            self._model.__class__ = VGPWrapper
 
     def __repr__(self) -> str:
         """"""
@@ -892,6 +845,16 @@ class VariationalGaussianProcess(
     @property
     def model(self) -> VGP:
         return self._model
+
+    def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        return self._posterior.predict_f(query_points)
+
+    def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        return self._posterior.predict_f(query_points, full_cov=True)
+
+    def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        f_mean, f_var = self.predict(query_points)
+        return self.model.likelihood.predict_mean_and_var(f_mean, f_var)
 
     def update(self, dataset: Dataset, *, jitter: float = DEFAULTS.JITTER) -> None:
         """
@@ -902,31 +865,8 @@ class VariationalGaussianProcess(
             the covariance matrix.
         """
         self._ensure_variable_model_data()
-
-        model = self.model
-
-        x, y = self.model.data[0].value(), self.model.data[1].value()
-        assert_data_is_compatible(dataset, Dataset(x, y))
-
-        f_mu, f_cov = self.model.predict_f(dataset.query_points, full_cov=True)  # [N, L], [L, N, N]
-
-        # GPflow's VGP model is hard-coded to use the whitened representation, i.e.
-        # q_mu and q_sqrt parametrize q(v), and u = f(X) = L v, where L = cholesky(K(X, X))
-        # Hence we need to back-transform from f_mu and f_cov to obtain the updated
-        # new_q_mu and new_q_sqrt:
-        Knn = model.kernel(dataset.query_points, full_cov=True)  # [N, N]
-        jitter_mat = jitter * tf.eye(len(dataset), dtype=Knn.dtype)
-        Lnn = tf.linalg.cholesky(Knn + jitter_mat)  # [N, N]
-        new_q_mu = tf.linalg.triangular_solve(Lnn, f_mu)  # [N, L]
-        tmp = tf.linalg.triangular_solve(Lnn[None], f_cov)  # [L, N, N], L⁻¹ f_cov
-        S_v = tf.linalg.triangular_solve(Lnn[None], tf.linalg.matrix_transpose(tmp))  # [L, N, N]
-        new_q_sqrt = tf.linalg.cholesky(S_v + jitter_mat)  # [L, N, N]
-
-        model.data[0].assign(dataset.query_points)
-        model.data[1].assign(dataset.observations)
-        model.num_data = len(dataset)
-        model.q_mu.assign(Parameter(new_q_mu))
-        model.q_sqrt.assign(Parameter(new_q_sqrt, transform=gpflow.utilities.triangular()))
+        update_vgp_data(self.model, (dataset.query_points, dataset.observations))
+        self._posterior.update_cache()
 
     def optimize(self, dataset: Dataset) -> None:
         """
@@ -969,6 +909,8 @@ class VariationalGaussianProcess(
 
         else:
             self.optimizer.optimize(model, dataset)
+
+        self._posterior.update_cache()
 
     def get_inducing_variables(self) -> Tuple[TensorType, TensorType, TensorType, bool]:
         """

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -120,6 +120,13 @@ class TrainableProbabilisticModel(ProbabilisticModel, Protocol):
         """
         raise NotImplementedError
 
+    def after_load(self) -> None:
+        """
+        Call this after de-pickling the model, or loading it in another way that bypasses
+        `__init__`.
+        """
+        pass
+
 
 @runtime_checkable
 class SupportsPredictJoint(ProbabilisticModel, Protocol):


### PR DESCRIPTION
Use GPflow posterior objects to speed up acquisition.
- this still requires new versions of GPflow and GPflux, and maybe the software architecture could be nicer.