### PR TITLE
Fix slowtests broken by gpflow posterior pr

### DIFF
--- a/docs/notebooks/scalable_thompson_sampling_using_sparse_gaussian_processes.pct.py
+++ b/docs/notebooks/scalable_thompson_sampling_using_sparse_gaussian_processes.pct.py
@@ -24,12 +24,21 @@ tf.random.set_seed(1793)
 
 # %%
 import trieste
-from trieste.objectives import hartmann_6, HARTMANN_6_MINIMUM, HARTMANN_6_SEARCH_SPACE
+from trieste.objectives import (
+    hartmann_6,
+    HARTMANN_6_MINIMUM,
+    HARTMANN_6_SEARCH_SPACE,
+)
 from trieste.types import TensorType
+
 search_space = HARTMANN_6_SEARCH_SPACE
 
-def noisy_hartmann_6(x:TensorType) -> TensorType: # contaminate observations with Gaussian noise
-    return hartmann_6(x) + tf.random.normal([len(x),1], 0, 1, tf.float64) 
+
+def noisy_hartmann_6(
+    x: TensorType,
+) -> TensorType:  # contaminate observations with Gaussian noise
+    return hartmann_6(x) + tf.random.normal([len(x), 1], 0, 1, tf.float64)
+
 
 num_initial_data_points = 15
 initial_query_points = search_space.sample(num_initial_data_points)
@@ -40,23 +49,26 @@ initial_data = observer(initial_query_points)
 # We'll use a sparse Gaussian process regression to model the function, as implemented in GPflow. The GPflow models cannot be used directly in our Bayesian optimization routines, so we build a GPflow's `SVGP` model using Trieste's convenient model build function `build_svgp` and pass it to the `SparseVariational` wrapper. Note that we also define a `KMeansInducingPointSelector` selector, i.e. we reallocate the 50 inducing points of our `SVGP` model at the start of each BO step to be the centroids of a k-means clustering of the observations. As the optimization progresses, observations are likely to be concentrated in the optimal regions, so clustering provides “targeted” inducing points for BO.
 
 # %%
-from trieste.models.gpflow import SparseVariational, build_svgp, KMeansInducingPointSelector
+from trieste.models.gpflow import (
+    SparseVariational,
+    build_svgp,
+    KMeansInducingPointSelector,
+)
 from trieste.models.optimizer import BatchOptimizer
 
 gpflow_model = build_svgp(
-    initial_data, 
-    search_space, 
-    likelihood_variance=0.01, 
-    num_inducing_points=50
+    initial_data, search_space, likelihood_variance=0.01, num_inducing_points=50
 )
 
 inducing_point_selector = KMeansInducingPointSelector(search_space)
 
 model = SparseVariational(
-    gpflow_model, 
-    num_rff_features=1_000, 
+    gpflow_model,
+    num_rff_features=1_000,
     inducing_point_selector=inducing_point_selector,
-    optimizer = BatchOptimizer(tf.optimizers.Adam(0.1), max_iter=100, batch_size=50, compile=True)
+    optimizer=BatchOptimizer(
+        tf.optimizers.Adam(0.1), max_iter=100, batch_size=50, compile=True
+    ),
 )
 
 
