### PR TITLE
Clean up ParallelContinuousThompsonSampling and slightly improve testing

### DIFF
--- a/tests/unit/acquisition/function/test_continuous_thompson_sampling.py
+++ b/tests/unit/acquisition/function/test_continuous_thompson_sampling.py
@@ -31,7 +31,26 @@ from trieste.acquisition.function.continuous_thompson_sampling import (
 )
 from trieste.acquisition.function.function import lower_confidence_bound
 from trieste.data import Dataset
-from trieste.models import TrajectoryFunctionClass
+from trieste.models import TrajectoryFunction, TrajectoryFunctionClass, TrajectorySampler
+from trieste.models.gpflow import (
+    RandomFourierFeatureTrajectorySampler,
+    feature_decomposition_trajectory,
+)
+
+
+class DumbTrajectorySampler(RandomFourierFeatureTrajectorySampler):
+    """A RandomFourierFeatureTrajectorySampler that doesn't update trajectories in place."""
+
+    def update_trajectory(self, trajectory: TrajectoryFunction) -> TrajectoryFunction:
+        tf.debugging.Assert(isinstance(trajectory, feature_decomposition_trajectory), [])
+        return self.get_trajectory()
+
+
+class ModelWithDumbSamplers(QuadraticMeanAndRBFKernelWithSamplers):
+    """A model that uses DumbTrajectorySampler."""
+
+    def trajectory_sampler(self) -> TrajectorySampler[QuadraticMeanAndRBFKernelWithSamplers]:
+        return DumbTrajectorySampler(self, 100)
 
 
 def test_greedy_thompson_sampling_raises_for_model_without_trajectory_sampler() -> None:
@@ -43,15 +62,15 @@ def test_greedy_thompson_sampling_raises_for_model_without_trajectory_sampler() 
         GreedyContinuousThompsonSampling().prepare_acquisition_function(model)  # type: ignore
 
 
-def test_greedy_thompson_sampling_builder_builds_trajectory() -> None:
+@pytest.mark.parametrize("dumb_samplers", [True, False])
+def test_greedy_thompson_sampling_builder_builds_trajectory(dumb_samplers: bool) -> None:
     x_range = tf.linspace(0.0, 1.0, 5)
     x_range = tf.cast(x_range, dtype=tf.float64)
     xs = tf.reshape(tf.stack(tf.meshgrid(x_range, x_range, indexing="ij"), axis=-1), (-1, 2))
     ys = quadratic(xs)
     dataset = Dataset(xs, ys)
-    model = QuadraticMeanAndRBFKernelWithSamplers(
-        dataset, noise_variance=tf.constant(1.0, dtype=tf.float64)
-    )
+    model_type = ModelWithDumbSamplers if dumb_samplers else QuadraticMeanAndRBFKernelWithSamplers
+    model = model_type(dataset, noise_variance=tf.constant(1.0, dtype=tf.float64))
     model.kernel = (
         gpflow.kernels.RBF()
     )  # need a gpflow kernel object for random feature decompositions
@@ -62,15 +81,17 @@ def test_greedy_thompson_sampling_builder_builds_trajectory() -> None:
     assert isinstance(new_acq_fn, TrajectoryFunctionClass)
 
 
-def test_greedy_thompson_sampling_builder_raises_when_update_with_wrong_function() -> None:
+@pytest.mark.parametrize("dumb_samplers", [True, False])
+def test_greedy_thompson_sampling_builder_raises_when_update_with_wrong_function(
+    dumb_samplers: bool,
+) -> None:
     x_range = tf.linspace(0.0, 1.0, 5)
     x_range = tf.cast(x_range, dtype=tf.float64)
     xs = tf.reshape(tf.stack(tf.meshgrid(x_range, x_range, indexing="ij"), axis=-1), (-1, 2))
     ys = quadratic(xs)
     dataset = Dataset(xs, ys)
