### PR TITLE
Deepcopy keras model history callback

### DIFF
--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -417,3 +417,22 @@ def test_deepgp_deep_copies_different_callback_types(callbacks: list[Callback]) 
     assert tuple(type(callback) for callback in model.optimizer.fit_args["callbacks"]) == tuple(
         type(callback) for callback in model_copy.optimizer.fit_args["callbacks"]
     )
+
+
+def test_deepgp_deep_copies_optimization_history() -> None:
+    x = tf.constant(np.arange(5).reshape(-1, 1), dtype=gpflow.default_float())
+    model = DeepGaussianProcess(partial(single_layer_dgp_model, x))
+    dataset = Dataset(x, fnc_3x_plus_10(x))
+    model.update(dataset)
+    model.optimize(dataset)
+
+    assert model.model_keras.history.history
+    expected_history = model.model_keras.history.history
+
+    model_copy = copy.deepcopy(model)
+    assert model_copy.model_keras.history.history
+    history = model_copy.model_keras.history.history
+
+    assert history.keys() == expected_history.keys()
+    for k, v in expected_history.items():
+        assert history[k] == v

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -604,3 +604,21 @@ def test_deep_ensemble_deep_copies_optimizer_without_callbacks() -> None:
     model_copy = copy.deepcopy(model)
     assert model_copy.optimizer is not model.optimizer
     assert model_copy.optimizer.fit_args == model.optimizer.fit_args
+
+
+def test_deep_ensemble_deep_copies_optimization_history() -> None:
+    example_data = _get_example_data([10, 3], [10, 3])
+    keras_ensemble = trieste_keras_ensemble_model(example_data, _ENSEMBLE_SIZE, False)
+    model = DeepEnsemble(keras_ensemble)
+    model.optimize(example_data)
+
+    assert model.model.history.history
+    expected_history = model.model.history.history
+
+    model_copy = copy.deepcopy(model)
+    assert model_copy.model.history.history
+    history = model_copy.model.history.history
+
+    assert history.keys() == expected_history.keys()
+    for k, v in expected_history.items():
+        assert history[k] == v

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Any, Callable, Sequence
 
+import dill
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -109,6 +110,19 @@ class KerasEnsemble:
         state = self.__dict__.copy()
         state["_model"] = self._model.to_json()
         state["_weights"] = self._model.get_weights()
+
+        # Save the history callback (serializing any model)
+        history_model = self._model.history.model
+        try:
+            if history_model is self._model:
+                # no need to serialize the main model, just use a special value instead
+                self._model.history.model = ...
+            elif history_model:
+                self._model.history.model = (history_model.to_json(), history_model.get_weights())
+            state["_history"] = dill.dumps(self._model.history)
+        finally:
+            self._model.history.model = history_model
+
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -118,6 +132,19 @@ class KerasEnsemble:
             state["_model"], custom_objects={"MultivariateNormalTriL": MultivariateNormalTriL}
         )
         self._model.set_weights(state["_weights"])
+
+        # Restore the history (including any model)
+        self._model.history = dill.loads(self._history)
+        if self._model.history.model is ...:
+            self._model.history.set_model(self._model)
+        elif self._model.history.model:
+            model_json, weights = self._model.history.model
+            model = tf.keras.models.model_from_json(
+                model_json,
+                custom_objects={"MultivariateNormalTriL": MultivariateNormalTriL},
+            )
+            model.set_weights(weights)
+            self._model.history.set_model(model)
 
 
 class KerasEnsembleNetwork:

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -133,8 +133,8 @@ class KerasEnsemble:
         )
         self._model.set_weights(state["_weights"])
 
-        # Restore the history (including any model)
-        self._model.history = dill.loads(self._history)
+        # Restore the history (including any model it contains)
+        self._model.history = dill.loads(state["_history"])
         if self._model.history.model is ...:
             self._model.history.set_model(self._model)
         elif self._model.history.model:

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -411,17 +411,16 @@ class DeepEnsemble(
         # Unpickle the optimizer, and restore all the callback models
         self._optimizer = dill.loads(self._optimizer)
         for callback in self._optimizer.fit_args.get("callbacks", []):
-            if callback.model:
-                if callback.model is ...:
-                    callback.set_model(self.model)
-                elif callback.model:
-                    model_json, weights = callback.model
-                    model = tf.keras.models.model_from_json(
-                        model_json,
-                        custom_objects={"MultivariateNormalTriL": MultivariateNormalTriL},
-                    )
-                    model.set_weights(weights)
-                    callback.set_model(model)
+            if callback.model is ...:
+                callback.set_model(self.model)
+            elif callback.model:
+                model_json, weights = callback.model
+                model = tf.keras.models.model_from_json(
+                    model_json,
+                    custom_objects={"MultivariateNormalTriL": MultivariateNormalTriL},
+                )
+                model.set_weights(weights)
+                callback.set_model(model)
 
         # Recompile the model
         self.model.compile(


### PR DESCRIPTION
Turns out the history callback is created automatically and stored separately from the other callbacks. Make sure we copy it (handling the fact that, like other callbacks, it may contain a non-pickleable model).

The other callback that's added automatically is ProgbarLogger for logging, but that's not stored so we don't need to copy it.