### PR TITLE
Remove superfluous super calls

### DIFF
--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -84,7 +84,6 @@ class GaussianProcess(
         kernels: Sequence[tfp.math.psd_kernels.PositiveSemidefiniteKernel],
         noise_variance: float = 1.0,
     ):
-        super().__init__()
         self._mean_functions = mean_functions
         self._kernels = kernels
         self._noise_variance = noise_variance

--- a/trieste/acquisition/function/active_learning.py
+++ b/trieste/acquisition/function/active_learning.py
@@ -44,8 +44,6 @@ class PredictiveVariance(SingleModelAcquisitionBuilder[SupportsPredictJoint]):
         :param jitter: The size of the jitter to use when stabilising the Cholesky decomposition of
             the covariance matrix.
         """
-        super().__init__()
-
         self._jitter = jitter
 
     def __repr__(self) -> str:
@@ -137,8 +135,6 @@ class ExpectedFeasibility(SingleModelAcquisitionBuilder[ProbabilisticModel]):
         tf.debugging.assert_positive(alpha, message="Parameter alpha must be positive.")
         tf.debugging.assert_scalar(delta)
         tf.debugging.Assert(delta in [1, 2], [delta])
-
-        super().__init__()
 
         self._threshold = threshold
         self._alpha = alpha

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -344,8 +344,6 @@ class ProbabilityOfFeasibility(SingleModelAcquisitionBuilder[ProbabilisticModel]
         """
         tf.debugging.assert_scalar(threshold)
 
-        super().__init__()
-
         self._threshold = threshold
 
     def __repr__(self) -> str:
@@ -603,8 +601,6 @@ class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder[HasRepara
         """
         tf.debugging.assert_positive(sample_size)
         tf.debugging.assert_greater_equal(jitter, 0.0)
-
-        super().__init__()
 
         self._sample_size = sample_size
         self._jitter = jitter

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -227,8 +227,6 @@ class BatchMonteCarloExpectedHypervolumeImprovement(
         tf.debugging.assert_positive(sample_size)
         tf.debugging.assert_greater_equal(jitter, 0.0)
 
-        super().__init__()
-
         self._sample_size = sample_size
         self._jitter = jitter
 

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -45,8 +45,6 @@ class GPflowPredictor(
         :param optimizer: The optimizer with which to train the model. Defaults to
             :class:`~trieste.models.optimizer.Optimizer` with :class:`~gpflow.optimizers.Scipy`.
         """
-        super().__init__()
-
         if optimizer is None:
             optimizer = Optimizer(gpflow.optimizers.Scipy())
 

--- a/trieste/models/gpflux/interface.py
+++ b/trieste/models/gpflux/interface.py
@@ -36,8 +36,6 @@ class GPfluxPredictor(SupportsGetObservationNoise, ABC):
         :param optimizer: The optimizer with which to train the model. Defaults to
             :class:`~trieste.models.optimizer.BatchOptimizer` with :class:`~tf.optimizers.Adam`.
         """
-        super().__init__()
-
         if optimizer is None:
             optimizer = BatchOptimizer(tf.optimizers.Adam())
 

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -361,7 +361,6 @@ class ModelStack(ProbabilisticModel, Generic[ProbabilisticModelType]):
             method signature requires at least one model. It is not treated specially.
         :param \*models_with_event_sizes: The other models, and sizes of their output events.
         """
-        super().__init__()
         self._models, self._event_sizes = zip(*(model_with_event_size,) + models_with_event_sizes)
 
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -42,9 +42,6 @@ class KerasEnsemble:
         :param networks: A list of neural network specifications, one for each member of the
             ensemble. The ensemble will be built using these specifications.
         """
-
-        super().__init__()
-
         for index, network in enumerate(networks):
             if not isinstance(network, KerasEnsembleNetwork):
                 raise ValueError(

--- a/trieste/models/keras/interface.py
+++ b/trieste/models/keras/interface.py
@@ -37,8 +37,6 @@ class KerasPredictor(ProbabilisticModel, ABC):
             :class:`~tf.optimizers.Adam` optimizer with default parameters.
         :raise ValueError: If the optimizer is not an instance of :class:`~tf.optimizers.Optimizer`.
         """
-        super().__init__()
-
         if optimizer is None:
             optimizer = KerasOptimizer(tf.optimizers.Adam())
         self._optimizer = optimizer


### PR DESCRIPTION
Remove unnecessary (and in some cases — e.g. when the parent is a protocol — incorrect) calls to `super().__init__`. In general you should only call an explicitly defined init method in a super class. 