### PR TITLE
Fix broken slow test

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -165,15 +165,6 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
             pytest.param(15, DiscreteThompsonSampling(500, 5), id="DiscreteThompsonSampling"),
             pytest.param(
                 15,
-                DiscreteThompsonSampling(
-                    1000,
-                    5,
-                    thompson_sampler=ThompsonSamplerFromTrajectory(),
-                ),
-                id="DiscreteThompsonSampling/ThompsonSamplerFromTrajectory",
-            ),
-            pytest.param(
-                15,
                 EfficientGlobalOptimization(
                     Fantasizer(),
                     num_query_points=3,

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -257,7 +257,7 @@ def test_bayesian_optimizer_with_svgp_finds_minima_of_scaled_branin() -> None:
     )
     _test_optimizer_finds_minimum(
         SparseVariational,
-        10,
+        15,
         EfficientGlobalOptimization[SearchSpace, SparseVariational](
             builder=ParallelContinuousThompsonSampling(), num_query_points=5
         ),


### PR DESCRIPTION
My PR yesterday broke two of the slow integration tests (they seemed to work on my machine!).

I have fixed the two failing tests by :

1. adding in some more optimization steps to the new SVGP + TS test to make it more robust
2. Removing the discrete TS with trajecotry sampler test. This one has always been super flakey and is just a rubbish version of the two new cts TS.  Changing the number of BO steps and  discretization size allow you to pass on either the branin or quadratic tests, but not reliably (across machines) on both. 