### PR TITLE
Include VERSION in sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     package_data={
         "trieste": ["py.typed"],
     },
+    data_files=[("", ["VERSION"])],
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Versioned documentation means we need to distribute VERSION with the tar.gz sdist.