### PR TITLE
Make DeepGPs copyable (ish)

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import tempfile
+from functools import partial
 from pathlib import Path
 from typing import Any, List, Mapping, Optional, Tuple, Type, cast
 
@@ -556,9 +557,9 @@ def _test_optimizer_finds_minimum(
         )
 
     elif model_type is DeepGaussianProcess:
-        track_state = False
-        dgp = build_vanilla_deep_gp(initial_data, search_space)
-        model = DeepGaussianProcess(dgp, **model_args)
+        model = DeepGaussianProcess(
+            partial(build_vanilla_deep_gp, initial_data, search_space), **model_args
+        )
 
     elif model_type is DeepEnsemble:
         keras_ensemble = build_keras_ensemble(initial_data, 5, 3, 25, "selu")

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -549,3 +549,14 @@ def test_deep_ensemble_deep_copies_optimizer_callback_models() -> None:
     assert isinstance(callback_copy, tf.keras.callbacks.EarlyStopping)
     assert callback_copy.model is model_copy.model is not callback.model
     npt.assert_equal(callback_copy.model.get_weights(), callback.model.get_weights())
+
+
+def test_deep_ensemble_deep_copies_optimizer_without_callbacks() -> None:
+    example_data = _get_example_data([10, 3], [10, 3])
+    keras_ensemble = trieste_keras_ensemble_model(example_data, _ENSEMBLE_SIZE, False)
+    model = DeepEnsemble(keras_ensemble)
+    del model.optimizer.fit_args["callbacks"]
+
+    model_copy = copy.deepcopy(model)
+    assert model_copy.optimizer is not model.optimizer
+    assert model_copy.optimizer.fit_args == model.optimizer.fit_args

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -533,19 +533,19 @@ def test_deep_ensemble_deep_copies_optimizer_state() -> None:
 
 
 def test_deep_ensemble_deep_copies_optimizer_callback_models() -> None:
-    example_data = empty_dataset([1], [1])
+    example_data = _get_example_data([10, 3], [10, 3])
     keras_ensemble = trieste_keras_ensemble_model(example_data, _ENSEMBLE_SIZE, False)
     model = DeepEnsemble(keras_ensemble)
+    new_example_data = _get_example_data([20, 3], [20, 3])
+    model.update(new_example_data)
+    model.optimize(new_example_data)
 
     callback = model.optimizer.fit_args["callbacks"][0]
     assert isinstance(callback, tf.keras.callbacks.EarlyStopping)
-    # default callback doesn't contain a model, so let's randomly add one
-    assert callback.model is None
-    callback.model = model.model
+    assert callback.model is model.model
 
     model_copy = copy.deepcopy(model)
-    assert len(model_copy.optimizer.fit_args.get("callbacks", [])) == 1
     callback_copy = model_copy.optimizer.fit_args["callbacks"][0]
     assert isinstance(callback_copy, tf.keras.callbacks.EarlyStopping)
