### PR TITLE
model optimization history not deep copied

### DIFF
--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -417,3 +417,22 @@ def test_deepgp_deep_copies_different_callback_types(callbacks: list[Callback]) 
     assert tuple(type(callback) for callback in model.optimizer.fit_args["callbacks"]) == tuple(
         type(callback) for callback in model_copy.optimizer.fit_args["callbacks"]
     )
+
+
+def test_deepgp_deep_copies_optimization_history() -> None:
+    x = tf.constant(np.arange(5).reshape(-1, 1), dtype=gpflow.default_float())
+    model = DeepGaussianProcess(partial(single_layer_dgp_model, x))
+    dataset = Dataset(x, fnc_3x_plus_10(x))
+    model.update(dataset)
+    model.optimize(dataset)
+
+    assert model.model_keras.history.history
+    expected_history = model.model_keras.history.history
+
+    model_copy = copy.deepcopy(model)
+    assert model_copy.model_keras.history.history
+    history = model_copy.model_keras.history.history
+
+    assert history.keys() == expected_history.keys()
+    for k, v in expected_history.items():
+        assert history[k] == v

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -604,3 +604,21 @@ def test_deep_ensemble_deep_copies_optimizer_without_callbacks() -> None:
     model_copy = copy.deepcopy(model)
     assert model_copy.optimizer is not model.optimizer
     assert model_copy.optimizer.fit_args == model.optimizer.fit_args
+
+
+def test_deep_ensemble_deep_copies_optimization_history() -> None:
+    example_data = _get_example_data([10, 3], [10, 3])
+    keras_ensemble = trieste_keras_ensemble_model(example_data, _ENSEMBLE_SIZE, False)
+    model = DeepEnsemble(keras_ensemble)
+    model.optimize(example_data)
+
+    assert model.model.history.history
+    expected_history = model.model.history.history
+
+    model_copy = copy.deepcopy(model)
+    assert model_copy.model.history.history
+    history = model_copy.model.history.history
+
+    assert history.keys() == expected_history.keys()
+    for k, v in expected_history.items():
+        assert history[k] == v


### PR DESCRIPTION
added unit tests that show this for DeepEnsemble and DeepGaussianProcess
I haven't checked for gpflow models, most likely something similar happens there...