### PR TITLE
Fix versioned documentation

### DIFF
--- a/.github/workflows/develop-deploy.yaml
+++ b/.github/workflows/develop-deploy.yaml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        ref: gh-pages-history
+        path: gh-pages-history
     - uses: actions/setup-python@v2
       with:
         python-version: 3.7

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -61,7 +61,7 @@ def test_versions_is_valid(versions: list[dict[str, Any]]) -> None:
         assert isinstance(v, dict)
         assert set(v.keys()) == {"version", "url"}
         assert all(isinstance(value, str) for value in v.values())
-        assert v["url"] == f"../{v['version']}/index.html"
+        assert v["url"] == f"https://secondmind-labs.github.io/trieste/{v['version']}/index.html"
 
 
 def test_version_in_versions(version: str, versions: list[dict[str, Any]]) -> None:

--- a/versions.json
+++ b/versions.json
@@ -1,10 +1,10 @@
 [
   {
     "version": "develop",
-    "url": "../develop/index.html"
+    "url": "https://secondmind-labs.github.io/trieste/develop/index.html"
   },
   {
     "version": "0.11.3",
-    "url": "../0.11.3/index.html"
+    "url": "https://secondmind-labs.github.io/trieste/0.11.3/index.html"
   }
 ]


### PR DESCRIPTION
Fix versioned documentation issues:

- check out pages branch in develop-deploy.yaml
- use full urls in versions.json so that switching works not just at the top level