### PR TITLE
Support gpflux 0.2.7

### DIFF
--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -48,6 +48,8 @@ try:
     # code ugliness is due to https://github.com/python/mypy/issues/8823
     RFF: Any = getattr(gpflux.layers.basis_functions, "RandomFourierFeatures")
 except AttributeError:
+    import gpflux.layers.basis_functions.fourier_features  # needed for 0.2.7
+
     RFF = getattr(
         getattr(gpflux.layers.basis_functions, "fourier_features"), "RandomFourierFeaturesCosine"
     )

--- a/trieste/models/gpflux/sampler.py
+++ b/trieste/models/gpflux/sampler.py
@@ -40,6 +40,8 @@ try:
     # code ugliness is due to https://github.com/python/mypy/issues/8823
     RFF: Any = getattr(gpflux.layers.basis_functions, "RandomFourierFeatures")
 except AttributeError:
+    import gpflux.layers.basis_functions.fourier_features  # needed for 0.2.7
+
     RFF = getattr(
         getattr(gpflux.layers.basis_functions, "fourier_features"), "RandomFourierFeaturesCosine"
     )


### PR DESCRIPTION
The recent changes to support gpflux 0.3.0 and TF 2.8 broke our support for gpflux 0.2.7! This fixes that.

However, we currently only run tests on "production" (gpflux 0.2.3, TF 2.4) and "latest" (which is now gpflux 0.3.0, TF 2.8), so I'm not sure how to test this without adding another test target, which we don't want to do right now. I'll add an issue, though hopefully we'll be able to drop support for 0.2.3 soon anyway.