### PR TITLE
Fix SearchSpace.dimension typing

### DIFF
--- a/docs/notebooks/deep_gaussian_processes.pct.py
+++ b/docs/notebooks/deep_gaussian_processes.pct.py
@@ -77,7 +77,12 @@ from trieste.models.optimizer import KerasOptimizer
 
 def build_dgp_model(data, search_space):
     dgp = build_vanilla_deep_gp(
-        data, search_space, 2, 100, likelihood_variance=1e-5, trainable_likelihood=False
+        data,
+        search_space,
+        2,
+        100,
+        likelihood_variance=1e-5,
+        trainable_likelihood=False,
     )
     return DeepGaussianProcess(dgp)
 

--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -25,6 +25,7 @@ from typing_extensions import Final
 
 from tests.util.misc import TF_DEBUGGING_ERROR_TYPES, ShapeLike, various_shapes
 from trieste.space import Box, DiscreteSearchSpace, SearchSpace, TaggedProductSearchSpace
+from trieste.types import TensorType
 
 
 class Integers(SearchSpace):
@@ -43,7 +44,7 @@ class Integers(SearchSpace):
     def sample(self, num_samples: int) -> tf.Tensor:
         return tf.random.shuffle(tf.range(self.limit))[:num_samples]
 
-    def __contains__(self, point: tf.Tensor) -> tf.Tensor:
+    def __contains__(self, point: tf.Tensor) -> bool | TensorType:
         tf.debugging.assert_integer(point)
         return 0 <= point < self.limit
 
@@ -51,7 +52,7 @@ class Integers(SearchSpace):
         return Integers(self.limit * other.limit)
 
     @property
-    def dimension(self) -> tf.Tensor:
+    def dimension(self) -> TensorType:
         pass
 
 

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -53,7 +53,7 @@ class SearchSpace(ABC):
 
     @property
     @abstractmethod
-    def dimension(self) -> int:
+    def dimension(self) -> TensorType:
         """The number of inputs in this search space."""
 
     @property
@@ -132,7 +132,7 @@ class DiscreteSearchSpace(SearchSpace):
         return self._points
 
     @property
-    def dimension(self) -> int:
+    def dimension(self) -> TensorType:
         """The number of inputs in this search space."""
         return self._dimension
 
@@ -252,7 +252,7 @@ class Box(SearchSpace):
         return self._upper
 
     @property
-    def dimension(self) -> int:
+    def dimension(self) -> TensorType:
         """The number of inputs in this search space."""
         return self._dimension
 
@@ -456,9 +456,9 @@ class TaggedProductSearchSpace(SearchSpace):
         return self._tags
 
     @property
-    def dimension(self) -> int:
+    def dimension(self) -> TensorType:
         """The number of inputs in this product search space."""
-        return int(self._dimension)
+        return self._dimension
 
     def get_subspace(self, tag: str) -> SearchSpace:
         """


### PR DESCRIPTION
As noted in https://github.com/secondmind-labs/trieste/issues/509, the typing of `SearchSpace.dimension` is currently wrong. However, the absence of typing stubs for tensorflow means mypy doesn't catch this. 