### PR TITLE
Fix k-means behavior when can't calculate stds

### DIFF
--- a/tests/unit/models/gpflow/test_inducing_point_selectors.py
+++ b/tests/unit/models/gpflow/test_inducing_point_selectors.py
@@ -88,7 +88,7 @@ def test_inducing_point_selectors_returns_correctly_shaped_inducing_points(
     [
         UniformInducingPointSelector(Box([0.0, -1.0], [1.0, 0.0])),
         RandomSubSampleInducingPointSelector(Box([0.0, -1.0], [1.0, 0.0])),
-        KMeansInducingPointSelector(Box([0.0, -1.0], [10.0, 0.0])),
+        KMeansInducingPointSelector(Box([0.0, -1.0], [1.0, 0.0])),
     ],
 )
 def test_inducing_point_selectors_choose_points_still_in_space(

--- a/tests/unit/models/gpflow/test_inducing_point_selectors.py
+++ b/tests/unit/models/gpflow/test_inducing_point_selectors.py
@@ -82,25 +82,26 @@ def test_inducing_point_selectors_returns_correctly_shaped_inducing_points(
     npt.assert_array_equal(inducing_points.shape, new_inducing_points.shape)
 
 
+@random_seed
 @pytest.mark.parametrize(
     "selector",
     [
         UniformInducingPointSelector(Box([0.0, -1.0], [1.0, 0.0])),
         RandomSubSampleInducingPointSelector(Box([0.0, -1.0], [1.0, 0.0])),
-        KMeansInducingPointSelector(Box([0.0, -1.0], [1.0, 0.0])),
+        KMeansInducingPointSelector(Box([0.0, -1.0], [10.0, 0.0])),
     ],
 )
 def test_inducing_point_selectors_choose_points_still_in_space(
     selector: InducingPointSelector[SparseVariational],
 ) -> None:
-    X = tf.constant([[0.9, -0.5], [0.5, -0.9]], dtype=tf.float64)
+    X = tf.constant([[0.01, -0.99], [0.99, -0.01]], dtype=tf.float64)
     Y = fnc_3x_plus_10(X)
     dataset = Dataset(X, Y)
     svgp = svgp_model(X, Y)
     model = SparseVariational(svgp)
-    inducing_points = X
+    inducing_points = selector._search_space.sample(10)
     new_inducing_points = selector.calculate_inducing_points(inducing_points, model, dataset)
-    assert tf.reduce_all([point in Box([0.0, -1.0], [1.0, 0.0]) for point in new_inducing_points])
+    assert tf.reduce_all([point in selector._search_space for point in new_inducing_points])
 
 
 @random_seed

--- a/trieste/models/gpflow/inducing_point_selectors.py
+++ b/trieste/models/gpflow/inducing_point_selectors.py
@@ -211,15 +211,14 @@ class KMeansInducingPointSelector(InducingPointSelector[ProbabilisticModel]):
 
         centroids, _ = kmeans(shuffled_query_points, int(tf.math.minimum(M, N)))  # [C, d]
 
+        if normalize:
+            centroids *= query_points_stds  # [M, d]
+
         if len(centroids) < M:  # choose remaining points as random samples
             uniform_sampler = UniformInducingPointSelector(self._search_space)
             extra_centroids = uniform_sampler._recalculate_inducing_points(  # [M-C, d]
                 M - len(centroids), model, dataset
             )
-            extra_centroids = extra_centroids / query_points_stds  # remember to standardize
             centroids = tf.concat([centroids, extra_centroids], axis=0)  # [M, d]
 
-        if normalize:
-            return centroids * query_points_stds  # [M, d]
-        else:
-            return centroids  # [M, d]
+        return centroids  # [M, d]


### PR DESCRIPTION
Small bug fix for when empirical stds are 0 in the query points for the K-means inducing point initializer.

The old logic wasn't quite right.

I have updated the tests so that they would have failed before the fix.