### PR TITLE
Avoid recompiling training loss closure

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -260,7 +260,7 @@ def test_bayesian_optimizer_with_svgp_finds_minima_of_scaled_branin() -> None:
         40,
         EfficientGlobalOptimization[SearchSpace, SparseVariational](),
         optimize_branin=True,
-        model_args={"optimizer": Optimizer(gpflow.optimizers.Scipy())},
+        model_args={"optimizer": Optimizer(gpflow.optimizers.Scipy(), compile=True)},
     )
     _test_optimizer_finds_minimum(
         SparseVariational,
@@ -269,7 +269,7 @@ def test_bayesian_optimizer_with_svgp_finds_minima_of_scaled_branin() -> None:
             builder=ParallelContinuousThompsonSampling(), num_query_points=5
         ),
         optimize_branin=True,
-        model_args={"optimizer": Optimizer(gpflow.optimizers.Scipy())},
+        model_args={"optimizer": Optimizer(gpflow.optimizers.Scipy(), compile=True)},
     )
 
 
@@ -279,7 +279,7 @@ def test_bayesian_optimizer_with_svgp_finds_minima_of_simple_quadratic() -> None
         SparseVariational,
         5,
         EfficientGlobalOptimization[SearchSpace, SparseVariational](),
-        model_args={"optimizer": Optimizer(gpflow.optimizers.Scipy())},
+        model_args={"optimizer": Optimizer(gpflow.optimizers.Scipy(), compile=True)},
     )
 
 


### PR DESCRIPTION
Avoid regenerating a new closure every BO step by compiling and saving a single function.

Also avoid recompiling acquisition functions combined using a Product or other reducer.