### PR TITLE
Start fixing typing issues hidden by lack of numpy stubs

### DIFF
--- a/docs/notebooks/openai_gym_lunar_lander.pct.py
+++ b/docs/notebooks/openai_gym_lunar_lander.pct.py
@@ -243,7 +243,7 @@ plotting.plot_regret(
 # Here we choose the query point that gives the best predictive expected reward according to our model. When running the simulation with at this point, we expect to see mostly large positive rewards.
 
 # %%
-mean, _ = result.model.predict(result.dataset.query_points)
+mean = result.model.predict(result.dataset.query_points)[0]
 w_best = result.dataset.query_points[np.argmin(mean), :]
 
 for _ in range(10):

--- a/docs/notebooks/util/plotting_plotly.py
+++ b/docs/notebooks/util/plotting_plotly.py
@@ -164,9 +164,7 @@ def plot_model_predictions_plotly(
 
     n_output = Fmean.shape[1]
 
-    fig = make_subplots(
-        rows=1, cols=n_output, specs=[np.repeat({"type": "surface"}, n_output).tolist()]
-    )
+    fig = make_subplots(rows=1, cols=n_output, specs=[[{"type": "surface"}] * n_output])
 
     for k in range(n_output):
         fmean = Fmean[:, k].numpy()
@@ -216,7 +214,7 @@ def plot_function_plotly(
     fig = make_subplots(
         rows=1,
         cols=n_output,
-        specs=[np.repeat({"type": "surface"}, n_output).tolist()],
+        specs=[[{"type": "surface"}] * n_output],
         subplot_titles=title,
     )
 

--- a/tests/unit/acquisition/function/test_greedy_batch.py
+++ b/tests/unit/acquisition/function/test_greedy_batch.py
@@ -139,7 +139,7 @@ def test_locally_penalized_acquisitions_combine_base_and_penalization_correctly(
 
     best = acq_builder._eta
     lipschitz_constant = acq_builder._lipschitz_constant
-    penalizer = penalizer(model, pending_points, lipschitz_constant, best)
+    penalizer_value = penalizer(model, pending_points, lipschitz_constant, best)
 
     x_range = tf.linspace(0.0, 1.0, 11)
     x_range = tf.cast(x_range, dtype=tf.float64)
@@ -147,7 +147,7 @@ def test_locally_penalized_acquisitions_combine_base_and_penalization_correctly(
 
     lp_acq_values = lp_acq(xs[..., None, :])
     base_acq_values = base_acq(xs[..., None, :])
-    penal_values = penalizer(xs[..., None, :])
+    penal_values = penalizer_value(xs[..., None, :])
     penalized_base_acq = tf.math.exp(tf.math.log(base_acq_values) + tf.math.log(penal_values))
 
     if isinstance(base_builder, ExpectedImprovement):

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -450,7 +450,7 @@ def test_async_greedy_raises_for_incorrect_query_points() -> None:
     ],
 )
 def test_async_keeps_track_of_pending_points(
-    async_rule: AcquisitionRule[State[TensorType, AsynchronousRuleState], Box, ProbabilisticModel]
+    async_rule: AcquisitionRule[State[Optional[AsynchronousRuleState], TensorType], Box, ProbabilisticModel]
 ) -> None:
     search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -450,7 +450,9 @@ def test_async_greedy_raises_for_incorrect_query_points() -> None:
     ],
 )
 def test_async_keeps_track_of_pending_points(
-    async_rule: AcquisitionRule[State[Optional[AsynchronousRuleState], TensorType], Box, ProbabilisticModel]
+    async_rule: AcquisitionRule[
+        State[Optional[AsynchronousRuleState], TensorType], Box, ProbabilisticModel
+    ]
 ) -> None:
     search_space = Box(tf.constant([-2.2, -1.0]), tf.constant([1.3, 3.3]))
     dataset = Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -462,6 +462,7 @@ def test_async_keeps_track_of_pending_points(
     state, point2 = state_fn(state)
 
     assert state is not None
+    assert state.pending_points is not None
     assert len(state.pending_points) == 2
 
     # pretend we saw observation for the first point
@@ -477,6 +478,7 @@ def test_async_keeps_track_of_pending_points(
     state, point3 = state_fn(state)
 
     assert state is not None
+    assert state.pending_points is not None
     assert len(state.pending_points) == 2
 
     # we saw first point, so pendings points are

--- a/tests/unit/models/gpflow/test_builders.py
+++ b/tests/unit/models/gpflow/test_builders.py
@@ -44,6 +44,7 @@ from trieste.models.gpflow.builders import (
     build_vgp_classifier,
 )
 from trieste.space import Box, DiscreteSearchSpace, SearchSpace
+from trieste.types import TensorType
 
 
 @pytest.mark.parametrize("kernel_priors", [True, False])
@@ -315,7 +316,7 @@ def _check_likelihood(
     model: GPModel,
     classification: bool,
     likelihood_variance: Optional[float],
-    empirical_variance: Optional[float],
+    empirical_variance: Optional[TensorType],
     trainable_likelihood: bool,
 ) -> None:
     if classification:
@@ -334,7 +335,7 @@ def _check_likelihood(
 
 
 def _check_mean_function(
-    model: GPModel, classification: bool, empirical_mean: Optional[float]
+    model: GPModel, classification: bool, empirical_mean: Optional[TensorType]
 ) -> None:
     assert isinstance(model.mean_function, gpflow.mean_functions.Constant)
     if classification:
@@ -347,7 +348,7 @@ def _check_kernel(
     model: GPModel,
     classification: bool,
     kernel_variance: Optional[float],
-    empirical_variance: float,
+    empirical_variance: TensorType,
     kernel_priors: bool,
     noise_free: bool,
 ) -> None:

--- a/tests/unit/models/gpflow/test_builders.py
+++ b/tests/unit/models/gpflow/test_builders.py
@@ -362,7 +362,7 @@ def _check_kernel(
             else:
                 variance = CLASSIFICATION_KERNEL_VARIANCE
     else:
-        variance = empirical_variance
+        variance = float(empirical_variance)
     npt.assert_allclose(model.kernel.variance, variance, rtol=1e-6)
     if kernel_priors:
         if noise_free:

--- a/tests/unit/models/keras/test_utils.py
+++ b/tests/unit/models/keras/test_utils.py
@@ -26,7 +26,7 @@ def test_get_tensor_spec_from_data_raises_for_incorrect_dataset() -> None:
     dataset = empty_dataset([1], [1])
 
     with pytest.raises(ValueError):
-        get_tensor_spec_from_data(dataset.query_points)
+        get_tensor_spec_from_data(dataset.query_points)  # type: ignore
 
 
 @pytest.mark.parametrize(
@@ -53,7 +53,7 @@ def test_sample_with_replacement_raises_for_invalid_dataset() -> None:
     dataset = empty_dataset([1], [1])
 
     with pytest.raises(ValueError):
-        sample_with_replacement(dataset.query_points)
+        sample_with_replacement(dataset.query_points)  # type: ignore
 
 
 def test_sample_with_replacement_raises_for_empty_dataset() -> None:

--- a/tests/unit/models/keras/test_utils.py
+++ b/tests/unit/models/keras/test_utils.py
@@ -26,7 +26,7 @@ def test_get_tensor_spec_from_data_raises_for_incorrect_dataset() -> None:
     dataset = empty_dataset([1], [1])
 
     with pytest.raises(ValueError):
-        get_tensor_spec_from_data(dataset.query_points)  # type: ignore
+        get_tensor_spec_from_data(dataset.query_points)
 
 
 @pytest.mark.parametrize(
@@ -53,7 +53,7 @@ def test_sample_with_replacement_raises_for_invalid_dataset() -> None:
     dataset = empty_dataset([1], [1])
 
     with pytest.raises(ValueError):
-        sample_with_replacement(dataset.query_points)  # type: ignore
+        sample_with_replacement(dataset.query_points)
 
 
 def test_sample_with_replacement_raises_for_empty_dataset() -> None:

--- a/trieste/acquisition/function/active_learning.py
+++ b/trieste/acquisition/function/active_learning.py
@@ -83,7 +83,7 @@ class PredictiveVariance(SingleModelAcquisitionBuilder[SupportsPredictJoint]):
         return function  # no need to update anything
 
 
-def predictive_variance(model: SupportsPredictJoint, jitter: float) -> TensorType:
+def predictive_variance(model: SupportsPredictJoint, jitter: float) -> AcquisitionFunction:
     """
     The predictive variance acquisition function for active learning, based on
     the determinant of the covariance (see :cite:`MacKay1992` for details).
@@ -176,7 +176,7 @@ def bichon_ranjan_criterion(
     threshold: float,
     alpha: float,
     delta: int,
-) -> TensorType:
+) -> AcquisitionFunction:
     r"""
     Return the *bichon* criterion (:cite:`bichon2008efficient`) and *ranjan* criterion
     (:cite:`ranjan2008sequential`) used in Expected feasibility acquisition function for active

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -19,7 +19,7 @@ This module contains functionality for optimizing
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union, cast
 
 import greenlet as gr
 import numpy as np
@@ -480,7 +480,7 @@ class ScipyLbfgsBGreenlet(gr.greenlet):  # type: ignore[misc]
                 # Send `x` to parent greenlet, which will evaluate all `x`s in a batch.
                 cache_y, cache_dy_dx = self.parent.switch(cache_x)
 
-            return cache_y, cache_dy_dx
+            return cast(np.ndarray, cache_y), cast(np.ndarray, cache_dy_dx)
 
         return spo.minimize(
             lambda x: value_and_gradient(x)[0],

--- a/trieste/data.py
+++ b/trieste/data.py
@@ -91,7 +91,7 @@ class Dataset:
             tf.concat([self.observations, rhs.observations], axis=0),
         )
 
-    def __len__(self) -> TensorType:
+    def __len__(self) -> tf.Tensor:
         """
         :return: The number of query points, or equivalently the number of observations.
         """

--- a/trieste/models/gpflow/builders.py
+++ b/trieste/models/gpflow/builders.py
@@ -182,7 +182,9 @@ def build_sgpr(
     kernel = _get_kernel(empirical_variance, search_space, kernel_priors, kernel_priors)
     mean = _get_mean_function(empirical_mean)
 
-    inducing_points = _get_inducing_points(search_space, num_inducing_points)
+    inducing_points = gpflow.inducing_variables.InducingPoints(
+        _get_inducing_points(search_space, num_inducing_points)
+    )
 
     model = SGPR(data.astuple(), kernel, inducing_points, mean_function=mean)
 

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -242,12 +242,12 @@ class Box(SearchSpace):
         return f"Box({self._lower!r}, {self._upper!r})"
 
     @property
-    def lower(self) -> TensorType:
+    def lower(self) -> tf.Tensor:
         """The lower bounds of the box."""
         return self._lower
 
     @property
-    def upper(self) -> TensorType:
+    def upper(self) -> tf.Tensor:
         """The upper bounds of the box."""
         return self._upper
 


### PR DESCRIPTION
Fixing a few typing errors currently hidden by the lack of numpy stubs. We'll want to fix these before upgrade to a more recent numpy version.

The main remaining issue is our careless use of `TensorType = Union[np.ndarray, tf.Tensor]`, where we often assume that inputs and outputs are `tf.Tensors` and don't bother handling the `np.ndarray` case. One possible fix is to drop support for ndarrays by redefining `TensorType = tf.Tensor`, and then (if we need to) add it back in some of the higher level interfaces.