### PR TITLE
Compiled model optimizers for gpflow models

### DIFF
--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -167,7 +167,7 @@ def test_gpflow_wrappers_ref_optimize(gpflow_interface_factory: ModelFactoryType
             ),
         )
         gpflow.optimizers.Scipy().minimize(
-            reference_model.training_loss_closure(compile=False),
+            reference_model.training_loss_closure(compile=True),
             reference_model.trainable_variables,
         )
 

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -48,7 +48,7 @@ class GPflowPredictor(
             :class:`~trieste.models.optimizer.Optimizer` with :class:`~gpflow.optimizers.Scipy`.
         """
         if optimizer is None:
-            optimizer = Optimizer(gpflow.optimizers.Scipy())
+            optimizer = Optimizer(gpflow.optimizers.Scipy(), compile=True)
 
         self._optimizer = optimizer
         self._posterior: Optional[BasePosterior] = None

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -557,7 +557,7 @@ class SparseVariational(
         """
 
         if optimizer is None:
-            optimizer = BatchOptimizer(tf.optimizers.Adam(), batch_size=100)
+            optimizer = BatchOptimizer(tf.optimizers.Adam(), batch_size=100, compile=True)
 
         super().__init__(optimizer)
         self._model = model
@@ -824,9 +824,9 @@ class VariationalGaussianProcess(
         tf.debugging.assert_rank(model.q_sqrt, 3)
 
         if optimizer is None and not use_natgrads:
-            optimizer = Optimizer(gpflow.optimizers.Scipy())
+            optimizer = Optimizer(gpflow.optimizers.Scipy(), compile=True)
         elif optimizer is None and use_natgrads:
-            optimizer = BatchOptimizer(tf.optimizers.Adam(), batch_size=100)
+            optimizer = BatchOptimizer(tf.optimizers.Adam(), batch_size=100, compile=True)
 
         super().__init__(optimizer)
 


### PR DESCRIPTION
The default optimizers for our gpflow models now have `compile=True`. Not sure why we didn't do this before, as it speeds model fitting up a lot!