### PR TITLE
Detect unreachable code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,8 +69,8 @@ $ python notebooks/quickrun/quickrun.py
 ```
 Note that this will modify the notebook files.
 To revert them to what they were before, you can execute the following:
-```python
-python notebooks/quickrun/quickrun.py --revert
+```bash
+$ python notebooks/quickrun/quickrun.py --revert
 ```
 
 # License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ module = ["trieste.*", "tests.*"]
 disallow_any_generics = true
 disallow_untyped_defs = true
 disallow_subclassing_any = true
+warn_unreachable = true
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -264,14 +264,14 @@ def test_optimize_continuous_recovery_runs(
         else:
             return _quadratic_sum([0.5, 0.5])  # return function that is easy to optimize
 
-        optimizer = generate_continuous_optimizer(
-            num_optimization_runs=1, num_recovery_runs=num_recovery_runs
-        )
-        if failed_first_optimization and (num_recovery_runs == 0):
-            with pytest.raises(FailedOptimizationError):
-                optimizer(Box([-1], [1]), _target_fn)
-        else:
+    optimizer = generate_continuous_optimizer(
+        num_optimization_runs=1, num_recovery_runs=num_recovery_runs
+    )
+    if failed_first_optimization and (num_recovery_runs == 0):
+        with pytest.raises(FailedOptimizationError):
             optimizer(Box([-1], [1]), _target_fn)
+    else:
+        optimizer(Box([-1], [1]), _target_fn)
 
 
 def test_optimize_continuous_when_target_raises_exception() -> None:

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -259,10 +259,10 @@ def test_optimize_continuous_recovery_runs(
             )  # check that we do correct number of recovery runs
             currently_failing = False
 
-        if currently_failing:  # return function that is impossible to optimize
-            return _delta_function(10)
+        if currently_failing:  # use function that is impossible to optimize
+            return _delta_function(10)(x)
         else:
-            return _quadratic_sum([0.5, 0.5])  # return function that is easy to optimize
+            return _quadratic_sum([0.5, 0.5])(x)  # use function that is easy to optimize
 
     optimizer = generate_continuous_optimizer(
         num_optimization_runs=1, num_recovery_runs=num_recovery_runs

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -628,7 +628,7 @@ class HIPPO(GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]):
             self._penalization, hippo_penalizer
         ):
             # if possible, just update the penalization function variables
-            self._penalization.update(pending_points)
+            self._penalization.update(pending_points)  # type: ignore[unreachable]  # (confused by tf.function)
             return self._penalized_acquisition
         else:
             # otherwise construct a new penalized acquisition function

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -628,7 +628,8 @@ class HIPPO(GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]):
             self._penalization, hippo_penalizer
         ):
             # if possible, just update the penalization function variables