@@ -64,7 +76,7 @@ model = SparseVariational(
 # ## Create the Thompson sampling acquisition rule
 #
 # Thompson sampling chooses query points as the minimizers of random samples from the model of our objective
-# function. 
+# function.
 #
 # Using a [decoupled sampling scheme](https://arxiv.org/abs/2002.09309), we can build approximate samples from our sparse GP surrogate model at low cost. As we can cheaply evaluate the values and gradients of these approximate samples at any point across the search space, our acquisition function optimizers can be used to find the minimizers of the samples across the whole search space. We can increase the quality of these approximate samples at the expense of computational cost by increasing `num_rff_features` (as specified when defining our model above).
 #
@@ -75,14 +87,15 @@ from trieste.acquisition.rule import EfficientGlobalOptimization
 from trieste.acquisition import ParallelContinuousThompsonSampling
 from trieste.acquisition.optimizer import automatic_optimizer_selector
 from trieste.acquisition.utils import split_acquisition_function_calls
+
 num_query_points = 100
 
-acq_rule =  EfficientGlobalOptimization(
-    builder = ParallelContinuousThompsonSampling(),
+acq_rule = EfficientGlobalOptimization(
+    builder=ParallelContinuousThompsonSampling(),
     num_query_points=num_query_points,
-    optimizer =  split_acquisition_function_calls(
+    optimizer=split_acquisition_function_calls(
         automatic_optimizer_selector, split_size=100_000
-    )
+    ),
 )
 
 # %% [markdown]
@@ -112,7 +125,9 @@ ground_truth_regret = hartmann_6(dataset.query_points) - HARTMANN_6_MINIMUM
 best_found_truth_idx = tf.squeeze(tf.argmin(ground_truth_regret, axis=0))
 
 fig, ax = plt.subplots()
-plot_regret(ground_truth_regret.numpy(),ax,num_init=10, idx_best=best_found_truth_idx)
+plot_regret(
+    ground_truth_regret.numpy(), ax, num_init=10, idx_best=best_found_truth_idx
+)
 
 ax.set_yscale("log")
 ax.set_ylabel("Regret")

--- a/tests/integration/test_active_learning.py
+++ b/tests/integration/test_active_learning.py
@@ -138,7 +138,7 @@ def test_optimizer_learns_scaled_branin_function(
             id="ExpectedFeasibility/20",
         ),
         pytest.param(
-            35,
+            25,
             EfficientGlobalOptimization(
                 IntegratedVarianceReduction(BRANIN_SEARCH_SPACE.sample_sobol(2000), 80.0),
                 num_query_points=3,
@@ -147,7 +147,7 @@ def test_optimizer_learns_scaled_branin_function(
             id="IntegratedVarianceReduction/80",
         ),
         pytest.param(
-            35,
+            25,
             EfficientGlobalOptimization(
                 IntegratedVarianceReduction(BRANIN_SEARCH_SPACE.sample_sobol(2000), [78.0, 82.0]),
                 num_query_points=3,

--- a/tests/integration/test_active_learning.py
+++ b/tests/integration/test_active_learning.py
@@ -138,7 +138,7 @@ def test_optimizer_learns_scaled_branin_function(
             id="ExpectedFeasibility/20",
         ),
         pytest.param(
-            28,
+            35,
             EfficientGlobalOptimization(
                 IntegratedVarianceReduction(BRANIN_SEARCH_SPACE.sample_sobol(2000), 80.0),
                 num_query_points=3,
@@ -147,7 +147,7 @@ def test_optimizer_learns_scaled_branin_function(
             id="IntegratedVarianceReduction/80",
         ),
         pytest.param(
-            28,
+            35,
             EfficientGlobalOptimization(
                 IntegratedVarianceReduction(BRANIN_SEARCH_SPACE.sample_sobol(2000), [78.0, 82.0]),
                 num_query_points=3,

--- a/tests/integration/test_active_learning.py
+++ b/tests/integration/test_active_learning.py
@@ -138,7 +138,7 @@ def test_optimizer_learns_scaled_branin_function(
             id="ExpectedFeasibility/20",
         ),
         pytest.param(
-            25,
+            28,
             EfficientGlobalOptimization(
                 IntegratedVarianceReduction(BRANIN_SEARCH_SPACE.sample_sobol(2000), 80.0),
                 num_query_points=3,
@@ -147,7 +147,7 @@ def test_optimizer_learns_scaled_branin_function(
             id="IntegratedVarianceReduction/80",
         ),
         pytest.param(
-            25,
+            28,
             EfficientGlobalOptimization(
                 IntegratedVarianceReduction(BRANIN_SEARCH_SPACE.sample_sobol(2000), [78.0, 82.0]),
                 num_query_points=3,

--- a/tests/integration/test_active_learning.py
+++ b/tests/integration/test_active_learning.py
@@ -183,21 +183,6 @@ def test_optimizer_learns_feasibility_set_of_thresholded_branin_function(
     """
     search_space = BRANIN_SEARCH_SPACE
 
-    def build_model(data: Dataset) -> GaussianProcessRegression:
-        variance = tf.math.reduce_variance(data.observations)
-        kernel = gpflow.kernels.Matern52(variance=variance, lengthscales=[0.2, 0.2])
-        prior_scale = tf.cast(1.0, dtype=tf.float64)
-        kernel.variance.prior = tfp.distributions.LogNormal(
-            tf.math.log(kernel.variance), prior_scale
-        )
-        kernel.lengthscales.prior = tfp.distributions.LogNormal(
-            tf.math.log(kernel.lengthscales), prior_scale
-        )
-        gpr = gpflow.models.GPR(data.astuple(), kernel, noise_variance=1e-5)
-        gpflow.set_trainable(gpr.likelihood, False)
-
-        return GaussianProcessRegression(gpr)
-
     num_initial_points = 6
     initial_query_points = search_space.sample_halton(num_initial_points)
     observer = mk_observer(branin)

--- a/tests/integration/test_ask_tell_optimization.py
+++ b/tests/integration/test_ask_tell_optimization.py
@@ -66,7 +66,7 @@ OPTIMIZER_PARAMS = (
             id="EfficientGlobalOptimization/reload_state",
         ),
         pytest.param(15, False, lambda: TrustRegion(), id="TrustRegion"),
-        pytest.param(15, True, lambda: TrustRegion(), id="TrustRegion/reload_state"),
+        pytest.param(16, True, lambda: TrustRegion(), id="TrustRegion/reload_state"),
         pytest.param(
             10,
             False,

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -66,6 +66,12 @@ class GPflowPredictor(
         """
         self._posterior = self.model.posterior(PrecomputeCacheType.VARIABLE)
 
+    def __setstate__(self, state: dict) -> None:
+        # when unpickling we may need to regenerate the posterior cache
+        self.__dict__.update(state)
+        if self._posterior is not None:
+            self.create_posterior_cache()
+
     def update_posterior_cache(self) -> None:
         """Update the posterior cache. This needs to be called whenever the underlying model
         is changed."""

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -85,14 +85,14 @@ class GPflowPredictor(
 
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         mean, cov = (self._posterior or self.model).predict_f(query_points)
-        # posterior predict has been observed to return negative variance values; stop it
+        # posterior predict can return negative variance values [cf GPFlow issue #1813]
         if self._posterior is not None:
             cov = tf.clip_by_value(cov, 1e-12, cov.dtype.max)
         return mean, cov
 
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         mean, cov = (self._posterior or self.model).predict_f(query_points, full_cov=True)
-        # posterior predict has been observed to return negative variance values; stop it
+        # posterior predict can return negative variance values [cf GPFlow issue #1813]
         if self._posterior is not None:
             cov = tf.linalg.set_diag(
                 cov, tf.clip_by_value(tf.linalg.diag_part(cov), 1e-12, cov.dtype.max)

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 import gpflow
 import tensorflow as tf
@@ -66,7 +66,7 @@ class GPflowPredictor(
         """
         self._posterior = self.model.posterior(PrecomputeCacheType.VARIABLE)
 
-    def __setstate__(self, state: dict) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         # when unpickling we may need to regenerate the posterior cache
         self.__dict__.update(state)
         if self._posterior is not None:

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -85,16 +85,18 @@ class GPflowPredictor(
 
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         mean, cov = (self._posterior or self.model).predict_f(query_points)
-        # posterior predict has been observed to return negative values; stop it
+        # posterior predict has been observed to return negative variance values; stop it
         if self._posterior is not None:
             cov = tf.clip_by_value(cov, 1e-12, cov.dtype.max)
         return mean, cov
 
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         mean, cov = (self._posterior or self.model).predict_f(query_points, full_cov=True)
-        # posterior predict has been observed to return negative values; stop it
+        # posterior predict has been observed to return negative variance values; stop it
         if self._posterior is not None:
-            cov = tf.clip_by_value(cov, 1e-12, cov.dtype.max)
+            cov = tf.linalg.set_diag(
+                cov, tf.clip_by_value(tf.linalg.diag_part(cov), 1e-12, cov.dtype.max)
+            )
         return mean, cov
 
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -84,10 +84,18 @@ class GPflowPredictor(
         """The underlying GPflow model."""
 
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
-        return (self._posterior or self.model).predict_f(query_points)
+        mean, cov = (self._posterior or self.model).predict_f(query_points)
+        # posterior predict has been observed to return negative values; stop it
+        if self._posterior is not None:
+            cov = tf.clip_by_value(cov, 1e-12, cov.dtype.max)
+        return mean, cov
 
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
-        return (self._posterior or self.model).predict_f(query_points, full_cov=True)
+        mean, cov = (self._posterior or self.model).predict_f(query_points, full_cov=True)
+        # posterior predict has been observed to return negative values; stop it
+        if self._posterior is not None:
+            cov = tf.clip_by_value(cov, 1e-12, cov.dtype.max)
+        return mean, cov
 
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         return self.model.predict_f_samples(query_points, num_samples)


### PR DESCRIPTION
Partly fix failing slowtests.

1. handle depickling models with posterior caches
2. temporary(?) workaround for the fact that posterior predict_f can sometimes return negative variances

A few of the active learning integration tests are still failing due to being numerically very unstable. Will look at those in a separate PR.