-    assert callback_copy.model is not callback.model
+    assert callback_copy.model is model_copy.model is not callback.model
     npt.assert_equal(callback_copy.model.get_weights(), callback.model.get_weights())

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -605,7 +605,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                         raise NotImplementedError(
                             "Failed to save the optimization state. Some models do not support "
                             "deecopying or serialization and cannot be saved. "
-                            "(This is particularly common for deep neural network models.) "
+                            "(This is particularly common for deep neural network models, "
+                            "though some of the model wrappers accept a model closure as a workaround.) "
                             "For these models, the `track_state`` argument of the "
                             ":meth:`~trieste.bayesian_optimizer.BayesianOptimizer.optimize` method "
                             "should be set to `False`. This means that only the final model "

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -605,8 +605,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                         raise NotImplementedError(
                             "Failed to save the optimization state. Some models do not support "
                             "deecopying or serialization and cannot be saved. "
-                            "(This is particularly common for deep neural network models, "
-                            "though some of the model wrappers accept a model closure as a workaround.) "
+                            "(This is particularly common for deep neural network models, though "
+                            "some of the model wrappers accept a model closure as a workaround.) "
                             "For these models, the `track_state`` argument of the "
                             ":meth:`~trieste.bayesian_optimizer.BayesianOptimizer.optimize` method "
                             "should be set to `False`. This means that only the final model "

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -144,7 +144,7 @@ class DeepGaussianProcess(
         # serialize all the callback models, pickle the optimizer(!), and revert (ugh!)
         callback: Callback
         saved_models: list[KerasOptimizer] = []
-        for callback in self._optimizer.fit_args["callbacks"]:
+        for callback in self._optimizer.fit_args.get("callbacks", []):
             saved_models.append(callback.model)
             if callback.model is self._model_keras:
                 # no need to serialize the main model (and it probably wouldn't work anyway)
@@ -152,7 +152,7 @@ class DeepGaussianProcess(
             elif callback.model:
                 callback.model = (callback.model.to_json(), callback.model.get_weights())
         state["_optimizer"] = dill.dumps(state["_optimizer"])
-        for callback, model in zip(self._optimizer.fit_args["callbacks"], saved_models):
+        for callback, model in zip(self._optimizer.get("callbacks", []), saved_models):
             callback.model = model
 
         return state

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -152,7 +152,7 @@ class DeepGaussianProcess(
             elif callback.model:
                 callback.model = (callback.model.to_json(), callback.model.get_weights())
         state["_optimizer"] = dill.dumps(state["_optimizer"])
-        for callback, model in zip(self._optimizer.get("callbacks", []), saved_models):
+        for callback, model in zip(self._optimizer.fit_args.get("callbacks", []), saved_models):
             callback.model = model
 
         return state

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -14,10 +14,15 @@
 
 from __future__ import annotations
 
+from typing import Any, Callable
+
+import dill
+import gpflow
 import tensorflow as tf
 from gpflow.inducing_variables import InducingPoints
 from gpflux.layers import GPLayer, LatentVariableLayer
 from gpflux.models import DeepGP
+from tensorflow.python.keras.callbacks import Callback
 
 from ...data import Dataset
 from ...types import TensorType
@@ -49,13 +54,14 @@ class DeepGaussianProcess(
 
     def __init__(
         self,
-        model: DeepGP,
+        model: DeepGP | Callable[[], DeepGP],
         optimizer: KerasOptimizer | None = None,
         num_rff_features: int = 1000,
         continuous_optimisation: bool = True,
     ):
         """
-        :param model: The underlying GPflux deep Gaussian process model.
+        :param model: The underlying GPflux deep Gaussian process model. Passing in a named closure
+            rather than a model can help when copying or serialising.
         :param optimizer: The optimizer configuration for training the model. Defaults to
             :class:`~trieste.models.optimizer.KerasOptimizer` wrapper with
             :class:`~tf.optimizers.Adam` optimizer. The ``optimizer`` argument to the wrapper is
@@ -74,6 +80,12 @@ class DeepGaussianProcess(
         :raise ValueError: If ``model`` has unsupported layers, ``num_rff_features`` is less than 0,
             or if the ``optimizer`` is not of a supported type.
         """
+        if isinstance(model, DeepGP):
+            self._model_closure = None
+        else:
+            self._model_closure = model
+            model = model()
+
         for layer in model.f_layers:
             if not isinstance(layer, (GPLayer, LatentVariableLayer)):
                 raise ValueError(
@@ -120,6 +132,54 @@ class DeepGaussianProcess(
         self._model_keras.compile(self.optimizer.optimizer)
         self._absolute_epochs = 0
         self._continuous_optimisation = continuous_optimisation
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+
+        # when using a model closure, store the model parameters, not the model itself
+        if self._model_closure is not None:
+            state["_model_gpflux"] = gpflow.utilities.parameter_dict(self._model_gpflux)
+            state["_model_keras"] = gpflow.utilities.parameter_dict(self._model_keras)
+
+        # serialize all the callback models, pickle the optimizer(!), and revert (ugh!)
+        callback: Callback
+        saved_models: list[KerasOptimizer] = []
+        for callback in self._optimizer.fit_args["callbacks"]:
+            saved_models.append(callback.model)
+            if callback.model is self._model_keras:
+                # no need to serialize the main model (and it probably wouldn't work anyway)
+                callback.model = ...
+            elif callback.model:
+                callback.model = (callback.model.to_json(), callback.model.get_weights())
+        state["_optimizer"] = dill.dumps(state["_optimizer"])
+        for callback, model in zip(self._optimizer.fit_args["callbacks"], saved_models):
+            callback.model = model
+
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+
+        if self._model_closure is not None:
+            dgp: DeepGP = state["_model_closure"]()
+            self._model_gpflux = dgp
+            self._model_keras = dgp.as_training_model()
+
+        self._optimizer = dill.loads(self._optimizer)
+        for callback in self._optimizer.fit_args.get("callbacks", []):
+            if callback.model is ...:
+                callback.model = self._model_keras
+            elif callback.model:
+                model, weights = callback.model
+                callback.model = tf.keras.models.model_from_json(
+                    model,
+                )
+                callback.model.set_weights(weights)
+        self._model_keras.compile(self._optimizer.optimizer)
+
+        if self._model_closure is not None:
+            gpflow.utilities.multiple_assign(self._model_gpflux, state["_model_gpflux"])
+            gpflow.utilities.multiple_assign(self._model_keras, state["_model_keras"])
 
     def __repr__(self) -> str:
         """"""

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -377,10 +377,11 @@ class DeepEnsemble(
             saved_models: list[KerasOptimizer] = []
             for callback in self._optimizer.fit_args["callbacks"]:
                 saved_models.append(callback.model)
-                callback.model = callback.model and (
-                    callback.model.to_json(),
-                    callback.model.get_weights(),
-                )
+                if callback.model is self.model:
+                    # no need to serialize the main model
+                    callback.model = ...
+                elif callback.model:
+                    callback.model = (callback.model.to_json(), callback.model.get_weights())
             state["_optimizer"] = dill.dumps(state["_optimizer"])
             for callback, model in zip(self._optimizer.fit_args["callbacks"], saved_models):
                 callback.model = model
@@ -389,19 +390,23 @@ class DeepEnsemble(
     def __setstate__(self, state: dict[str, Any]) -> None:
         # Restore optimizer and callback models after depickling, and recompile.
         self.__dict__.update(state)
-        if self._optimizer:
-            # unpickle the optimizer, and restore all the callback models
-            self._optimizer = dill.loads(self._optimizer)
-            for callback in self._optimizer.fit_args.get("callbacks", []):
-                if callback.model:
+
+        # Unpickle the optimizer, and restore all the callback models
+        self._optimizer = dill.loads(self._optimizer)
+        for callback in self._optimizer.fit_args.get("callbacks", []):
+            if callback.model:
+                if callback.model is ...:
+                    callback.model = self.model
+                elif callback.model:
                     model, weights = callback.model
                     callback.model = tf.keras.models.model_from_json(
                         model,
                         custom_objects={"MultivariateNormalTriL": MultivariateNormalTriL},
                     )
                     callback.model.set_weights(weights)
+
         # Recompile the model
-        self._model.model.compile(
+        self.model.compile(
             self.optimizer.optimizer,
             loss=[self.optimizer.loss] * self._model.ensemble_size,
             metrics=[self.optimizer.metrics] * self._model.ensemble_size,

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -375,7 +375,7 @@ class DeepEnsemble(
             # serialize all the callback models, pickle the optimizer(!), and revert (ugh!)
             callback: Callback
             saved_models: list[KerasOptimizer] = []
-            for callback in self._optimizer.fit_args["callbacks"]:
+            for callback in self._optimizer.fit_args.get("callbacks", []):
                 saved_models.append(callback.model)
                 if callback.model is self.model:
                     # no need to serialize the main model
@@ -383,7 +383,7 @@ class DeepEnsemble(
                 elif callback.model:
                     callback.model = (callback.model.to_json(), callback.model.get_weights())
             state["_optimizer"] = dill.dumps(state["_optimizer"])
-            for callback, model in zip(self._optimizer.fit_args["callbacks"], saved_models):
+            for callback, model in zip(self._optimizer.fit_args.get("callbacks", []), saved_models):
                 callback.model = model
         return state
 


### PR DESCRIPTION
Add support for copying DeepGPs by making DeepGaussianProcess accept a closure so we don't have to copy the architecture (something gpflux doesn't support).

Also fix issue with deep ensembles failing to copy when the fit args doesn't include a callbacks key.