-            self._penalization.update(pending_points)  # type: ignore[unreachable]  # (confused by tf.function)
+            # (the type ignore is due to mypy getting confused by tf.function)
+            self._penalization.update(pending_points)  # type: ignore[unreachable]
             return self._penalized_acquisition
         else:
             # otherwise construct a new penalized acquisition function

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -279,7 +279,7 @@ def generate_continuous_optimizer(
         )  # Check that at least one optimization was successful for each function
 
         if (
-            not successful_optimization
+            num_recovery_runs and not successful_optimization
         ):  # if all optimizations failed for a function then try again from random starts
             random_points = space.sample(num_recovery_runs)[:, None, :]  # [num_recovery_runs, 1, D]
             tiled_random_points = tf.tile(random_points, [1, V, 1])  # [num_recovery_runs, V, D]

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -161,7 +161,7 @@ def generate_continuous_optimizer(
     num_initial_samples: int = NUM_SAMPLES_MIN,
     num_optimization_runs: int = 10,
     num_recovery_runs: int = 10,
-    optimizer_args: dict[str, Any] = dict(),
+    optimizer_args: Optional[dict[str, Any]] = None,
 ) -> AcquisitionOptimizer[Box | TaggedProductSearchSpace]:
     """
     Generate a gradient-based optimizer for :class:'Box' and :class:'TaggedProductSearchSpace'
@@ -271,7 +271,7 @@ def generate_continuous_optimizer(
             target_func,
             space,
             initial_points,
-            optimizer_args,
+            optimizer_args or {},
         )
 
         successful_optimization = tf.reduce_all(
@@ -289,7 +289,7 @@ def generate_continuous_optimizer(
                 recovery_fun_values,
                 recovery_chosen_x,
             ) = _perform_parallel_continuous_optimization(
-                target_func, space, tiled_random_points, optimizer_args
+                target_func, space, tiled_random_points, optimizer_args or {}
             )
 
             successes = tf.concat(
@@ -466,7 +466,7 @@ class ScipyLbfgsBGreenlet(gr.greenlet):  # type: ignore[misc]
         self,
         start: "np.ndarray[Any, Any]",
         bounds: spo.Bounds,
-        optimizer_args: dict[str, Any] = dict(),
+        optimizer_args: Optional[dict[str, Any]] = None,
     ) -> spo.OptimizeResult:
         cache_x = start + 1  # Any value different from `start`.
         cache_y: Optional["np.ndarray[Any, Any]"] = None
@@ -493,7 +493,7 @@ class ScipyLbfgsBGreenlet(gr.greenlet):  # type: ignore[misc]
             jac=lambda x: value_and_gradient(x)[1],
             method="l-bfgs-b",
             bounds=bounds,
-            **optimizer_args,
+            **(optimizer_args or {}),
         )
 
 

--- a/trieste/models/gpflux/sampler.py
+++ b/trieste/models/gpflux/sampler.py
@@ -247,15 +247,13 @@ class DeepGaussianProcessDecoupledLayer(ABC):
         self._num_features = num_features
         self._layer = layer
 
-        if isinstance(layer.kernel, gpflow.kernels.MultioutputKernel):
-            if not isinstance(layer.kernel, gpflow.kernels.SharedIndependent):
-                raise ValueError(
-                    f"Multioutput kernels other than gpflow.kernels.SharedIndependent are not"
-                    f"currently supported, received {type(layer.kernel)}"
-                )
-            self._kernel = layer.kernel.kernel
-        else:
-            self._kernel = layer.kernel
+        assert isinstance(layer.kernel, gpflow.kernels.MultioutputKernel)
+        if not isinstance(layer.kernel, gpflow.kernels.SharedIndependent):
+            raise ValueError(
+                f"Multioutput kernels other than gpflow.kernels.SharedIndependent are not"
+                f"currently supported, received {type(layer.kernel)}"
+            )
+        self._kernel = layer.kernel.kernel
 
         self._feature_functions = ResampleableDecoupledDeepGaussianProcessFeatureFunctions(
             layer, num_features

--- a/trieste/models/gpflux/sampler.py
+++ b/trieste/models/gpflux/sampler.py
@@ -247,13 +247,17 @@ class DeepGaussianProcessDecoupledLayer(ABC):
         self._num_features = num_features
         self._layer = layer
 
-        assert isinstance(layer.kernel, gpflow.kernels.MultioutputKernel)
-        if not isinstance(layer.kernel, gpflow.kernels.SharedIndependent):
-            raise ValueError(
-                f"Multioutput kernels other than gpflow.kernels.SharedIndependent are not"
-                f"currently supported, received {type(layer.kernel)}"
-            )
-        self._kernel = layer.kernel.kernel
+        if isinstance(layer.kernel, gpflow.kernels.MultioutputKernel):
+            if not isinstance(layer.kernel, gpflow.kernels.SharedIndependent):
+                raise ValueError(
+                    f"Multioutput kernels other than gpflow.kernels.SharedIndependent are not"
+                    f"currently supported, received {type(layer.kernel)}"
+                )
+            self._kernel = layer.kernel.kernel
+        else:
+            # GPLayers are supposed to only use multioutput kernels but we also use them with
+            # simple kernels
+            self._kernel = layer.kernel  # type: ignore[unreachable]
 
         self._feature_functions = ResampleableDecoupledDeepGaussianProcessFeatureFunctions(
             layer, num_features


### PR DESCRIPTION
Enable mypy checking for unreachable code and fix revealed issues: mostly an indentation issue in test_optimize_continuous_recovery_runs, which revealed an actual bug where continuous optimizer raised the wrong exception when num_recovery_runs was 0 due to an empty tensor dtype issue.