### PR TITLE
sgpr wrapper

### DIFF
--- a/tests/unit/models/conftest.py
+++ b/tests/unit/models/conftest.py
@@ -34,6 +34,7 @@ from trieste.data import Dataset
 from trieste.models.gpflow import (
     GaussianProcessRegression,
     GPflowPredictor,
+    SparseGaussianProcessRegression,
     SparseVariational,
     VariationalGaussianProcess,
 )
@@ -45,7 +46,7 @@ from trieste.types import TensorType
     name="gpflow_interface_factory",
     params=[
         (GaussianProcessRegression, gpr_model),
-        (GaussianProcessRegression, sgpr_model),
+        (SparseGaussianProcessRegression, sgpr_model),
         (VariationalGaussianProcess, vgp_model),
         (SparseVariational, svgp_model),
     ],

--- a/tests/unit/models/gpflow/test_config.py
+++ b/tests/unit/models/gpflow/test_config.py
@@ -24,6 +24,7 @@ from trieste.models import TrainableProbabilisticModel
 from trieste.models.config import ModelRegistry
 from trieste.models.gpflow import (
     GaussianProcessRegression,
+    SparseGaussianProcessRegression,
     SparseVariational,
     VariationalGaussianProcess,
 )
@@ -33,7 +34,7 @@ from trieste.models.gpflow import (
     "supported_models",
     [
         (GPR, GaussianProcessRegression),
-        (SGPR, GaussianProcessRegression),
+        (SGPR, SparseGaussianProcessRegression),
         (VGP, VariationalGaussianProcess),
         (SVGP, SparseVariational),
     ],

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -558,6 +558,15 @@ def test_gaussian_process_regression_pairwise_covariance(num_outputs: int) -> No
     np.testing.assert_allclose(expected_covariance, actual_covariance, atol=1e-5)
 
 
+def test_gaussian_process_regression_trajectory_sampler_raises_multi_latent_gp() -> None:
+    x = tf.constant(np.arange(1, 5).reshape(-1, 1), dtype=gpflow.default_float())  # shape: [4, 1]
+    y = fnc_3x_plus_10(x)
+    model = GaussianProcessRegression(gpr_model(x, tf.repeat(y, 2, axis=1)))
+
+    with pytest.raises(NotImplementedError):
+        model.trajectory_sampler()
+
+
 @random_seed
 @pytest.mark.parametrize("use_decoupled_sampler", [True, False])
 def test_gaussian_process_regression_trajectory_sampler_has_correct_samples(
@@ -702,9 +711,6 @@ def test_sparse_gaussian_process_regression_raises_for_invalid_init() -> None:
     x = tf.convert_to_tensor(x_np, x_np.dtype)
     y = fnc_3x_plus_10(x)
 
-    with pytest.raises(NotImplementedError):
-        SparseGaussianProcessRegression(two_output_sgpr_model(x, y))
-
     with pytest.raises(ValueError):
         SparseGaussianProcessRegression(sgpr_model(x, y), num_rff_features=-1)
 
@@ -800,6 +806,14 @@ def test_sparse_gaussian_process_regression_optimize(compile: bool) -> None:
     assert model.model.training_loss() < loss
 
 
+def test_sparse_gaussian_process_regression_trajectory_sampler_raises_multi_latent_gp() -> None:
+    data = mock_data()
+    model = SparseGaussianProcessRegression(sgpr_model(*data, num_latent_gps=2))
+
+    with pytest.raises(NotImplementedError):
+        model.trajectory_sampler()
+
+
 @random_seed
 def test_sparse_gaussian_process_regression_trajectory_sampler_has_correct_samples() -> None:
     x = tf.constant(np.arange(5).reshape(-1, 1), dtype=gpflow.default_float())
@@ -829,6 +843,14 @@ def test_sparse_gaussian_process_regression_trajectory_sampler_has_correct_sampl
     # test predictions almost correct at data
     npt.assert_allclose(sample_mean[:3] + 1.0, true_mean[:3] + 1.0, rtol=0.1)
     npt.assert_allclose(sample_variance[:3], true_variance[:3], rtol=0.3)
+
+
+def test_sparse_gaussian_process_regression_get_inducing_raises_multi_latent_gp() -> None:
+    data = mock_data()
+    model = SparseGaussianProcessRegression(sgpr_model(*data, num_latent_gps=2))
+
+    with pytest.raises(NotImplementedError):
+        model.get_inducing_variables()
 
 
 def test_sparse_gaussian_process_regression_correctly_returns_inducing_points() -> None:
@@ -1015,6 +1037,14 @@ def test_variational_gaussian_process_update_q_mu_sqrt_unchanged() -> None:
 
     npt.assert_allclose(old_q_mu, new_q_mu, atol=1e-5)
     npt.assert_allclose(old_q_sqrt, new_q_sqrt, atol=1e-5)
+
+
+def test_variational_gaussian_process_trajectory_sampler_raises_multi_latent_gp() -> None:
+    data = mock_data()
+    model = VariationalGaussianProcess(vgp_model(*data, num_latent_gps=2))
+
+    with pytest.raises(NotImplementedError):
+        model.trajectory_sampler()
 
 
 @random_seed
@@ -1371,6 +1401,14 @@ def test_sparse_variational_optimize(batcher: DatasetTransformer, compile: bool)
     loss = model.model.training_loss(data)
     model.optimize(dataset)
     assert model.model.training_loss(data) < loss
+
+
+def test_sparse_variational_gaussian_process_trajectory_sampler_raises_multi_latent_gp() -> None:
+    data = mock_data()
+    model = SparseVariational(svgp_model(*data, num_latent_gps=2))
+
+    with pytest.raises(NotImplementedError):
+        model.trajectory_sampler()
 
 
 @random_seed

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -48,7 +48,6 @@ from tests.util.models.gpflow.models import (
     mock_data,
     sgpr_model,
     svgp_model,
-    two_output_sgpr_model,
     two_output_svgp_model,
     vgp_matern_model,
     vgp_model,
@@ -822,12 +821,11 @@ def test_sparse_gaussian_process_regression_trajectory_sampler_raises_multi_late
 
 @random_seed
 def test_sparse_gaussian_process_regression_trajectory_sampler_has_correct_samples() -> None:
-    x = tf.constant(np.arange(5).reshape(-1, 1), dtype=gpflow.default_float())
-    model = SparseGaussianProcessRegression(sgpr_model(x, _3x_plus_gaussian_noise(x)))
-    model.model.likelihood.variance.assign(1e-3)
-    model.update_posterior_cache()
+    x = tf.constant(np.arange(10).reshape((-1, 1)), dtype=gpflow.default_float())
+    sgpr = SGPR((x, _3x_plus_gaussian_noise(x)), gpflow.kernels.Matern32(), x, noise_variance=1e-5)
+    model = SparseGaussianProcessRegression(sgpr)
 
-    num_samples = 300
+    num_samples = 100
     trajectory_sampler = model.trajectory_sampler()
 
     assert isinstance(trajectory_sampler, DecoupledTrajectorySampler)
@@ -847,7 +845,7 @@ def test_sparse_gaussian_process_regression_trajectory_sampler_has_correct_sampl
     npt.assert_allclose(sample_variance[3:], true_variance[3:], rtol=0.5)
 
     # test predictions almost correct at data
-    npt.assert_allclose(sample_mean[:3] + 1.0, true_mean[:3] + 1.0, rtol=0.1)
+    npt.assert_allclose(sample_mean[:3] + 1.0, true_mean[:3] + 1.0, rtol=0.01)
     npt.assert_allclose(sample_variance[:3], true_variance[:3], rtol=0.3)
 
 

--- a/tests/unit/models/gpflow/test_sampler.py
+++ b/tests/unit/models/gpflow/test_sampler.py
@@ -18,7 +18,6 @@ from typing import List, Type
 
 import gpflow
 import gpflux
-import numpy as np
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
@@ -30,7 +29,6 @@ from tests.util.models.gpflow.models import (
     QuadraticMeanAndRBFKernel,
     QuadraticMeanAndRBFKernelWithSamplers,
     rbf,
-    two_output_svgp_model,
 )
 from trieste.data import Dataset
 from trieste.models.gpflow import (
@@ -38,7 +36,6 @@ from trieste.models.gpflow import (
     DecoupledTrajectorySampler,
     IndependentReparametrizationSampler,
     RandomFourierFeatureTrajectorySampler,
-    SparseVariational,
     feature_decomposition_trajectory,
 )
 from trieste.models.interfaces import ReparametrizationSampler, SupportsPredictJoint
@@ -275,15 +272,6 @@ def test_rff_trajectory_sampler_raises_for_a_non_gpflow_kernel() -> None:
         RandomFourierFeatureTrajectorySampler(model, num_features=100)
 
 
-def test_rff_trajectory_sampler_raises_for_a_multi_latent_gp() -> None:
-    x = tf.constant(np.arange(1, 7).reshape(-1, 1), dtype=gpflow.default_float())
-    svgp = two_output_svgp_model(x, "auto", True)
-    model = SparseVariational(svgp)
-
-    with pytest.raises(NotImplementedError):
-        RandomFourierFeatureTrajectorySampler(model, num_features=100)
-
-
 @pytest.mark.parametrize("num_evals", [1, 5])
 @pytest.mark.parametrize("num_features", [5, 10])
 @pytest.mark.parametrize("batch_size", [1])
@@ -509,15 +497,6 @@ def test_decoupled_trajectory_sampler_raises_for_a_non_gpflow_kernel() -> None:
     model = QuadraticMeanAndRBFKernelWithSamplers(dataset=dataset)
 
     with pytest.raises(AssertionError):
-        DecoupledTrajectorySampler(model, num_features=100)
-
-
-def test_decoupled_trajectory_sampler_raises_for_a_multi_latent_gp() -> None:
-    x = tf.constant(np.arange(1, 7).reshape(-1, 1), dtype=gpflow.default_float())
-    svgp = two_output_svgp_model(x, "auto", True)
-    model = SparseVariational(svgp)
-
-    with pytest.raises(NotImplementedError):
         DecoupledTrajectorySampler(model, num_features=100)
 
 

--- a/tests/unit/models/gpflow/test_sampler.py
+++ b/tests/unit/models/gpflow/test_sampler.py
@@ -18,6 +18,7 @@ from typing import List, Type
 
 import gpflow
 import gpflux
+import numpy as np
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
@@ -29,6 +30,7 @@ from tests.util.models.gpflow.models import (
     QuadraticMeanAndRBFKernel,
     QuadraticMeanAndRBFKernelWithSamplers,
     rbf,
+    two_output_svgp_model,
 )
 from trieste.data import Dataset
 from trieste.models.gpflow import (
@@ -36,6 +38,7 @@ from trieste.models.gpflow import (
     DecoupledTrajectorySampler,
     IndependentReparametrizationSampler,
     RandomFourierFeatureTrajectorySampler,
+    SparseVariational,
     feature_decomposition_trajectory,
 )
 from trieste.models.interfaces import ReparametrizationSampler, SupportsPredictJoint
@@ -266,10 +269,18 @@ def test_rff_trajectory_sampler_raises_for_invalid_number_of_features(
 
 
 def test_rff_trajectory_sampler_raises_for_a_non_gpflow_kernel() -> None:
-
     dataset = Dataset(tf.constant([[-2.0]]), tf.constant([[4.1]]))
     model = QuadraticMeanAndRBFKernelWithSamplers(dataset=dataset)
     with pytest.raises(AssertionError):
+        RandomFourierFeatureTrajectorySampler(model, num_features=100)
+
+
+def test_rff_trajectory_sampler_raises_for_a_multi_latent_gp() -> None:
+    x = tf.constant(np.arange(1, 7).reshape(-1, 1), dtype=gpflow.default_float())
+    svgp = two_output_svgp_model(x, "auto", True)
+    model = SparseVariational(svgp)
+
+    with pytest.raises(NotImplementedError):
         RandomFourierFeatureTrajectorySampler(model, num_features=100)
 
 
@@ -494,10 +505,19 @@ def test_decoupled_trajectory_sampler_raises_for_invalid_number_of_features(
 
 
 def test_decoupled_trajectory_sampler_raises_for_a_non_gpflow_kernel() -> None:
-
     dataset = Dataset(tf.constant([[-2.0]]), tf.constant([[4.1]]))
     model = QuadraticMeanAndRBFKernelWithSamplers(dataset=dataset)
+
     with pytest.raises(AssertionError):
+        DecoupledTrajectorySampler(model, num_features=100)
+
+
+def test_decoupled_trajectory_sampler_raises_for_a_multi_latent_gp() -> None:
+    x = tf.constant(np.arange(1, 7).reshape(-1, 1), dtype=gpflow.default_float())
+    svgp = two_output_svgp_model(x, "auto", True)
+    model = SparseVariational(svgp)
+
+    with pytest.raises(NotImplementedError):
         DecoupledTrajectorySampler(model, num_features=100)
 
 

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -68,11 +68,11 @@ class GaussianMarginal(ProbabilisticModel):
     """A probabilistic model with Gaussian marginal distribution. Assumes events of shape [N]."""
 
     @property
-    def model(self):
+    def model(self) -> ProbabilisticModel:
         return self
 
     @property
-    def num_latent_gps(self):
+    def num_latent_gps(self) -> int:
         return 1
 
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:

--- a/trieste/models/gpflow/__init__.py
+++ b/trieste/models/gpflow/__init__.py
@@ -26,7 +26,12 @@ from .inducing_point_selectors import (
     UniformInducingPointSelector,
 )
 from .interface import GPflowPredictor
-from .models import GaussianProcessRegression, SparseVariational, VariationalGaussianProcess
+from .models import (
+    GaussianProcessRegression,
+    SparseGaussianProcessRegression,
+    SparseVariational,
+    VariationalGaussianProcess,
+)
 from .sampler import (
     BatchReparametrizationSampler,
     DecoupledTrajectorySampler,

--- a/trieste/models/gpflow/config.py
+++ b/trieste/models/gpflow/config.py
@@ -20,7 +20,12 @@ from gpflow.models import GPR, SGPR, SVGP, VGP
 
 from ..config import ModelRegistry
 from ..interfaces import TrainableProbabilisticModel
-from .models import GaussianProcessRegression, SparseGaussianProcessRegression, SparseVariational, VariationalGaussianProcess
+from .models import (
+    GaussianProcessRegression,
+    SparseGaussianProcessRegression,
+    SparseVariational,
+    VariationalGaussianProcess,
+)
 
 # Here we list all the GPflow models currently supported by model interfaces
 # and optimizers, and register them for usage with ModelConfig.

--- a/trieste/models/gpflow/config.py
+++ b/trieste/models/gpflow/config.py
@@ -20,13 +20,13 @@ from gpflow.models import GPR, SGPR, SVGP, VGP
 
 from ..config import ModelRegistry
 from ..interfaces import TrainableProbabilisticModel
-from .models import GaussianProcessRegression, SparseVariational, VariationalGaussianProcess
+from .models import GaussianProcessRegression, SparseGaussianProcessRegression, SparseVariational, VariationalGaussianProcess
 
 # Here we list all the GPflow models currently supported by model interfaces
 # and optimizers, and register them for usage with ModelConfig.
 _SUPPORTED_MODELS: Dict[Type[Any], Type[TrainableProbabilisticModel]] = {
     GPR: GaussianProcessRegression,
-    SGPR: GaussianProcessRegression,
+    SGPR: SparseGaussianProcessRegression,
     VGP: VariationalGaussianProcess,
     SVGP: SparseVariational,
 }

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -312,8 +312,20 @@ class GaussianProcessRegression(
         Return a trajectory sampler. For :class:`GaussianProcessRegression`, we build
         trajectories using a random Fourier feature approximation.
 
+        At the moment only models with single latent GP are supported.
+
         :return: The trajectory sampler.
+        :raise NotImplementedError: If we try to use the
+            sampler with a model that has more than one latent GP.
         """
+        if self.model.num_latent_gps > 1:
+            raise NotImplementedError(
+                f"""
+                Trajectory sampler does not currently support models with multiple latent
+                GPs, however received a model with {self.model.num_latent_gps} latent GPs.
+                """
+            )
+
         if self._use_decoupled_sampler:
             return DecoupledTrajectorySampler(self, self._num_rff_features)
         else:
@@ -542,8 +554,8 @@ class SparseGaussianProcessRegression(
         :param inducing_point_selector: The (optional) desired inducing point selector that
             will update the underlying GPflow SGPR model's inducing points as
             the optimization progresses.
-        :raise NotImplementedError (or ValueError): If we try to use a model with more than one
-            latent GP, invalid ``num_rff_features``, or an ``inducing_point_selector`` with a model
+        :raise NotImplementedError (or ValueError): If we try to use a model with invalid
+            ``num_rff_features``, or an ``inducing_point_selector`` with a model
             that has more than one set of inducing points.
         """
         super().__init__(optimizer)
@@ -567,14 +579,6 @@ class SparseGaussianProcessRegression(
                     """
                 )
         self._inducing_point_selector = inducing_point_selector
-
-        if self.model.num_latent_gps > 1:
-            raise NotImplementedError(
-                f"""
-                We do not currently support models with more than one latent GP,
-                however received a model with {self.model.num_latent_gps} outputs.
-                """
-            )
 
         self._ensure_variable_model_data()
         self.create_posterior_cache()
@@ -733,7 +737,16 @@ class SparseGaussianProcessRegression(
             variational mean ``q_mu``; a tensor containing the Cholesky decomposition of the
             variational covariance ``q_sqrt``; and a bool denoting if we are using whitened or
             non-whitened representations.
+        :raise NotImplementedError: If the model has more than one latent GP.
         """
+        if self.model.num_latent_gps > 1:
+            raise NotImplementedError(
+                f"""
+                We do not currently support models with more than one latent GP,
+                however received a model with {self.model.num_latent_gps} outputs.
+                """
+            )
+
         inducing_variable = self.model.inducing_variable
 
         if isinstance(inducing_variable, SharedIndependentInducingVariables):
@@ -785,8 +798,20 @@ class SparseGaussianProcessRegression(
         trajectories using a decoupled random Fourier feature approximation. Note that this
         is available only for single output models.
 
+        At the moment only models with single latent GP are supported.
+
         :return: The trajectory sampler.
+        :raise NotImplementedError: If we try to use the
+            sampler with a model that has more than one latent GP.
         """
+        if self.model.num_latent_gps > 1:
+            raise NotImplementedError(
+                f"""
+                Trajectory sampler does not currently support models with multiple latent
+                GPs, however received a model with {self.model.num_latent_gps} latent GPs.
+                """
+            )
+
         return DecoupledTrajectorySampler(self, self._num_rff_features)
 
     def get_internal_data(self) -> Dataset:
@@ -1052,8 +1077,19 @@ class SparseVariational(
         Return a trajectory sampler. For :class:`SparseVariational`, we build
         trajectories using a decoupled random Fourier feature approximation.
 
+        At the moment only models with single latent GP are supported.
+
         :return: The trajectory sampler.
+        :raise NotImplementedError: If we try to use the
+            sampler with a model that has more than one latent GP.
         """
+        if self.model.num_latent_gps > 1:
+            raise NotImplementedError(
+                f"""
+                Trajectory sampler does not currently support models with multiple latent
+                GPs, however received a model with {self.model.num_latent_gps} latent GPs.
+                """
+            )
 
         return DecoupledTrajectorySampler(self, self._num_rff_features)
 
@@ -1283,8 +1319,19 @@ class VariationalGaussianProcess(
         Return a trajectory sampler. For :class:`VariationalGaussianProcess`, we build
         trajectories using a decoupled random Fourier feature approximation.
 
+        At the moment only models with single latent GP are supported.
+
         :return: The trajectory sampler.
+        :raise NotImplementedError: If we try to use the
+            sampler with a model that has more than one latent GP.
         """
+        if self.model.num_latent_gps > 1:
+            raise NotImplementedError(
+                f"""
+                Trajectory sampler does not currently support models with multiple latent
+                GPs, however received a model with {self.model.num_latent_gps} latent GPs.
+                """
+            )
 
         return DecoupledTrajectorySampler(self, self._num_rff_features)
 

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -675,7 +675,6 @@ class SparseGaussianProcessRegression(
 
         num_data = dataset.query_points.shape[0]
         self.model.num_data.assign(num_data)
-        self.update_posterior_cache()
 
         if self._inducing_point_selector is not None:
             new_inducing_points = self._inducing_point_selector.calculate_inducing_points(
@@ -688,6 +687,8 @@ class SparseGaussianProcessRegression(
                 )
             ):  # only bother updating if points actually change
                 self._update_inducing_variables(new_inducing_points)
+
+        self.update_posterior_cache()
 
     def _update_inducing_variables(self, new_inducing_points: TensorType) -> None:
         """

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -72,13 +72,12 @@ class GaussianProcessRegression(
     HasTrajectorySampler,
 ):
     """
-    A :class:`TrainableProbabilisticModel` wrapper for a GPflow :class:`~gpflow.models.GPR`
-    or :class:`~gpflow.models.SGPR`.
+    A :class:`TrainableProbabilisticModel` wrapper for a GPflow :class:`~gpflow.models.GPR`.
     """
 
     def __init__(
         self,
-        model: GPR | SGPR,
+        model: SGPR,
         optimizer: Optimizer | None = None,
         num_kernel_samples: int = 10,
         num_rff_features: int = 1000,
@@ -123,7 +122,7 @@ class GaussianProcessRegression(
         return f"GaussianProcessRegression({self.model!r}, {self.optimizer!r})"
 
     @property
-    def model(self) -> GPR | SGPR:
+    def model(self) -> GPR:
         return self._model
 
     def _ensure_variable_model_data(self) -> None:
@@ -179,9 +178,6 @@ class GaussianProcessRegression(
         :return: Covariance matrix between the sets of query points with shape [..., L, N, M]
             (L being the number of latent GPs = number of output dimensions)
         """
-        if isinstance(self.model, SGPR):
-            raise NotImplementedError("Covariance between points is not supported for SGPR.")
-
         tf.debugging.assert_shapes(
             [(query_points_1, [..., "N", "D"]), (query_points_2, ["M", "D"])]
         )
@@ -335,7 +331,6 @@ class GaussianProcessRegression(
         :return: mean_qp_new: predictive mean at query_points, with shape [..., M, L],
                  and var_qp_new: predictive variance at query_points, with shape [..., M, L]
         """
-
         tf.debugging.assert_shapes(
             [
                 (additional_data.query_points, [..., "N", "D"]),
@@ -346,9 +341,6 @@ class GaussianProcessRegression(
             " and observations with shape [..., N, L], and query_points "
             "should have shape [M, D]",
         )
-
-        if isinstance(self.model, SGPR):
-            raise NotImplementedError("Conditional predict f is not supported for SGPR.")
 
         mean_add, cov_add = self.model.predict_f(
             additional_data.query_points, full_cov=True
@@ -405,7 +397,6 @@ class GaussianProcessRegression(
                  and cov_qp_new: predictive covariance between query_points, with shape
                  [..., L, M, M]
         """
-
         tf.debugging.assert_shapes(
             [
                 (additional_data.query_points, [..., "N", "D"]),
@@ -416,9 +407,6 @@ class GaussianProcessRegression(
             " and observations with shape [..., N, L], and query_points "
             "should have shape [M, D]",
         )
-
-        if isinstance(self.model, SGPR):
-            raise NotImplementedError("Conditional predict f is not supported for SGPR.")
 
         leading_dims = tf.shape(additional_data.query_points)[:-2]  # [...]
         new_shape = tf.concat([leading_dims, tf.shape(query_points)], axis=0)  # [..., M, D]
@@ -478,9 +466,6 @@ class GaussianProcessRegression(
         :return: samples of f at query points, with shape [..., num_samples, M, L]
         """
 
-        if isinstance(self.model, SGPR):
-            raise NotImplementedError("Conditional predict y is not supported for SGPR.")
-
         mean_new, cov_new = self.conditional_predict_joint(query_points, additional_data)
         mean_for_sample = tf.linalg.adjoint(mean_new)  # [..., L, N]
         samples = sample_mvn(
@@ -501,11 +486,273 @@ class GaussianProcessRegression(
         :return: predictive variance at query_points, with shape [..., M, L],
                  and predictive variance at query_points, with shape [..., M, L]
         """
-
-        if isinstance(self.model, SGPR):
-            raise NotImplementedError("Conditional predict y is not supported for SGPR.")
         f_mean, f_var = self.conditional_predict_f(query_points, additional_data)
         return self.model.likelihood.predict_mean_and_var(f_mean, f_var)
+
+
+class SparseGaussianProcessRegression(
+    GPflowPredictor,
+    TrainableProbabilisticModel,
+    SupportsCovarianceBetweenPoints,
+    SupportsGetInducingVariables,
+    SupportsGetInternalData,
+    HasTrajectorySampler,
+):
+    """
+    A :class:`TrainableProbabilisticModel` wrapper for a GPflow :class:`~gpflow.models.SGPR`.
+    """
+
+    def __init__(
+        self,
+        model: SGPR,
+        optimizer: Optimizer | None = None,
+        num_rff_features: int = 1000,
+        inducing_point_selector: Optional[InducingPointSelector[SparseVariational]] = None,
+    ):
+        """
+        :param model: The GPflow model to wrap.
+        :param optimizer: The optimizer with which to train the model. Defaults to
+            :class:`~trieste.models.optimizer.Optimizer` with :class:`~gpflow.optimizers.Scipy`.
+        :param num_rff_features: The number of random Fourier features used to approximate the
+            kernel when calling :meth:`trajectory_sampler`. We use a default of 1000 as it
+            typically perfoms well for a wide range of kernels. Note that very smooth
+            kernels (e.g. RBF) can be well-approximated with fewer features.
+        :param inducing_point_selector: The (optional) desired inducing_point_selector that
+            will update the underlying GPflow sparse variational model's inducing points as
+            the optimization progresses.
+        :raise NotImplementedError: If we try to use an inducing_point_selector with a model
+            that has more than one set of inducing points.
+        """
+        super().__init__(optimizer)
+        self._model = model
+
+        check_optimizer(self.optimizer)
+
+        if num_rff_features <= 0:
+            raise ValueError(
+                f"num_rff_features must be greater or equal to zero but got {num_rff_features}."
+            )
+        self._num_rff_features = num_rff_features
+
+        if isinstance(self.model.inducing_variable, SeparateIndependentInducingVariables):
+            if inducing_point_selector is not None:
+                raise NotImplementedError(
+                    f"""
+                    InducingPointSelectors only currently support models with a single set
+                    of inducing points however received inducing points of
+                    type {type(self.model.inducing_variable)}.
+                    """
+                )
+        self._inducing_point_selector = inducing_point_selector
+
+        self._ensure_variable_model_data()
+        
+    def __repr__(self) -> str:
+        """"""
+        return (
+            f"SparseGaussianProcessRegression({self.model!r}, {self.optimizer!r},"
+            f"{self._num_rff_features!r}, {self._inducing_point_selector!r})"
+        )
+
+    @property
+    def model(self) -> SGPR:
+        return self._model
+
+    @property
+    def inducing_point_selector(
+        self
+    ) -> Optional[InducingPointSelector[SparseGaussianProcessRegression]]:
+        return self._inducing_point_selector
+
+    def _ensure_variable_model_data(self) -> None:
+        # GPflow stores the data in Tensors. However, since we want to be able to update the data
+        # without having to retrace the acquisition functions, put it in Variables instead.
+        # Data has to be stored in variables with dynamic shape to allow for changes
+        # Sometimes, for instance after serialization-deserialization, the shape can be overridden
+        # Thus here we ensure data is stored in dynamic shape Variables
+        if not all(isinstance(x, tf.Variable) and x.shape[0] is None for x in self._model.data):
+            self._model.data = (
+                tf.Variable(
+                    self._model.data[0], trainable=False, shape=[None, *self._model.data[0].shape[1:]]
+                ),
+                tf.Variable(
+                    self._model.data[1], trainable=False, shape=[None, *self._model.data[1].shape[1:]]
+                ),
+            )
+
+        if not isinstance(self._model.num_data, tf.Variable):
+            self._model.num_data = tf.Variable(self._model.num_data, trainable=False)
+
+        if not hasattr(self.model, "q_mu") and not hasattr(self.model, "q_sqrt"):
+            q_mu, q_var = self.model.compute_qu()
+            q_sqrt = tf.linalg.cholesky(q_var)
+            self._model.q_mu = tf.Variable(self._model.q_mu, trainable=False)
+            self._model.q_sqrt = tf.Variable(self._model.q_sqrt, trainable=False)
+
+    def update(self, dataset: Dataset) -> None:
+        self._ensure_variable_model_data()
+
+        x, y = self.model.data[0].value(), self.model.data[1].value()
+
+        assert_data_is_compatible(dataset, Dataset(x, y))
+
+        if dataset.query_points.shape[-1] != x.shape[-1]:
+            raise ValueError
+
+        if dataset.observations.shape[-1] != y.shape[-1]:
+            raise ValueError
+
+        self.model.data[0].assign(dataset.query_points)
+        self.model.data[1].assign(dataset.observations)
+    
+        current_inducing_points, q_mu, _, _ = self.get_inducing_variables()
+
+        if isinstance(current_inducing_points, list):
+            inducing_points_trailing_dim = current_inducing_points[0].shape[-1]
+        else:
+            inducing_points_trailing_dim = current_inducing_points.shape[-1]
+
+        if dataset.query_points.shape[-1] != inducing_points_trailing_dim:
+            raise ValueError(
+                f"Shape {dataset.query_points.shape} of new query points is incompatible with"
+                f" shape {self.model.inducing_variable.Z.shape} of existing query points."
+                f" Trailing dimensions must match."
+            )
+
+        if dataset.observations.shape[-1] != q_mu.shape[-1]:
+            raise ValueError(
+                f"Shape {dataset.observations.shape} of new observations is incompatible with"
+                f" shape {self.model.q_mu.shape} of existing observations. Trailing"
+                f" dimensions must match."
+            )
+
+        num_data = dataset.query_points.shape[0]
+        self.model.num_data.assign(num_data)
+
+        if self._inducing_point_selector is not None:
+            new_inducing_points = self._inducing_point_selector.calculate_inducing_points(
+                current_inducing_points, self, dataset
+            )
+            if not tf.reduce_all(
+                tf.math.equal(
+                    new_inducing_points,
+                    current_inducing_points,
+                )
+            ):  # only bother updating if points actually change
+                self._update_inducing_variables(new_inducing_points)
+
+    def _update_inducing_variables(self, new_inducing_points: TensorType) -> None:
+        """
+        When updating the inducing points of a model, we must also update the other
+        inducing variables, i.e. `q_mu` and `q_sqrt` accordingly. The exact form of this update
+        depends if we are using whitened representations of the inducing variables.
+        See :meth:`_whiten_points` for details.
+
+        :param new_inducing_points: The desired values for the new inducing points.
+        :raise NotImplementedError: If we try to update the inducing variables of a model
+            that has more than one set of inducing points.
+        """
+
+        if isinstance(new_inducing_points, list):
+            raise NotImplementedError(
+                f"""
+                We do not currently support updating models with multiple sets of
+                inducing points however received; {new_inducing_points}
+                """
+            )
+
+        old_inducing_points, _, _, _ = self.get_inducing_variables()
+        tf.assert_equal(
+            tf.shape(old_inducing_points), tf.shape(new_inducing_points)
+        )  # number of inducing points must not change
+
+        new_q_mu, new_f_cov = self.predict_joint(new_inducing_points)  # [N, L], [L, N, N]
+        jitter_mat = DEFAULTS.JITTER * tf.eye(
+            tf.shape(new_inducing_points)[0], dtype=new_f_cov.dtype
+        )
+        new_q_sqrt = tf.linalg.cholesky(new_f_cov + jitter_mat)
+
+        self.model.q_mu.assign(new_q_mu)  # [N, L]
+        self.model.q_sqrt.assign(new_q_sqrt)  # [L, N, N]
+
+        if isinstance(self.model.inducing_variable, SharedIndependentInducingVariables):
+            # gpflow says inducing_variable might be a ndarray; it won't
+            cast(TensorType, self.model.inducing_variable.inducing_variable).Z.assign(
+                new_inducing_points
+            )  # [M, D]
+        else:
+            self.model.inducing_variable.Z.assign(new_inducing_points)  # [M, D]
+
+    def get_inducing_variables(
+        self,
+    ) -> Tuple[Union[TensorType, list[TensorType]], TensorType, TensorType, bool]:
+        """
+        Return the model's inducing variables.
+
+        :return: The inducing points (i.e. locations of the inducing variables), as a Tensor or a
+            list of Tensors (when the model has multiple inducing points); A tensor containing the
+            variational mean q_mu; a tensor containing the Cholesky decomposition of the variational
+            covariance q_sqrt; and a bool denoting if we are using whitened or
+            non-whitened representations.
+        """
+        inducing_variable = self.model.inducing_variable
+
+        if isinstance(inducing_variable, SharedIndependentInducingVariables):
+            # gpflow says inducing_variable might be a ndarray; it won't
+            inducing_points = cast(TensorType, inducing_variable.inducing_variable).Z  # [M, D]
+        elif isinstance(inducing_variable, SeparateIndependentInducingVariables):
+            inducing_points = [
+                cast(TensorType, inducing_variable).Z
+                for inducing_variable in inducing_variable.inducing_variables
+            ]  # list of L [M, D] tensors
+        else:
+            inducing_points = inducing_variable.Z  # [M, D]
+
+        return inducing_points, self.model.q_mu, self.model.q_sqrt, False
+
+    def covariance_between_points(
+        self, query_points_1: TensorType, query_points_2: TensorType
+    ) -> TensorType:
+        r"""
+        Compute the posterior covariance between sets of query points.
+
+        Note that query_points_2 must be a rank 2 tensor, but query_points_1 can
+        have leading dimensions.
+
+        :param query_points_1: Set of query points with shape [..., A, D]
+        :param query_points_2: Sets of query points with shape [B, D]
+        :return: Covariance matrix between the sets of query points with shape [..., L, A, B]
+            (L being the number of latent GPs = number of output dimensions)
+        """
+        inducing_points, _, q_sqrt, whiten = self.get_inducing_variables()
+
+        return _covariance_between_points_for_variational_models(
+            kernel=self.get_kernel(),
+            inducing_points=inducing_points,
+            q_sqrt=q_sqrt,
+            query_points_1=query_points_1,
+            query_points_2=query_points_2,
+            whiten=whiten,
+        )
+
+    def trajectory_sampler(self) -> TrajectorySampler[SparseGaussianProcessRegression]:
+        """
+        Return a trajectory sampler. For :class:`SparseGaussianProcessRegression`, we build
+        trajectories using a decoupled random Fourier feature approximation.
+
+        :return: The trajectory sampler.
+        """
+
+        return DecoupledTrajectorySampler(self, self._num_rff_features)
+
+    def get_internal_data(self) -> Dataset:
+        """
+        Return the model's training data.
+
+        :return: The model's training data.
+        """
+        return Dataset(self.model.data[0], self.model.data[1])
+
 
 
 class NumDataPropertyMixin:
@@ -670,7 +917,10 @@ class SparseVariational(
 
     def __repr__(self) -> str:
         """"""
-        return f"SparseVariational({self.model!r}, {self.optimizer!r})"
+        return (
+            f"SparseVariational({self.model!r}, {self.optimizer!r},"
+            f"{self._num_rff_features!r}, {self._inducing_point_selector!r})"
+        )
 
     @property
     def model(self) -> SVGP:
@@ -966,9 +1216,15 @@ class VariationalGaussianProcess(
                 pretransformed_shape=[*self._model.q_sqrt.unconstrained_variable.shape[:-1], None],
             )
 
+        if not isinstance(self._model.num_data, tf.Variable):
+            self._model.num_data = tf.Variable(self._model.num_data, trainable=False, dtype=tf.int64)
+
     def __repr__(self) -> str:
         """"""
-        return f"VariationalGaussianProcess({self.model!r}, {self.optimizer!r})"
+        return (
+            f"VariationalGaussianProcess({self.model!r}, {self.optimizer!r})"
+            f"{self._use_natgrads!r}, {self._natgrad_gamma!r}, {self._num_rff_features!r})"
+        )
 
     @property
     def model(self) -> VGP:
@@ -994,9 +1250,10 @@ class VariationalGaussianProcess(
         model.q_mu.assign(new_q_mu)
         model.q_sqrt.assign(new_q_sqrt)
 
+        num_data = tf.cast(dataset.query_points.shape[0], tf.int64)
         model.data[0].assign(dataset.query_points)  # do not update data until called _whiten_points
         model.data[1].assign(dataset.observations)
-        model.num_data.assign(len(dataset))
+        model.num_data.assign(num_data)
 
     def optimize(self, dataset: Dataset) -> None:
         """

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -520,8 +520,8 @@ class DecoupledTrajectorySampler(
         ):
             raise NotImplementedError(
                 f"RandomFourierFeatureTrajectorySampler only works with models that either support "
-                f"get_kernel, get_observation_noise and get_internal_data or support get_kernel, "
-                f"get_observation_noise and get_internal_data; but received {model.__repr__()}."
+                f"get_kernel, get_observation_noise and get_internal_data or support get_kernel "
+                f"and get_inducing_variables; but received {model.__repr__()}."
             )
 
         tf.debugging.assert_positive(num_features)

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -330,7 +330,8 @@ class RandomFourierFeatureTrajectorySampler(
     This class builds functions that approximate a trajectory sampled from an underlying Gaussian
     process model. For tractibility, the Gaussian process is approximated with a Bayesian
     Linear model across a set of features sampled from the Fourier feature decomposition of
-    the model's kernel. See :cite:`hernandez2014predictive` for details.
+    the model's kernel. See :cite:`hernandez2014predictive` for details. Currently we do not
+    support models with multiple latent Gaussian processes.
 
     In particular, we approximate the Gaussian processes' posterior samples as the finite feature
     approximation
@@ -478,7 +479,8 @@ class DecoupledTrajectorySampler(
 
     This class builds functions that approximate a trajectory sampled from an underlying Gaussian
     process model using decoupled sampling. See :cite:`wilson2020efficiently` for an introduction
-    to decoupled sampling.
+    to decoupled sampling. Currently we do not support models with multiple latent Gaussian
+    processes.
 
     Unlike our :class:`RandomFourierFeatureTrajectorySampler` which uses a RFF decomposition to
     aprroximate the Gaussian process posterior, a :class:`DecoupledTrajectorySampler` only
@@ -501,8 +503,6 @@ class DecoupledTrajectorySampler(
     :class:`FeatureDecompositionInternalDataModel` type,
     :class:`FeatureDecompositionInducingPointModel` will take a priority and inducing points
     will be used for computations rather than data.
-
-    At the moment only models with single latent GP are supported.
     """
 
     def __init__(
@@ -519,17 +519,8 @@ class DecoupledTrajectorySampler(
         :param num_features: The number of features used to approximate the kernel. We use a default
             of 1000 as it typically perfoms well for a wide range of kernels. Note that very smooth
             kernels (e.g. RBF) can be well-approximated with fewer features.
-        :raise NotImplementedError: If the model is not of valid type, or we try to use the
-            sampler with a model that has more than one latent GP.
+        :raise NotImplementedError: If the model is not of valid type.
         """
-        if model.model.num_latent_gps > 1:
-            raise NotImplementedError(
-                f"""
-                DecoupledTrajectorySampler does not currently support models with multiple latent
-                GPs, however received a model with {model.model.num_latent_gps} latent GPs.
-                """
-            )
-
         if not isinstance(
             model, (FeatureDecompositionInducingPointModel, FeatureDecompositionInternalDataModel)
         ):
@@ -627,8 +618,6 @@ class ResampleableRandomFourierFeatureFunctions(RFF):  # type: ignore[misc]
     :class:`FeatureDecompositionInternalDataModel` type,
     :class:`FeatureDecompositionInducingPointModel` will take a priority and inducing points
     will be used for computations rather than data.
-
-    At the moment only models with single latent GP are supported.
     """
 
     def __init__(
@@ -642,17 +631,8 @@ class ResampleableRandomFourierFeatureFunctions(RFF):  # type: ignore[misc]
         """
         :param model: The model that will be approximed by these feature functions.
         :param n_components: The desired number of features.
-        :raise NotImplementedError: If the model is not of valid type, or we try to use the
-            sampler with a model that has more than one latent GP.
+        :raise NotImplementedError: If the model is not of valid type.
         """
-        if model.model.num_latent_gps > 1:
-            raise NotImplementedError(
-                f"""
-                DecoupledTrajectorySampler does not currently support models with multiple latent
-                GPs, however received a model with {model.model.num_latent_gps} latent GPs.
-                """
-            )
-
         if not isinstance(
             model,
             (
@@ -704,8 +684,6 @@ class ResampleableDecoupledFeatureFunctions(ResampleableRandomFourierFeatureFunc
     :class:`FeatureDecompositionInternalDataModel` type,
     :class:`FeatureDecompositionInducingPointModel` will take a priority and inducing points
     will be used for computations rather than data.
-
-    At the moment only models with single latent GP are supported.
     """
 
     def __init__(

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -496,6 +496,13 @@ class DecoupledTrajectorySampler(
 
     The expression for :math:`v_i` depends on if we are using an exact Gaussian process or a sparse
     approximations. See  eq. (13) in :cite:`wilson2020efficiently` for details.
+
+    Note that if a model is both of :class:`FeatureDecompositionInducingPointModel` type and
+    :class:`FeatureDecompositionInternalDataModel` type,
+    :class:`FeatureDecompositionInducingPointModel` will take a priority and inducing points
+    will be used for computations rather than data.
+
+    At the moment only models with single latent GP are supported.
     """
 
     def __init__(
@@ -512,14 +519,22 @@ class DecoupledTrajectorySampler(
         :param num_features: The number of features used to approximate the kernel. We use a default
             of 1000 as it typically perfoms well for a wide range of kernels. Note that very smooth
             kernels (e.g. RBF) can be well-approximated with fewer features.
-        :raise ValueError: If ``dataset`` is empty.
+        :raise NotImplementedError: If the model is not of valid type, or we try to use the
+            sampler with a model that has more than one latent GP.
         """
+        if model.model.num_latent_gps > 1:
+            raise NotImplementedError(
+                f"""
+                DecoupledTrajectorySampler does not currently support models with multiple latent
+                GPs, however received a model with {model.model.num_latent_gps} latent GPs.
+                """
+            )
 
         if not isinstance(
             model, (FeatureDecompositionInducingPointModel, FeatureDecompositionInternalDataModel)
         ):
             raise NotImplementedError(
-                f"RandomFourierFeatureTrajectorySampler only works with models that either support "
+                f"DecoupledTrajectorySampler only works with models that either support "
                 f"get_kernel, get_observation_noise and get_internal_data or support get_kernel "
                 f"and get_inducing_variables; but received {model.__repr__()}."
             )
@@ -528,6 +543,7 @@ class DecoupledTrajectorySampler(
         self._num_features = num_features
         self._model = model
         feature_functions = ResampleableDecoupledFeatureFunctions(self._model, self._num_features)
+
         super().__init__(self._model, feature_functions)
 
     def _prepare_weight_sampler(self) -> Callable[[int], TensorType]:
@@ -606,6 +622,13 @@ class ResampleableRandomFourierFeatureFunctions(RFF):  # type: ignore[misc]
 
     In particular, we store the bias and weights as variables, which can then be
     updated without triggering expensive graph retracing.
+
+    Note that if a model is both of :class:`FeatureDecompositionInducingPointModel` type and
+    :class:`FeatureDecompositionInternalDataModel` type,
+    :class:`FeatureDecompositionInducingPointModel` will take a priority and inducing points
+    will be used for computations rather than data.
+
+    At the moment only models with single latent GP are supported.
     """
 
     def __init__(
@@ -619,7 +642,16 @@ class ResampleableRandomFourierFeatureFunctions(RFF):  # type: ignore[misc]
         """
         :param model: The model that will be approximed by these feature functions.
         :param n_components: The desired number of features.
+        :raise NotImplementedError: If the model is not of valid type, or we try to use the
+            sampler with a model that has more than one latent GP.
         """
+        if model.model.num_latent_gps > 1:
+            raise NotImplementedError(
+                f"""
+                DecoupledTrajectorySampler does not currently support models with multiple latent
+                GPs, however received a model with {model.model.num_latent_gps} latent GPs.
+                """
+            )
 
         if not isinstance(
             model,
@@ -631,7 +663,7 @@ class ResampleableRandomFourierFeatureFunctions(RFF):  # type: ignore[misc]
             raise NotImplementedError(
                 f"ResampleableRandomFourierFeatureFunctions only work with models that either"
                 f"support get_kernel, get_observation_noise and get_internal_data or support "
-                f"get_kernel, get_observation_noise and get_internal_data;"
+                f"get_kernel and get_inducing_variables;"
                 f"but received {model.__repr__()}."
             )
 
@@ -639,10 +671,11 @@ class ResampleableRandomFourierFeatureFunctions(RFF):  # type: ignore[misc]
         self._n_components = n_components
         super().__init__(self._kernel, self._n_components, dtype=tf.float64)
 
-        if isinstance(model, SupportsGetInternalData):
-            dummy_X = model.get_internal_data().query_points[0:1, :]
-        else:
+        if isinstance(model, SupportsGetInducingVariables):
             dummy_X = model.get_inducing_variables()[0][0:1, :]
+        else:
+            dummy_X = model.get_internal_data().query_points[0:1, :]
+
         self.__call__(dummy_X)  # dummy call to force init of weights
         self.b: TensorType = tf.Variable(self.b)
         self.W: TensorType = tf.Variable(self.W)  # allow updateable weights
@@ -666,6 +699,13 @@ class ResampleableDecoupledFeatureFunctions(ResampleableRandomFourierFeatureFunc
     A wrapper around our :class:`ResampleableRandomFourierFeatureFunctions` which rather
     than evaluates just `L` RFF functions instead evaluates the concatenation of
     `L` RFF functions with evaluations of the cannonical basis functions.
+
+    Note that if a model is both of :class:`FeatureDecompositionInducingPointModel` type and
+    :class:`FeatureDecompositionInternalDataModel` type,
+    :class:`FeatureDecompositionInducingPointModel` will take a priority and inducing points
+    will be used for computations rather than data.
+
+    At the moment only models with single latent GP are supported.
     """
 
     def __init__(
@@ -681,10 +721,10 @@ class ResampleableDecoupledFeatureFunctions(ResampleableRandomFourierFeatureFunc
         :param n_components: The desired number of features.
         """
 
-        if isinstance(model, SupportsGetInternalData):
-            inducing_points = model.get_internal_data().query_points  # [M, D]
-        else:
+        if isinstance(model, SupportsGetInducingVariables):
             inducing_points = model.get_inducing_variables()[0]  # [M, D]
+        else:
+            inducing_points = model.get_internal_data().query_points  # [M, D]
 
         self._cannonical_feature_functions = lambda x: tf.linalg.matrix_transpose(
             model.get_kernel().K(inducing_points, x)
@@ -760,6 +800,7 @@ class feature_decomposition_trajectory(TrajectoryFunctionClass):
         flat_x, unflatten = flatten_leading_dims(x)  # [N*B, d]
         flattened_feature_evaluations = self._feature_functions(flat_x)  # [N*B, m]
         feature_evaluations = unflatten(flattened_feature_evaluations)  # [N, B, m]
+
         return tf.reduce_sum(feature_evaluations * self._weights_sample, -1)  # [N, B]
 
     def resample(self) -> None:


### PR DESCRIPTION
current status
- inducing point management seems to work fine, with the caveat that I didn't look into details of different types of inducing points (SharedIndependentInducingVariables etc) - I assumed these are the same for both SVGP and SGPR in GPflow, so I simply reused these parts of code from SVGP - @henrymoss can you perhaps confirm this?
- I have reused the existing covariance function that we use in SVGP and VGP via the `compute_qu` method in SGPR model which gives us `q_sqrt`, but I still want to check math in the paper that this is the best way forward
- the only thing that doesn't work at the moment is trajectory sampling, I get some weird errors, potentially stemming from shape of `q_sqrt` that we get from `compute_qu` 

note that I did a bit of reshuffling of tests, it was a mess so I grouped them wrt the wrapper they are testing, ignore those tests if you are looking at tests, only sgpr ones are relevant
(I was itching to divide the tests into 5 different files: test_models_shared and then for each wrapper)