-    model = QuadraticMeanAndRBFKernelWithSamplers(
-        dataset, noise_variance=tf.constant(1.0, dtype=tf.float64)
-    )
+    model_type = ModelWithDumbSamplers if dumb_samplers else QuadraticMeanAndRBFKernelWithSamplers
+    model = model_type(dataset, noise_variance=tf.constant(1.0, dtype=tf.float64))
     model.kernel = (
         gpflow.kernels.RBF()
     )  # need a gpflow kernel object for random feature decompositions
@@ -89,40 +110,44 @@ def test_parallel_thompson_sampling_raises_for_model_without_trajectory_sampler(
         ParallelContinuousThompsonSampling().prepare_acquisition_function(model)  # type: ignore
 
 
-def test_parallel_thompson_sampling_builder_builds_trajectory() -> None:
+@pytest.mark.parametrize("dumb_samplers", [True, False])
+def test_parallel_thompson_sampling_builder_builds_trajectory(dumb_samplers: bool) -> None:
     x_range = tf.linspace(0.0, 1.0, 5)
     x_range = tf.cast(x_range, dtype=tf.float64)
     xs = tf.reshape(tf.stack(tf.meshgrid(x_range, x_range, indexing="ij"), axis=-1), (-1, 2))
     ys = quadratic(xs)
     dataset = Dataset(xs, ys)
-    model = QuadraticMeanAndRBFKernelWithSamplers(
-        dataset, noise_variance=tf.constant(1.0, dtype=tf.float64)
-    )
+    model_type = ModelWithDumbSamplers if dumb_samplers else QuadraticMeanAndRBFKernelWithSamplers
+    model = model_type(dataset, noise_variance=tf.constant(1.0, dtype=tf.float64))
     model.kernel = (
         gpflow.kernels.RBF()
     )  # need a gpflow kernel object for random feature decompositions
     builder = ParallelContinuousThompsonSampling()
     acq_fn = builder.prepare_acquisition_function(model)
     assert isinstance(acq_fn, TrajectoryFunctionClass)
+    assert acq_fn.__class__.__name__ == "NegatedTrajectory"
     new_acq_fn = builder.update_acquisition_function(acq_fn, model)
     assert isinstance(new_acq_fn, TrajectoryFunctionClass)
+    assert new_acq_fn.__class__.__name__ == "NegatedTrajectory"
 
 
-def test_parallel_thompson_sampling_builder_raises_when_update_with_wrong_function() -> None:
+@pytest.mark.parametrize("dumb_samplers", [True, False])
+def test_parallel_thompson_sampling_builder_raises_when_update_with_wrong_function(
+    dumb_samplers: bool,
+) -> None:
     x_range = tf.linspace(0.0, 1.0, 5)
     x_range = tf.cast(x_range, dtype=tf.float64)
     xs = tf.reshape(tf.stack(tf.meshgrid(x_range, x_range, indexing="ij"), axis=-1), (-1, 2))
     ys = quadratic(xs)
     dataset = Dataset(xs, ys)
-    model = QuadraticMeanAndRBFKernelWithSamplers(
-        dataset, noise_variance=tf.constant(1.0, dtype=tf.float64)
-    )
+    model_type = ModelWithDumbSamplers if dumb_samplers else QuadraticMeanAndRBFKernelWithSamplers
+    model = model_type(dataset, noise_variance=tf.constant(1.0, dtype=tf.float64))
     model.kernel = (
         gpflow.kernels.RBF()
     )  # need a gpflow kernel object for random feature decompositions
     builder = ParallelContinuousThompsonSampling()
     builder.prepare_acquisition_function(model)
-    with pytest.raises(tf.errors.InvalidArgumentError):
+    with pytest.raises(ValueError):
         builder.update_acquisition_function(lower_confidence_bound(model, 0.1), model)
 
 


### PR DESCRIPTION
Slightly improve test coverage, and make the code a little bit clearer and more robust: it now passes the original function to `update_trajectory` rather than the negated function (currently this doesn't make a difference as either (1) they're the same, because we updated the function in place, or (2) `update_trajectory` ignores the input and creates a new function from scratch, but this would be better if `update_trajectory` tried to use the passed in function in some unexpected way).