### PR TITLE
Raise error if use SVGP model with q_diag=True

### DIFF
--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -730,6 +730,15 @@ def test_variational_gaussian_process_predict() -> None:
     npt.assert_allclose(variance_y - model.get_observation_noise(), variance, atol=5e-5)
 
 
+
+def test_sparse_variational_raises_for_model_with_q_diag_true() ->None:
+    x = mock_data()[0]
+    model = SVGP(
+        gpflow.kernels.Matern32(), gpflow.likelihoods.Gaussian(), x[:2], num_data=len(x), q_diag=True
+    )
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES): 
+        sv = SparseVariational(model)
+
 def test_sparse_variational_model_attribute() -> None:
     model = svgp_model(*mock_data())
     sv = SparseVariational(model)

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -730,14 +730,18 @@ def test_variational_gaussian_process_predict() -> None:
     npt.assert_allclose(variance_y - model.get_observation_noise(), variance, atol=5e-5)
 
 
-
-def test_sparse_variational_raises_for_model_with_q_diag_true() ->None:
+def test_sparse_variational_raises_for_model_with_q_diag_true() -> None:
     x = mock_data()[0]
     model = SVGP(
-        gpflow.kernels.Matern32(), gpflow.likelihoods.Gaussian(), x[:2], num_data=len(x), q_diag=True
+        gpflow.kernels.Matern32(),
+        gpflow.likelihoods.Gaussian(),
+        x[:2],
+        num_data=len(x),
+        q_diag=True,
     )
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES): 
-        sv = SparseVariational(model)
+    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+        SparseVariational(model)
+
 
 def test_sparse_variational_model_attribute() -> None:
     model = svgp_model(*mock_data())

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -556,6 +556,12 @@ class SparseVariational(
             that has more than one set of inducing points.
         """
 
+        tf.debugging.assert_rank(
+            model.q_sqrt, 
+            3, 
+            "SparseVariational requires an SVGP model with q_diag=True."
+        )
+
         if optimizer is None:
             optimizer = BatchOptimizer(tf.optimizers.Adam(), batch_size=100, compile=True)
 

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -557,7 +557,7 @@ class SparseVariational(
         """
 
         tf.debugging.assert_rank(
-            model.q_sqrt, 3, "SparseVariational requires an SVGP model with q_diag=True."
+            model.q_sqrt, 3, "SparseVariational requires an SVGP model with q_diag=False."
         )
 
         if optimizer is None:

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -557,9 +557,7 @@ class SparseVariational(
         """
 
         tf.debugging.assert_rank(
-            model.q_sqrt, 
-            3, 
-            "SparseVariational requires an SVGP model with q_diag=True."
+            model.q_sqrt, 3, "SparseVariational requires an SVGP model with q_diag=True."
         )
 
         if optimizer is None:


### PR DESCRIPTION
Our `SparseVariational` does not support gpflow SVGP with q_diag=True.  In a future PR, I will add this functionality. For now I just make sure we raise a useful error.