### PR TITLE
Log AF values in histogram if vectorized

### DIFF
--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -267,8 +267,14 @@ class EfficientGlobalOptimization(
         if summary_writer:
             with summary_writer.as_default(step=step_number):
                 batched_points = tf.expand_dims(points, axis=0)
-                value = self._acquisition_function(batched_points)[0][0]
-                logging.scalar("EGO.acquisition_function/maximum_found" + "[0]" * greedy, value)
+                if isinstance(self._builder, VectorizedAcquisitionFunctionBuilder):
+                    values = self._acquisition_function(batched_points)[0]
+                    logging.histogram(
+                        "EGO.acquisition_function/maximum_found" + "[0]" * greedy, values
+                    )
+                else:
+                    value = self._acquisition_function(batched_points)[0][0]
+                    logging.scalar("EGO.acquisition_function/maximum_found" + "[0]" * greedy, value)
 
         if isinstance(self._builder, GreedyAcquisitionFunctionBuilder):
             for i in range(
@@ -288,8 +294,14 @@ class EfficientGlobalOptimization(
                 if summary_writer:
                     with summary_writer.as_default(step=step_number):
                         batched_points = tf.expand_dims(chosen_point, axis=0)
-                        value = self._acquisition_function(batched_points)[0][0]
-                        logging.scalar(f"EGO.acquisition_function/maximum_found[{i+1}]", value)
+                        if isinstance(self._builder, VectorizedAcquisitionFunctionBuilder):
+                            values = self._acquisition_function(batched_points)[0]
+                            logging.histogram(
+                                f"EGO.acquisition_function/maximum_found[{i+1}]", values
+                            )
+                        else:
+                            value = self._acquisition_function(batched_points)[0][0]
+                            logging.scalar(f"EGO.acquisition_function/maximum_found[{i+1}]", value)
 
         return points
 

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -267,14 +267,15 @@ class EfficientGlobalOptimization(
         if summary_writer:
             with summary_writer.as_default(step=step_number):
                 batched_points = tf.expand_dims(points, axis=0)
-                if isinstance(self._builder, VectorizedAcquisitionFunctionBuilder):
-                    values = self._acquisition_function(batched_points)[0]
+                values = self._acquisition_function(batched_points)[0]
+                if len(values) == 1:
+                    logging.scalar(
+                        "EGO.acquisition_function/maximum_found" + "[0]" * greedy, values[0]
+                    )
+                else:  # vectorized acquisition function
                     logging.histogram(
                         "EGO.acquisition_function/maximum_found" + "[0]" * greedy, values
                     )
-                else:
-                    value = self._acquisition_function(batched_points)[0][0]
-                    logging.scalar("EGO.acquisition_function/maximum_found" + "[0]" * greedy, value)
 
         if isinstance(self._builder, GreedyAcquisitionFunctionBuilder):
             for i in range(
@@ -294,14 +295,15 @@ class EfficientGlobalOptimization(
                 if summary_writer:
                     with summary_writer.as_default(step=step_number):
                         batched_points = tf.expand_dims(chosen_point, axis=0)
-                        if isinstance(self._builder, VectorizedAcquisitionFunctionBuilder):
-                            values = self._acquisition_function(batched_points)[0]
+                        values = self._acquisition_function(batched_points)[0]
+                        if len(values) == 1:
+                            logging.scalar(
+                                f"EGO.acquisition_function/maximum_found[{i + 1}]", values[0]
+                            )
+                        else:  # vectorized acquisition function
                             logging.histogram(
                                 f"EGO.acquisition_function/maximum_found[{i+1}]", values
                             )
-                        else:
-                            value = self._acquisition_function(batched_points)[0][0]
-                            logging.scalar(f"EGO.acquisition_function/maximum_found[{i+1}]", value)
 
         return points
 


### PR DESCRIPTION
The code for logging acquisition function values wasn't handling vectorised acquisition functions and was just logging one value as a scalar.