### PR TITLE
Make import work for gpflux>=0.2.7

### DIFF
--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -48,9 +48,9 @@ try:
     # code ugliness is due to https://github.com/python/mypy/issues/8823
     RFF: Any = getattr(gpflux.layers.basis_functions, "RandomFourierFeatures")
 except AttributeError:
-    from gpflux.layers.basis_functions.fourier_features import (  # type: ignore
-        RandomFourierFeaturesCosine as RFF,
-    )
+    import gpflux.layers.basis_functions.fourier_features.RandomFourierFeaturesCosine as RFFredef
+
+    RFF = RFFredef
 
 
 class IndependentReparametrizationSampler(ReparametrizationSampler[ProbabilisticModel]):

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -48,8 +48,8 @@ try:
     # code ugliness is due to https://github.com/python/mypy/issues/8823
     RFF: Any = getattr(gpflux.layers.basis_functions, "RandomFourierFeatures")
 except AttributeError:
-    from gpflux.layers.basis_functions.fourier_features import (
-        RandomFourierFeaturesCosine as RFF  # type: ignore
+    from gpflux.layers.basis_functions.fourier_features import (  # type: ignore
+        RandomFourierFeaturesCosine as RFF,
     )
 
 

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -48,7 +48,9 @@ try:
     # code ugliness is due to https://github.com/python/mypy/issues/8823
     RFF: Any = getattr(gpflux.layers.basis_functions, "RandomFourierFeatures")
 except AttributeError:
-    from gpflux.layers.basis_functions.fourier_features import RandomFourierFeaturesCosine as RFF
+    from gpflux.layers.basis_functions.fourier_features import (
+        RandomFourierFeaturesCosine as RFF  # type: ignore
+    )
 
 
 class IndependentReparametrizationSampler(ReparametrizationSampler[ProbabilisticModel]):

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -48,9 +48,7 @@ try:
     # code ugliness is due to https://github.com/python/mypy/issues/8823
     RFF: Any = getattr(gpflux.layers.basis_functions, "RandomFourierFeatures")
 except AttributeError:
-    RFF = getattr(
-        getattr(gpflux.layers.basis_functions, "fourier_features"), "RandomFourierFeaturesCosine"
-    )
+    from gpflux.layers.basis_functions.fourier_features import RandomFourierFeaturesCosine as RFF
 
 
 class IndependentReparametrizationSampler(ReparametrizationSampler[ProbabilisticModel]):


### PR DESCRIPTION
The existing mechanism to guarantee the import for version >= 0.2.7 doesn't work (still generates `AttributeError`). 
Another repo using `trieste==0.11.2` and `gpflux==0.2.7` cannot run tests successfully. 
I've tried several variants but nothing seems to address the issue using the existing mechanism. Here I rely on a direct import, the reassignment is necessary for `mypy`. It works but there's a problem with python==3.9 which is strange since it's not catching and handling the exception.