### PR TITLE
Make AF builders generic in the AF type

### DIFF
--- a/tests/integration/test_active_learning.py
+++ b/tests/integration/test_active_learning.py
@@ -58,7 +58,7 @@ from trieste.types import TensorType
 @pytest.mark.parametrize(
     "num_steps, acquisition_rule",
     [
-        (50, EfficientGlobalOptimization[SearchSpace, SupportsPredictJoint](PredictiveVariance())),
+        (50, EfficientGlobalOptimization(PredictiveVariance())),
         (
             70,
             EfficientGlobalOptimization(

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -39,6 +39,7 @@ from trieste.acquisition import (
     MonteCarloExpectedImprovement,
     MultipleOptimismNegativeLowerConfidenceBound,
     ParallelContinuousThompsonSampling,
+    expected_improvement,
 )
 from trieste.acquisition.optimizer import generate_continuous_optimizer
 from trieste.acquisition.rule import (
@@ -239,7 +240,7 @@ def test_bayesian_optimizer_with_vgp_finds_minima_of_scaled_branin() -> None:
     _test_optimizer_finds_minimum(
         VariationalGaussianProcess,
         10,
-        EfficientGlobalOptimization[SearchSpace, VariationalGaussianProcess](
+        EfficientGlobalOptimization[SearchSpace, VariationalGaussianProcess, TrajectoryFunction](
             builder=ParallelContinuousThompsonSampling(), num_query_points=5
         ),
     )
@@ -253,7 +254,7 @@ def test_bayesian_optimizer_with_vgp_finds_minima_of_simple_quadratic(use_natgra
     _test_optimizer_finds_minimum(
         VariationalGaussianProcess,
         None if use_natgrads else 5,
-        EfficientGlobalOptimization[SearchSpace, GPflowPredictor](),
+        EfficientGlobalOptimization[SearchSpace, GPflowPredictor, expected_improvement](),
         model_args={"use_natgrads": use_natgrads},
     )
 
@@ -264,14 +265,14 @@ def test_bayesian_optimizer_with_svgp_finds_minima_of_scaled_branin() -> None:
     _test_optimizer_finds_minimum(
         SparseVariational,
         40,
-        EfficientGlobalOptimization[SearchSpace, SparseVariational](),
+        EfficientGlobalOptimization[SearchSpace, SparseVariational, expected_improvement](),
         optimize_branin=True,
         model_args={"optimizer": Optimizer(gpflow.optimizers.Scipy(), compile=True)},
     )
     _test_optimizer_finds_minimum(
         SparseVariational,
         15,
-        EfficientGlobalOptimization[SearchSpace, SparseVariational](
+        EfficientGlobalOptimization[SearchSpace, SparseVariational, TrajectoryFunction](
             builder=ParallelContinuousThompsonSampling(), num_query_points=5
         ),
         optimize_branin=True,
@@ -284,7 +285,7 @@ def test_bayesian_optimizer_with_svgp_finds_minima_of_simple_quadratic() -> None
     _test_optimizer_finds_minimum(
         SparseVariational,
         5,
-        EfficientGlobalOptimization[SearchSpace, SparseVariational](),
+        EfficientGlobalOptimization[SearchSpace, SparseVariational, expected_improvement](),
         model_args={"optimizer": Optimizer(gpflow.optimizers.Scipy(), compile=True)},
     )
 
@@ -295,15 +296,17 @@ def test_bayesian_optimizer_with_sgpr_finds_minima_of_scaled_branin() -> None:
     _test_optimizer_finds_minimum(
         SparseGaussianProcessRegression,
         9,
-        EfficientGlobalOptimization[SearchSpace, SparseGaussianProcessRegression](),
+        EfficientGlobalOptimization[
+            SearchSpace, SparseGaussianProcessRegression, expected_improvement
+        ](),
         optimize_branin=True,
     )
     _test_optimizer_finds_minimum(
         SparseGaussianProcessRegression,
         20,
-        EfficientGlobalOptimization[SearchSpace, SparseGaussianProcessRegression](
-            builder=ParallelContinuousThompsonSampling(), num_query_points=5
-        ),
+        EfficientGlobalOptimization[
+            SearchSpace, SparseGaussianProcessRegression, TrajectoryFunction
+        ](builder=ParallelContinuousThompsonSampling(), num_query_points=5),
         optimize_branin=True,
     )
 
@@ -313,7 +316,9 @@ def test_bayesian_optimizer_with_sgpr_finds_minima_of_simple_quadratic() -> None
     _test_optimizer_finds_minimum(
         SparseGaussianProcessRegression,
         5,
-        EfficientGlobalOptimization[SearchSpace, SparseGaussianProcessRegression](),
+        EfficientGlobalOptimization[
+            SearchSpace, SparseGaussianProcessRegression, expected_improvement
+        ](),
     )
 
 

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -28,7 +28,6 @@ from _pytest.mark import ParameterSet
 from tests.util.misc import random_seed
 from trieste.acquisition import (
     GIBBON,
-    AcquisitionFunctionClass,
     AugmentedExpectedImprovement,
     BatchMonteCarloExpectedImprovement,
     Fantasizer,
@@ -634,7 +633,7 @@ def _test_optimizer_finds_minimum(
 
                 # check that acquisition functions defined as classes aren't retraced unnecessarily
                 # they should be retraced for the optimzier's starting grid, L-BFGS, and logging
-                if isinstance(acq_function, (AcquisitionFunctionClass, TrajectoryFunctionClass)):
+                if hasattr(acq_function, "__call__"):
                     assert acq_function.__call__._get_tracing_count() == 3  # type: ignore
 
                 # update trajectory function if necessary, so we can test it

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -59,7 +59,7 @@ from trieste.bayesian_optimizer import (
     stop_at_minimum,
 )
 from trieste.logging import tensorboard_writer
-from trieste.models import TrainableProbabilisticModel, TrajectoryFunctionClass
+from trieste.models import TrainableProbabilisticModel, TrajectoryFunction
 from trieste.models.gpflow import (
     GaussianProcessRegression,
     GPflowPredictor,
@@ -634,10 +634,10 @@ def _test_optimizer_finds_minimum(
                 # check that acquisition functions defined as classes aren't retraced unnecessarily
                 # they should be retraced for the optimzier's starting grid, L-BFGS, and logging
                 if hasattr(acq_function, "__call__"):
-                    assert acq_function.__call__._get_tracing_count() == 3  # type: ignore
+                    assert acq_function.__call__._get_tracing_count() == 3
 
                 # update trajectory function if necessary, so we can test it
-                if isinstance(acq_function, TrajectoryFunctionClass):
+                if isinstance(acq_function, TrajectoryFunction):
                     sampler = (
                         acquisition_rule._builder.single_builder._trajectory_sampler  # type: ignore
                     )

--- a/tests/integration/test_constrained_bayesian_optimization.py
+++ b/tests/integration/test_constrained_bayesian_optimization.py
@@ -20,7 +20,11 @@ import pytest
 import tensorflow as tf
 
 from tests.util.misc import random_seed
-from trieste.acquisition import ExpectedConstrainedImprovement, ProbabilityOfFeasibility
+from trieste.acquisition import (
+    AcquisitionFunction,
+    ExpectedConstrainedImprovement,
+    ProbabilityOfFeasibility,
+)
 from trieste.acquisition.rule import EfficientGlobalOptimization
 from trieste.bayesian_optimizer import BayesianOptimizer
 from trieste.data import Dataset
@@ -39,7 +43,9 @@ from trieste.types import TensorType
 )
 def test_optimizer_finds_minima_of_Gardners_Simulation_1(
     num_steps: int,
-    acquisition_function_builder: type[ExpectedConstrainedImprovement[ProbabilisticModel]],
+    acquisition_function_builder: type[
+        ExpectedConstrainedImprovement[ProbabilisticModel, AcquisitionFunction]
+    ],
 ) -> None:
     """
     Test that tests the covergence of constrained BO algorithms on the
@@ -80,7 +86,9 @@ def test_optimizer_finds_minima_of_Gardners_Simulation_1(
 
     pof = ProbabilityOfFeasibility(threshold=0.5)
     acq = acquisition_function_builder(OBJECTIVE, pof.using(CONSTRAINT))
-    rule: EfficientGlobalOptimization[Box, ProbabilisticModel] = EfficientGlobalOptimization(acq)
+    rule: EfficientGlobalOptimization[
+        Box, ProbabilisticModel, AcquisitionFunction
+    ] = EfficientGlobalOptimization(acq)
 
     dataset = (
         BayesianOptimizer(observer, search_space)

--- a/tests/integration/test_mixed_space_bayesian_optimization.py
+++ b/tests/integration/test_mixed_space_bayesian_optimization.py
@@ -18,11 +18,7 @@ import pytest
 import tensorflow as tf
 
 from tests.util.misc import random_seed
-from trieste.acquisition import (
-    AcquisitionFunctionClass,
-    BatchMonteCarloExpectedImprovement,
-    LocalPenalization,
-)
+from trieste.acquisition import BatchMonteCarloExpectedImprovement, LocalPenalization
 from trieste.acquisition.rule import AcquisitionRule, EfficientGlobalOptimization
 from trieste.bayesian_optimizer import BayesianOptimizer
 from trieste.models import TrainableProbabilisticModel
@@ -98,5 +94,5 @@ def test_optimizer_finds_minima_of_the_scaled_branin_function(
     # They should be retraced once for the optimzier's starting grid and once for L-BFGS.
     if isinstance(acquisition_rule, EfficientGlobalOptimization):
         acquisition_function = acquisition_rule._acquisition_function
-        if isinstance(acquisition_function, AcquisitionFunctionClass):
+        if hasattr(acquisition_function, "__call__"):
             assert acquisition_function.__call__._get_tracing_count() <= 3  # type: ignore

--- a/tests/unit/acquisition/function/test_active_learning.py
+++ b/tests/unit/acquisition/function/test_active_learning.py
@@ -171,18 +171,18 @@ def test_expected_feasibility_builder_updates_without_retracing(delta: int) -> N
     model = QuadraticMeanAndRBFKernel()
     builder = ExpectedFeasibility(threshold, alpha, delta)
     acq_fn = builder.prepare_acquisition_function(model)
-    assert acq_fn._get_tracing_count() == 0  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 0
 
     query_at = tf.linspace([[-10]], [[10]], 100)
     expected = bichon_ranjan_criterion(model, threshold, alpha, delta)(query_at)
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
-    assert acq_fn._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
     up_acq_fn = builder.update_acquisition_function(acq_fn, model)
     assert up_acq_fn == acq_fn
 
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
-    assert acq_fn._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
 
 @pytest.mark.parametrize("shape", various_shapes() - {()})

--- a/tests/unit/acquisition/function/test_active_learning.py
+++ b/tests/unit/acquisition/function/test_active_learning.py
@@ -118,16 +118,16 @@ def test_predictive_variance_builder_updates_without_retracing() -> None:
     model = QuadraticMeanAndRBFKernel()
     builder = PredictiveVariance()
     acq_fn = builder.prepare_acquisition_function(model)
-    assert acq_fn._get_tracing_count() == 0  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 0
     query_at = tf.linspace([[-10]], [[10]], 100)
     expected = predictive_variance(model, DEFAULTS.JITTER)(query_at)
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
-    assert acq_fn._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
     up_acq_fn = builder.update_acquisition_function(acq_fn, model)
     assert up_acq_fn == acq_fn
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
-    assert acq_fn._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
 
 @pytest.mark.parametrize("delta", [1, 2])

--- a/tests/unit/acquisition/function/test_active_learning.py
+++ b/tests/unit/acquisition/function/test_active_learning.py
@@ -383,18 +383,18 @@ def test_integrated_variance_reduction_builder_updates_without_retracing() -> No
 
     builder = IntegratedVarianceReduction(integration_points, threshold)
     acq_fn = builder.prepare_acquisition_function(model)
-    assert acq_fn.__call__._get_tracing_count() == 0  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 0
 
     query_at = tf.linspace([[-10]], [[10]], 100)
     expected = integrated_variance_reduction(model, integration_points, threshold)(query_at)
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
-    assert acq_fn.__call__._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
     up_acq_fn = builder.update_acquisition_function(acq_fn, model)
     assert up_acq_fn == acq_fn
 
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
-    assert acq_fn.__call__._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
 
 @pytest.mark.parametrize(
@@ -504,16 +504,16 @@ def test_bayesian_active_learning_by_disagreement_builder_updates_without_retrac
     builder = BayesianActiveLearningByDisagreement()
     acq_fn = builder.prepare_acquisition_function(model)
 
-    assert acq_fn.__call__._get_tracing_count() == 0  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 0
 
     query_at = tf.linspace([[-10]], [[10]], 100)
     expected = bayesian_active_learning_by_disagreement(model, DEFAULTS.JITTER)(query_at)
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
 
-    assert acq_fn.__call__._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
     up_acq_fn = builder.update_acquisition_function(acq_fn, model)
     assert up_acq_fn == acq_fn
 
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
-    assert acq_fn.__call__._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1

--- a/tests/unit/acquisition/function/test_continuous_thompson_sampling.py
+++ b/tests/unit/acquisition/function/test_continuous_thompson_sampling.py
@@ -31,7 +31,7 @@ from trieste.acquisition.function.continuous_thompson_sampling import (
 )
 from trieste.acquisition.function.function import lower_confidence_bound
 from trieste.data import Dataset
-from trieste.models import TrajectoryFunction, TrajectoryFunctionClass, TrajectorySampler
+from trieste.models import TrajectoryFunction, TrajectorySampler
 from trieste.models.gpflow import (
     RandomFourierFeatureTrajectorySampler,
     feature_decomposition_trajectory,
@@ -78,9 +78,9 @@ def test_greedy_thompson_sampling_builder_builds_trajectory(dumb_samplers: bool)
     )  # need a gpflow kernel object for random feature decompositions
     builder = GreedyContinuousThompsonSampling()
     acq_fn = builder.prepare_acquisition_function(model)
-    assert isinstance(acq_fn, TrajectoryFunctionClass)
+    assert isinstance(acq_fn, TrajectoryFunction)
     new_acq_fn = builder.update_acquisition_function(acq_fn, model)
-    assert isinstance(new_acq_fn, TrajectoryFunctionClass)
+    assert isinstance(new_acq_fn, TrajectoryFunction)
 
 
 @pytest.mark.parametrize("dumb_samplers", [True, False])
@@ -100,7 +100,8 @@ def test_greedy_thompson_sampling_builder_raises_when_update_with_wrong_function
     builder = GreedyContinuousThompsonSampling()
     builder.prepare_acquisition_function(model)
     with pytest.raises(tf.errors.InvalidArgumentError):
-        builder.update_acquisition_function(lower_confidence_bound(model, 0.1), model)
+        function = lower_confidence_bound(model, 0.1)
+        builder.update_acquisition_function(function, model)  # type: ignore
 
 
 def test_parallel_thompson_sampling_raises_for_model_without_trajectory_sampler() -> None:
@@ -126,10 +127,10 @@ def test_parallel_thompson_sampling_builder_builds_trajectory(dumb_samplers: boo
     )  # need a gpflow kernel object for random feature decompositions
     builder = ParallelContinuousThompsonSampling()
     acq_fn = builder.prepare_acquisition_function(model)
-    assert isinstance(acq_fn, TrajectoryFunctionClass)
+    assert isinstance(acq_fn, TrajectoryFunction)
     assert acq_fn.__class__.__name__ == "NegatedTrajectory"
     new_acq_fn = builder.update_acquisition_function(acq_fn, model)
-    assert isinstance(new_acq_fn, TrajectoryFunctionClass)
+    assert isinstance(new_acq_fn, TrajectoryFunction)
     assert new_acq_fn.__class__.__name__ == "NegatedTrajectory"
 
 
@@ -150,7 +151,8 @@ def test_parallel_thompson_sampling_builder_raises_when_update_with_wrong_functi
     builder = ParallelContinuousThompsonSampling()
     builder.prepare_acquisition_function(model)
     with pytest.raises(ValueError):
-        builder.update_acquisition_function(lower_confidence_bound(model, 0.1), model)
+        function = lower_confidence_bound(model, 0.1)
+        builder.update_acquisition_function(function, model)  # type: ignore
 
 
 def test_parallel_thompson_sampling_raises_for_changing_batch_size() -> None:

--- a/tests/unit/acquisition/function/test_function.py
+++ b/tests/unit/acquisition/function/test_function.py
@@ -87,11 +87,11 @@ def test_expected_improvement_builder_updates_expected_improvement_using_best_fr
     )
     model = QuadraticMeanAndRBFKernel()
     acq_fn = ExpectedImprovement().prepare_acquisition_function(model, dataset=dataset)
-    assert acq_fn.__call__._get_tracing_count() == 0  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 0
     xs = tf.linspace([[-10.0]], [[10.0]], 100)
     expected = expected_improvement(model, tf.constant([1.0]))(xs)
     npt.assert_allclose(acq_fn(xs), expected)
-    assert acq_fn.__call__._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
     new_dataset = Dataset(
         tf.concat([dataset.query_points, tf.constant([[0.0], [1.0], [2.0]])], 0),
@@ -103,7 +103,7 @@ def test_expected_improvement_builder_updates_expected_improvement_using_best_fr
     assert updated_acq_fn == acq_fn
     expected = expected_improvement(model, tf.constant([0.0]))(xs)
     npt.assert_allclose(acq_fn(xs), expected)
-    assert acq_fn.__call__._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
 
 def test_expected_improvement_builder_raises_for_empty_data() -> None:
@@ -382,7 +382,7 @@ def test_mc_expected_improvement_close_to_expected_improvement(
 
     best = tf.reduce_min(Branin.objective(dataset.query_points))
     eif = expected_improvement(model, best)
-    ei = eif(xs[..., None, :])  # type: ignore
+    ei = eif(xs[..., None, :])
 
     npt.assert_allclose(ei, ei_approx, rtol=rtol, atol=atol)
 
@@ -397,17 +397,17 @@ def test_mc_expected_improvement_updates_without_retracing() -> None:
     xs = tf.random.uniform([5, 1, 2], dtype=tf.float64)
 
     mcei = builder.prepare_acquisition_function(model, dataset=data)
-    assert mcei.__call__._get_tracing_count() == 0  # type: ignore
+    assert mcei.__call__._get_tracing_count() == 0
     npt.assert_allclose(mcei(xs), ei(xs), rtol=0.06)
-    assert mcei.__call__._get_tracing_count() == 1  # type: ignore
+    assert mcei.__call__._get_tracing_count() == 1
 
     data = Dataset(known_query_points, quadratic(known_query_points))
     up_mcei = builder.update_acquisition_function(mcei, model, dataset=data)
     ei = ExpectedImprovement().prepare_acquisition_function(model, dataset=data)
     assert up_mcei == mcei
-    assert mcei.__call__._get_tracing_count() == 1  # type: ignore
+    assert mcei.__call__._get_tracing_count() == 1
     npt.assert_allclose(mcei(xs), ei(xs), rtol=0.06)
-    assert mcei.__call__._get_tracing_count() == 1  # type: ignore
+    assert mcei.__call__._get_tracing_count() == 1
 
 
 @pytest.mark.parametrize("sample_size", [-2, 0])
@@ -552,7 +552,7 @@ def test_mc_augmented_expected_improvement_close_to_augmented_expected_improveme
 
     best = tf.reduce_min(Branin.objective(dataset.query_points))
     aeif = augmented_expected_improvement(model, best)
-    aei = aeif(xs[..., None, :])  # type: ignore
+    aei = aeif(xs[..., None, :])
 
     npt.assert_allclose(aei, aei_approx, rtol=rtol, atol=atol)
 
@@ -568,17 +568,17 @@ def test_mc_augmented_expected_improvement_updates_without_retracing() -> None:
     xs = tf.random.uniform([5, 1, 2], dtype=tf.float64)
 
     mcaei = builder.prepare_acquisition_function(model, dataset=data)
-    assert mcaei.__call__._get_tracing_count() == 0  # type: ignore
+    assert mcaei.__call__._get_tracing_count() == 0
     npt.assert_allclose(mcaei(xs), aei(xs), rtol=0.06)
-    assert mcaei.__call__._get_tracing_count() == 1  # type: ignore
+    assert mcaei.__call__._get_tracing_count() == 1
 
     data = Dataset(known_query_points, quadratic(known_query_points))
     up_mcaei = builder.update_acquisition_function(mcaei, model, dataset=data)
     aei = AugmentedExpectedImprovement().prepare_acquisition_function(model, dataset=data)
     assert up_mcaei == mcaei
-    assert mcaei.__call__._get_tracing_count() == 1  # type: ignore
+    assert mcaei.__call__._get_tracing_count() == 1
     npt.assert_allclose(mcaei(xs), aei(xs), rtol=0.06)
-    assert mcaei.__call__._get_tracing_count() == 1  # type: ignore
+    assert mcaei.__call__._get_tracing_count() == 1
 
 
 def test_negative_lower_confidence_bound_builder_builds_negative_lower_confidence_bound() -> None:
@@ -979,17 +979,17 @@ def test_batch_monte_carlo_expected_improvement_updates_without_retracing() -> N
     xs = tf.random.uniform([3, 5, 1, 2], dtype=tf.float64)
 
     batch_ei = builder.prepare_acquisition_function(model, dataset=data)
-    assert batch_ei.__call__._get_tracing_count() == 0  # type: ignore
+    assert batch_ei.__call__._get_tracing_count() == 0
     npt.assert_allclose(batch_ei(xs), ei(xs), rtol=0.06)
-    assert batch_ei.__call__._get_tracing_count() == 1  # type: ignore
+    assert batch_ei.__call__._get_tracing_count() == 1
 
     data = Dataset(known_query_points, quadratic(known_query_points))
     up_batch_ei = builder.update_acquisition_function(batch_ei, model, dataset=data)
     ei = ExpectedImprovement().update_acquisition_function(ei, model, dataset=data)
     assert up_batch_ei == batch_ei
-    assert batch_ei.__call__._get_tracing_count() == 1  # type: ignore
+    assert batch_ei.__call__._get_tracing_count() == 1
     npt.assert_allclose(batch_ei(xs), ei(xs), rtol=0.06)
-    assert batch_ei.__call__._get_tracing_count() == 1  # type: ignore
+    assert batch_ei.__call__._get_tracing_count() == 1
 
 
 def test_multiple_optimism_builder_builds_negative_lower_confidence_bound() -> None:
@@ -1008,16 +1008,16 @@ def test_multiple_optimism_builder_updates_without_retracing() -> None:
     search_space = Box([0, 0], [1, 1])
     builder = MultipleOptimismNegativeLowerConfidenceBound(search_space)
     acq_fn = builder.prepare_acquisition_function(model)
-    assert acq_fn.__call__._get_tracing_count() == 0  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 0
     query_at = tf.reshape(tf.linspace([[-10]], [[10]], 100), [10, 5, 2])
     expected = multiple_optimism_lower_confidence_bound(model, search_space.dimension)(query_at)
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
-    assert acq_fn.__call__._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
     up_acq_fn = builder.update_acquisition_function(acq_fn, model)
     assert up_acq_fn == acq_fn
     npt.assert_array_almost_equal(acq_fn(query_at), expected)
-    assert acq_fn.__call__._get_tracing_count() == 1  # type: ignore
+    assert acq_fn.__call__._get_tracing_count() == 1
 
 
 def test_multiple_optimism_builder_raises_when_update_with_wrong_function() -> None:

--- a/tests/unit/acquisition/function/test_greedy_batch.py
+++ b/tests/unit/acquisition/function/test_greedy_batch.py
@@ -279,8 +279,8 @@ def test_fantasize_reduces_predictive_variance(model_type: str, fantasize_method
     builder = Fantasizer(PredictiveVariance(), fantasize_method=fantasize_method)
     acq0 = builder.prepare_acquisition_function(models, data)
     acq1 = builder.update_acquisition_function(acq0, models, data, pending_points[:1])
-    assert acq0._get_tracing_count() == 0  # type: ignore
-    assert acq1._get_tracing_count() == 0  # type: ignore
+    assert acq0.__call__._get_tracing_count() == 0
+    assert acq1.__call__._get_tracing_count() == 0
 
     acq_val0 = acq0(x_test)
     acq_val1 = acq1(x_test)
@@ -290,13 +290,13 @@ def test_fantasize_reduces_predictive_variance(model_type: str, fantasize_method
     acq1_up = builder.update_acquisition_function(acq1, models, data, pending_points)
     assert acq1_up == acq1  # in-place updates
     acq1_up(x_test)
-    assert acq1_up._get_tracing_count() == 1  # type: ignore
+    assert acq1_up.__call__._get_tracing_count() == 1
 
     # ...and the base functions
     acq0_up = builder.update_acquisition_function(acq1, models, data)
     assert acq0_up == acq0  # in-place updates
     acq0_up(x_test)
-    assert acq0_up._get_tracing_count() == 1  # type: ignore
+    assert acq0_up.__call__._get_tracing_count() == 1
 
 
 @pytest.mark.parametrize("model_type", ["gpr", "stack"])

--- a/tests/unit/acquisition/multi_objective/test_function.py
+++ b/tests/unit/acquisition/multi_objective/test_function.py
@@ -850,7 +850,9 @@ def test_hippo_builder_raises_for_empty_data() -> None:
     num_obj = 3
     dataset = {"": empty_dataset([2], [num_obj])}
     model = {"": QuadraticMeanAndRBFKernel()}
-    hippo = cast(GreedyAcquisitionFunctionBuilder[QuadraticMeanAndRBFKernel], HIPPO(""))
+    hippo = cast(
+        GreedyAcquisitionFunctionBuilder[QuadraticMeanAndRBFKernel], HIPPO(objective_tag="")
+    )
 
     with pytest.raises(tf.errors.InvalidArgumentError):
         hippo.prepare_acquisition_function(model, dataset)
@@ -914,7 +916,7 @@ def test_hippo_penalized_acquisitions_match_base_acquisition(
     model = {"": _mo_test_model(2, *[None] * 2)}
 
     hippo_acq_builder: HIPPO[ProbabilisticModel] = HIPPO(
-        "", base_acquisition_function_builder=base_builder
+        objective_tag="", base_acquisition_function_builder=base_builder
     )
     hippo_acq = hippo_acq_builder.prepare_acquisition_function(model, data, None)
 
@@ -945,7 +947,7 @@ def test_hippo_penalized_acquisitions_combine_base_and_penalization_correctly(
     pending_points = tf.zeros([2, 2], dtype=tf.float64)
 
     hippo_acq_builder: HIPPO[ProbabilisticModel] = HIPPO(
-        "", base_acquisition_function_builder=base_builder
+        objective_tag="", base_acquisition_function_builder=base_builder
     )
     hippo_acq = hippo_acq_builder.prepare_acquisition_function(model, data, pending_points)
     base_acq = base_builder.prepare_acquisition_function(model, data)

--- a/tests/unit/acquisition/test_combination.py
+++ b/tests/unit/acquisition/test_combination.py
@@ -45,7 +45,7 @@ def test_reducer__repr_builders() -> None:
 
         _reduce = raise_exc
 
-    class Builder(AcquisitionFunctionBuilder[ProbabilisticModel]):
+    class Builder(AcquisitionFunctionBuilder[ProbabilisticModel, AcquisitionFunction]):
         def __init__(self, name: str):
             self._name = name
 
@@ -63,7 +63,7 @@ def test_reducer__repr_builders() -> None:
     assert repr(Dummy(Builder("foo"), Builder("bar"))) == "Dummy(Builder('foo'), Builder('bar'))"
 
 
-class _Static(AcquisitionFunctionBuilder[ProbabilisticModel]):
+class _Static(AcquisitionFunctionBuilder[ProbabilisticModel, AcquisitionFunction]):
     def __init__(self, f: AcquisitionFunction):
         self._f = f
 

--- a/tests/unit/acquisition/test_interface.py
+++ b/tests/unit/acquisition/test_interface.py
@@ -43,7 +43,9 @@ from trieste.types import TensorType
 from trieste.utils import DEFAULTS
 
 
-class _ArbitrarySingleBuilder(SingleModelAcquisitionBuilder[ProbabilisticModel]):
+class _ArbitrarySingleBuilder(
+    SingleModelAcquisitionBuilder[ProbabilisticModel, AcquisitionFunction]
+):
     def prepare_acquisition_function(
         self,
         model: ProbabilisticModel,
@@ -52,7 +54,9 @@ class _ArbitrarySingleBuilder(SingleModelAcquisitionBuilder[ProbabilisticModel])
         return raise_exc
 
 
-class _ArbitraryGreedySingleBuilder(SingleModelGreedyAcquisitionBuilder[ProbabilisticModel]):
+class _ArbitraryGreedySingleBuilder(
+    SingleModelGreedyAcquisitionBuilder[ProbabilisticModel, AcquisitionFunction]
+):
     def prepare_acquisition_function(
         self,
         model: ProbabilisticModel,
@@ -77,7 +81,7 @@ def test_single_model_acquisition_builder_repr_includes_class_name() -> None:
 
 
 def test_single_model_acquisition_builder_using_passes_on_correct_dataset_and_model() -> None:
-    class Builder(SingleModelAcquisitionBuilder[ProbabilisticModel]):
+    class Builder(SingleModelAcquisitionBuilder[ProbabilisticModel, AcquisitionFunction]):
         def prepare_acquisition_function(
             self,
             model: ProbabilisticModel,
@@ -109,7 +113,7 @@ def test_single_model_greedy_acquisition_builder_repr_includes_class_name() -> N
 @pytest.mark.parametrize(
     "function, function_repr",
     cast(
-        List[Tuple[SingleModelAcquisitionBuilder[SupportsPredictJoint]]],
+        List[Tuple[SingleModelAcquisitionBuilder[SupportsPredictJoint, AcquisitionFunction]]],
         [
             (ExpectedImprovement(), "ExpectedImprovement()"),
             (AugmentedExpectedImprovement(), "AugmentedExpectedImprovement()"),
@@ -129,7 +133,8 @@ def test_single_model_greedy_acquisition_builder_repr_includes_class_name() -> N
     ),
 )
 def test_single_model_acquisition_function_builder_reprs(
-    function: SingleModelAcquisitionBuilder[SupportsPredictJoint], function_repr: str
+    function: SingleModelAcquisitionBuilder[SupportsPredictJoint, AcquisitionFunction],
+    function_repr: str,
 ) -> None:
     assert repr(function) == function_repr
     assert repr(function.using("TAG")) == f"{function_repr} using tag 'TAG'"

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -82,7 +82,6 @@ from .function import (
 from .interface import (
     AcquisitionFunction,
     AcquisitionFunctionBuilder,
-    AcquisitionFunctionClass,
     GreedyAcquisitionFunctionBuilder,
     PenalizationFunction,
     SingleModelAcquisitionBuilder,

--- a/trieste/acquisition/combination.py
+++ b/trieste/acquisition/combination.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
-from typing import Optional
+from typing import Any, Optional
 
 import tensorflow as tf
 
@@ -33,9 +33,7 @@ class Reducer(AcquisitionFunctionBuilder[ProbabilisticModel, AcquisitionFunction
     by the method :meth:`_reduce`.
     """
 
-    def __init__(
-        self, *builders: AcquisitionFunctionBuilder[ProbabilisticModel, AcquisitionFunction]
-    ):
+    def __init__(self, *builders: AcquisitionFunctionBuilder[ProbabilisticModel, Any]):
         r"""
         :param \*builders: Acquisition function builders. At least one must be provided.
         :raise `~tf.errors.InvalidArgumentError`: If no builders are specified.

--- a/trieste/acquisition/combination.py
+++ b/trieste/acquisition/combination.py
@@ -25,7 +25,7 @@ from ..types import TensorType
 from .interface import AcquisitionFunction, AcquisitionFunctionBuilder
 
 
-class Reducer(AcquisitionFunctionBuilder[ProbabilisticModel]):
+class Reducer(AcquisitionFunctionBuilder[ProbabilisticModel, AcquisitionFunction]):
     r"""
     A :class:`Reducer` builds an :const:`~trieste.acquisition.AcquisitionFunction` whose output is
     calculated from the outputs of a number of other
@@ -33,7 +33,9 @@ class Reducer(AcquisitionFunctionBuilder[ProbabilisticModel]):
     by the method :meth:`_reduce`.
     """
 
-    def __init__(self, *builders: AcquisitionFunctionBuilder[ProbabilisticModel]):
+    def __init__(
+        self, *builders: AcquisitionFunctionBuilder[ProbabilisticModel, AcquisitionFunction]
+    ):
         r"""
         :param \*builders: Acquisition function builders. At least one must be provided.
         :raise `~tf.errors.InvalidArgumentError`: If no builders are specified.
@@ -67,8 +69,8 @@ class Reducer(AcquisitionFunctionBuilder[ProbabilisticModel]):
             acq.prepare_acquisition_function(models, datasets=datasets) for acq in self.acquisitions
         )
 
-        def evaluate_acquisition_function_fn(at: TensorType) -> TensorType:
-            return self._reduce_acquisition_functions(at, self.functions)
+        def evaluate_acquisition_function_fn(x: TensorType) -> TensorType:
+            return self._reduce_acquisition_functions(x, self.functions)
 
         return evaluate_acquisition_function_fn
 
@@ -88,13 +90,15 @@ class Reducer(AcquisitionFunctionBuilder[ProbabilisticModel]):
             for function, acq in zip(self.functions, self.acquisitions)
         )
 
-        def evaluate_acquisition_function_fn(at: TensorType) -> TensorType:
-            return self._reduce_acquisition_functions(at, self.functions)
+        def evaluate_acquisition_function_fn(x: TensorType) -> TensorType:
+            return self._reduce_acquisition_functions(x, self.functions)
 
         return evaluate_acquisition_function_fn
 
     @property
-    def acquisitions(self) -> Sequence[AcquisitionFunctionBuilder[ProbabilisticModel]]:
+    def acquisitions(
+        self,
+    ) -> Sequence[AcquisitionFunctionBuilder[ProbabilisticModel, AcquisitionFunction]]:
         """The acquisition function builders specified at class initialisation."""
         return self._acquisitions
 

--- a/trieste/acquisition/function/active_learning.py
+++ b/trieste/acquisition/function/active_learning.py
@@ -30,7 +30,7 @@ from ...models import ProbabilisticModel
 from ...models.interfaces import FastUpdateModel, SupportsPredictJoint
 from ...types import TensorType
 from ...utils import DEFAULTS
-from ..interface import AcquisitionFunction, AcquisitionFunctionClass, SingleModelAcquisitionBuilder
+from ..interface import AcquisitionFunction, SingleModelAcquisitionBuilder
 
 
 class PredictiveVariance(SingleModelAcquisitionBuilder[SupportsPredictJoint]):
@@ -305,7 +305,7 @@ class IntegratedVarianceReduction(SingleModelAcquisitionBuilder[FastUpdateModel]
         return function  # no need to update anything
 
 
-class integrated_variance_reduction(AcquisitionFunctionClass):
+class integrated_variance_reduction(AcquisitionFunction):
     r"""
     The reduction of the (weighted) average of the predicted variance over the integration points
     (a.k.a. Integrated Means Square Error or IMSE criterion).
@@ -465,7 +465,7 @@ class BayesianActiveLearningByDisagreement(SingleModelAcquisitionBuilder[Probabi
         return function  # no need to update anything
 
 
-class bayesian_active_learning_by_disagreement(AcquisitionFunctionClass):
+class bayesian_active_learning_by_disagreement(AcquisitionFunction):
     def __init__(self, model: ProbabilisticModel, jitter: float):
 
         r"""

--- a/trieste/acquisition/function/active_learning.py
+++ b/trieste/acquisition/function/active_learning.py
@@ -33,7 +33,35 @@ from ...utils import DEFAULTS
 from ..interface import AcquisitionFunction, SingleModelAcquisitionBuilder
 
 
-class PredictiveVariance(SingleModelAcquisitionBuilder[SupportsPredictJoint]):
+class predictive_variance(AcquisitionFunction):
+    def __init__(self, model: SupportsPredictJoint, jitter: float):
+        """
+        The predictive variance acquisition function for active learning, based on
+        the determinant of the covariance (see :cite:`MacKay1992` for details).
+        Note that the model needs to supply covariance of the joint marginal distribution,
+        which can be expensive to compute.
+
+        :param model: The model of the objective function.
+        :param jitter: The size of the jitter to use when stabilising the Cholesky decomposition of
+                the covariance matrix.
+        """
+        self._model = model
+        self._jitter = jitter
+
+    @tf.function
+    def __call__(self, x: TensorType) -> TensorType:
+        try:
+            _, covariance = self._model.predict_joint(x)
+        except NotImplementedError:
+            raise ValueError(
+                """
+                PredictiveVariance only supports models with a predict_joint method.
+                """
+            )
+        return tf.exp(tf.linalg.logdet(covariance + self._jitter))
+
+
+class PredictiveVariance(SingleModelAcquisitionBuilder[SupportsPredictJoint, predictive_variance]):
     """
     Builder for the determinant of the predictive covariance matrix over the batch points.
     For a batch of size 1 it is the same as maximizing the predictive variance.
@@ -54,7 +82,7 @@ class PredictiveVariance(SingleModelAcquisitionBuilder[SupportsPredictJoint]):
         self,
         model: SupportsPredictJoint,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> predictive_variance:
         """
         :param model: The model.
         :param dataset: Unused.
@@ -71,10 +99,10 @@ class PredictiveVariance(SingleModelAcquisitionBuilder[SupportsPredictJoint]):
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
+        function: predictive_variance,
         model: SupportsPredictJoint,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> predictive_variance:
         """
         :param function: The acquisition function to update.
         :param model: The model.
@@ -83,35 +111,92 @@ class PredictiveVariance(SingleModelAcquisitionBuilder[SupportsPredictJoint]):
         return function  # no need to update anything
 
 
-def predictive_variance(model: SupportsPredictJoint, jitter: float) -> AcquisitionFunction:
-    """
-    The predictive variance acquisition function for active learning, based on
-    the determinant of the covariance (see :cite:`MacKay1992` for details).
-    Note that the model needs to supply covariance of the joint marginal distribution,
-    which can be expensive to compute.
+class bichon_ranjan_criterion(AcquisitionFunction):
+    def __init__(
+        self,
+        model: ProbabilisticModel,
+        threshold: float,
+        alpha: float,
+        delta: int,
+    ):
+        r"""
+        Return the *bichon* criterion (:cite:`bichon2008efficient`) and *ranjan* criterion
+        (:cite:`ranjan2008sequential`) used in Expected feasibility acquisition function for active
+        learning of failure or feasibility regions.
 
-    :param model: The model of the objective function.
-    :param jitter: The size of the jitter to use when stabilising the Cholesky decomposition of
-            the covariance matrix.
-    """
+        The problem of identifying a failure or feasibility region of a function :math:`f` can be
+        formalized as estimating the excursion set, :math:`\Gamma^* = \{ x \in X: f(x) \ge T\}`, or
+        estimating the contour line, :math:`C^* = \{ x \in X: f(x) = T\}`, for some threshold
+        :math:`T` (see :cite:`bect2012sequential` for more details).
+
+        It turns out that probabilistic models can be used as classifiers for identifying where
+        excursion probability is larger than 1/2 and this idea is used to build many sequential
+        sampling strategies. We follow :cite:`bect2012sequential` and use a formulation which
+        provides a common expression for these two criteria:
+
+        .. math:: \mathbb{E}[\max(0, (\alpha s(x))^\delta - |T - m(x)|^\delta)]
+
+        Here :math:`m(x)` and :math:`s(x)` are the mean and standard deviation of the predictive
+        posterior of a probabilistic model. *Bichon* criterion is obtained when :math:`\delta = 1`
+        while *ranjan* criterion is obtained when :math:`\delta = 2`. :math:`\alpha>0` is another
+        parameter that acts as a percentage of standard deviation of the posterior around the
+        current boundary estimate where we want to sample. The goal is to sample a point with a
+        mean close to the threshold :math:`T` and a high variance, so that the positive difference
+        in the equation above is as large as possible.
+
+        Note that only batches of size 1 are allowed.
+
+        :param model: The probabilistic model of the objective function.
+        :param threshold: The failure or feasibility threshold.
+        :param alpha: The parameter which determines the neighbourhood around the estimated contour
+            line as a percentage of the posterior variance in which to allocate new points.
+        :param delta: The parameter identifying which criterion is used, *bichon* for value of 1
+            and *ranjan* for value of 2.
+        """
+        self._model = model
+        self._threshold = threshold
+        self._alpha = alpha
+        self._delta = delta
 
     @tf.function
-    def acquisition(x: TensorType) -> TensorType:
+    def __call__(self, x: TensorType) -> TensorType:
 
-        try:
-            _, covariance = model.predict_joint(x)
-        except NotImplementedError:
-            raise ValueError(
-                """
-                PredictiveVariance only supports models with a predict_joint method.
-                """
+        tf.debugging.assert_shapes(
+            [(x, [..., 1, None])],
+            message="This acquisition function only supports batch sizes of one.",
+        )
+
+        mean, variance = self._model.predict(tf.squeeze(x, -2))
+        stdev = tf.sqrt(variance)
+        t = (self._threshold - mean) / stdev
+        t_plus = t + self._alpha
+        t_minus = t - self._alpha
+        normal = tfp.distributions.Normal(tf.cast(0, x.dtype), tf.cast(1, x.dtype))
+
+        if self._delta == 1:
+            G = (
+                self._alpha * (normal.cdf(t_plus) - normal.cdf(t_minus))
+                - t * (2 * normal.cdf(t) - normal.cdf(t_plus) - normal.cdf(t_minus))
+                - (2 * normal.prob(t) - normal.prob(t_plus) - normal.prob(t_minus))
             )
-        return tf.exp(tf.linalg.logdet(covariance + jitter))
+            tf.debugging.check_numerics(G, "NaN or Inf values encountered in criterion")
+            criterion = G * stdev
+        elif self._delta == 2:
+            G = (
+                (self._alpha ** 2 - 1 - t ** 2) * (normal.cdf(t_plus) - normal.cdf(t_minus))
+                - 2 * t * (normal.prob(t_plus) - normal.prob(t_minus))
+                + t_plus * normal.prob(t_plus)
+                - t_minus * normal.prob(t_minus)
+            )
+            tf.debugging.check_numerics(G, "NaN or Inf values encountered in criterion")
+            criterion = G * variance
 
-    return acquisition
+        return criterion
 
 
-class ExpectedFeasibility(SingleModelAcquisitionBuilder[ProbabilisticModel]):
+class ExpectedFeasibility(
+    SingleModelAcquisitionBuilder[ProbabilisticModel, bichon_ranjan_criterion]
+):
     """
     Builder for the Expected feasibility acquisition function for identifying a failure or
     feasibility region. It implements two related sampling strategies called *bichon* criterion
@@ -151,7 +236,7 @@ class ExpectedFeasibility(SingleModelAcquisitionBuilder[ProbabilisticModel]):
         self,
         model: ProbabilisticModel,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> bichon_ranjan_criterion:
         """
         :param model: The model.
         :param dataset: Unused.
@@ -163,145 +248,11 @@ class ExpectedFeasibility(SingleModelAcquisitionBuilder[ProbabilisticModel]):
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
+        function: bichon_ranjan_criterion,
         model: ProbabilisticModel,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> bichon_ranjan_criterion:
 
-        return function  # no need to update anything
-
-
-def bichon_ranjan_criterion(
-    model: ProbabilisticModel,
-    threshold: float,
-    alpha: float,
-    delta: int,
-) -> AcquisitionFunction:
-    r"""
-    Return the *bichon* criterion (:cite:`bichon2008efficient`) and *ranjan* criterion
-    (:cite:`ranjan2008sequential`) used in Expected feasibility acquisition function for active
-    learning of failure or feasibility regions.
-
-    The problem of identifying a failure or feasibility region of a function :math:`f` can be
-    formalized as estimating the excursion set, :math:`\Gamma^* = \{ x \in X: f(x) \ge T\}`, or
-    estimating the contour line, :math:`C^* = \{ x \in X: f(x) = T\}`, for some threshold :math:`T`
-    (see :cite:`bect2012sequential` for more details).
-
-    It turns out that probabilistic models can be used as classifiers for identifying where
-    excursion probability is larger than 1/2 and this idea is used to build many sequential
-    sampling strategies. We follow :cite:`bect2012sequential` and use a formulation which provides
-    a common expression for these two criteria:
-
-    .. math:: \mathbb{E}[\max(0, (\alpha s(x))^\delta - |T - m(x)|^\delta)]
-
-    Here :math:`m(x)` and :math:`s(x)` are the mean and standard deviation of the predictive
-    posterior of a probabilistic model. *Bichon* criterion is obtained when :math:`\delta = 1` while
-    *ranjan* criterion is obtained when :math:`\delta = 2`. :math:`\alpha>0` is another parameter
-    that acts as a percentage of standard deviation of the posterior around the current boundary
-    estimate where we want to sample. The goal is to sample a point with a mean close to the
-    threshold :math:`T` and a high variance, so that the positive difference in the equation above
-    is as large as possible.
-
-    Note that only batches of size 1 are allowed.
-
-    :param model: The probabilistic model of the objective function.
-    :param threshold: The failure or feasibility threshold.
-    :param alpha: The parameter which determines the neighbourhood around the estimated contour
-        line as a percentage of the posterior variance in which to allocate new points.
-    :param delta: The parameter identifying which criterion is used, *bichon* for value of 1
-        and *ranjan* for value of 2.
-    """
-
-    @tf.function
-    def acquisition(x: TensorType) -> TensorType:
-
-        tf.debugging.assert_shapes(
-            [(x, [..., 1, None])],
-            message="This acquisition function only supports batch sizes of one.",
-        )
-
-        mean, variance = model.predict(tf.squeeze(x, -2))
-        stdev = tf.sqrt(variance)
-        t = (threshold - mean) / stdev
-        t_plus = t + alpha
-        t_minus = t - alpha
-        normal = tfp.distributions.Normal(tf.cast(0, x.dtype), tf.cast(1, x.dtype))
-
-        if delta == 1:
-            G = (
-                alpha * (normal.cdf(t_plus) - normal.cdf(t_minus))
-                - t * (2 * normal.cdf(t) - normal.cdf(t_plus) - normal.cdf(t_minus))
-                - (2 * normal.prob(t) - normal.prob(t_plus) - normal.prob(t_minus))
-            )
-            tf.debugging.check_numerics(G, "NaN or Inf values encountered in criterion")
-            criterion = G * stdev
-        elif delta == 2:
-            G = (
-                (alpha ** 2 - 1 - t ** 2) * (normal.cdf(t_plus) - normal.cdf(t_minus))
-                - 2 * t * (normal.prob(t_plus) - normal.prob(t_minus))
-                + t_plus * normal.prob(t_plus)
-                - t_minus * normal.prob(t_minus)
-            )
-            tf.debugging.check_numerics(G, "NaN or Inf values encountered in criterion")
-            criterion = G * variance
-
-        return criterion
-
-    return acquisition
-
-
-class IntegratedVarianceReduction(SingleModelAcquisitionBuilder[FastUpdateModel]):
-    """
-    Builder for the reduction of the integral of the predicted variance over the search
-    space given a batch of query points.
-    """
-
-    def __init__(
-        self,
-        integration_points: TensorType,
-        threshold: Optional[Union[float, Sequence[float], TensorType]] = None,
-    ) -> None:
-        """
-        :param integration_points: set of points to integrate the prediction variance over.
-        :param threshold: either None, a float or a sequence of 1 or 2 float values.
-        """
-        self._integration_points = integration_points
-        self._threshold = threshold
-
-    def __repr__(self) -> str:
-        """"""
-        return f"IntegratedVarianceReduction(threshold={self._threshold!r})"
-
-    def prepare_acquisition_function(
-        self,
-        model: FastUpdateModel,
-        dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
-        """
-        :param model: The model.
-        :param dataset: Unused.
-
-        :return: The integral of the predictive variance.
-        """
-        if not isinstance(model, FastUpdateModel):
-            raise NotImplementedError(
-                f"PredictiveVariance only works with FastUpdateModel models; "
-                f"received {model.__repr__()}"
-            )
-
-        return integrated_variance_reduction(model, self._integration_points, self._threshold)
-
-    def update_acquisition_function(
-        self,
-        function: AcquisitionFunction,
-        model: FastUpdateModel,
-        dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
-        """
-        :param function: The acquisition function to update.
-        :param model: The model.
-        :param dataset: Unused.
-        """
         return function  # no need to update anything
 
 
@@ -420,43 +371,55 @@ class integrated_variance_reduction(AcquisitionFunction):
         return -tf.reduce_mean(variance * self._weights, axis=-2)
 
 
-class BayesianActiveLearningByDisagreement(SingleModelAcquisitionBuilder[ProbabilisticModel]):
+class IntegratedVarianceReduction(
+    SingleModelAcquisitionBuilder[FastUpdateModel, integrated_variance_reduction]
+):
     """
-    Builder for the *Bayesian Active Learning By Disagreement* acquisition function defined in
-    :cite:`houlsby2011bayesian`.
+    Builder for the reduction of the integral of the predicted variance over the search
+    space given a batch of query points.
     """
 
-    def __init__(self, jitter: float = DEFAULTS.JITTER) -> None:
+    def __init__(
+        self,
+        integration_points: TensorType,
+        threshold: Optional[Union[float, Sequence[float], TensorType]] = None,
+    ) -> None:
         """
-        :param jitter: The size of the jitter to avoid numerical problem caused by the
-                log operation if variance is close to zero.
+        :param integration_points: set of points to integrate the prediction variance over.
+        :param threshold: either None, a float or a sequence of 1 or 2 float values.
         """
-        self._jitter = jitter
+        self._integration_points = integration_points
+        self._threshold = threshold
 
     def __repr__(self) -> str:
         """"""
-        return f"BayesianActiveLearningByDisagreement(jitter={self._jitter!r})"
+        return f"IntegratedVarianceReduction(threshold={self._threshold!r})"
 
     def prepare_acquisition_function(
         self,
-        model: ProbabilisticModel,
+        model: FastUpdateModel,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> integrated_variance_reduction:
         """
         :param model: The model.
         :param dataset: Unused.
 
-        :return: The determinant of the predictive function.
+        :return: The integral of the predictive variance.
         """
+        if not isinstance(model, FastUpdateModel):
+            raise NotImplementedError(
+                f"PredictiveVariance only works with FastUpdateModel models; "
+                f"received {model.__repr__()}"
+            )
 
-        return bayesian_active_learning_by_disagreement(model, self._jitter)
+        return integrated_variance_reduction(model, self._integration_points, self._threshold)
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
-        model: ProbabilisticModel,
+        function: integrated_variance_reduction,
+        model: FastUpdateModel,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> integrated_variance_reduction:
         """
         :param function: The acquisition function to update.
         :param model: The model.
@@ -518,3 +481,50 @@ class bayesian_active_learning_by_disagreement(AcquisitionFunction):
         Ef = (tf.sqrt(C2) / tf.sqrt(variance + C2)) * tf.exp(-(mean ** 2) / (2 * (variance + C2)))
 
         return -p * tf.math.log(p + self._jitter) - (1 - p) * tf.math.log(1 - p + self._jitter) - Ef
+
+
+class BayesianActiveLearningByDisagreement(
+    SingleModelAcquisitionBuilder[ProbabilisticModel, bayesian_active_learning_by_disagreement]
+):
+    """
+    Builder for the *Bayesian Active Learning By Disagreement* acquisition function defined in
+    :cite:`houlsby2011bayesian`.
+    """
+
+    def __init__(self, jitter: float = DEFAULTS.JITTER) -> None:
+        """
+        :param jitter: The size of the jitter to avoid numerical problem caused by the
+                log operation if variance is close to zero.
+        """
+        self._jitter = jitter
+
+    def __repr__(self) -> str:
+        """"""
+        return f"BayesianActiveLearningByDisagreement(jitter={self._jitter!r})"
+
+    def prepare_acquisition_function(
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
+    ) -> bayesian_active_learning_by_disagreement:
+        """
+        :param model: The model.
+        :param dataset: Unused.
+
+        :return: The determinant of the predictive function.
+        """
+
+        return bayesian_active_learning_by_disagreement(model, self._jitter)
+
+    def update_acquisition_function(
+        self,
+        function: bayesian_active_learning_by_disagreement,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
+    ) -> bayesian_active_learning_by_disagreement:
+        """
+        :param function: The acquisition function to update.
+        :param model: The model.
+        :param dataset: Unused.
+        """
+        return function  # no need to update anything

--- a/trieste/acquisition/function/entropy.py
+++ b/trieste/acquisition/function/entropy.py
@@ -30,7 +30,6 @@ from ...space import SearchSpace
 from ...types import TensorType
 from ..interface import (
     AcquisitionFunction,
-    AcquisitionFunctionClass,
     PenalizationFunction,
     ProbabilisticModelType,
     SingleModelAcquisitionBuilder,
@@ -160,7 +159,7 @@ class MinValueEntropySearch(SingleModelAcquisitionBuilder[ProbabilisticModelType
         return function
 
 
-class min_value_entropy_search(AcquisitionFunctionClass):
+class min_value_entropy_search(AcquisitionFunction):
     def __init__(self, model: ProbabilisticModel, samples: TensorType):
         r"""
         Return the max-value entropy search acquisition function (adapted from :cite:`wang2017max`),
@@ -437,7 +436,7 @@ class GibbonAcquisition:
         return self._diversity_term(x) + self._quality_term(x)
 
 
-class gibbon_quality_term(AcquisitionFunctionClass):
+class gibbon_quality_term(AcquisitionFunction):
     def __init__(self, model: SupportsCovarianceObservationNoise, samples: TensorType):
         """
         GIBBON's quality term measures the amount of information that each individual

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -35,65 +35,14 @@ from ...utils import DEFAULTS
 from ..interface import (
     AcquisitionFunction,
     AcquisitionFunctionBuilder,
-    AcquisitionFunctionClass,
+    AcquisitionFunctionType,
     ProbabilisticModelType,
     SingleModelAcquisitionBuilder,
     SingleModelVectorizedAcquisitionBuilder,
 )
 
 
-class ExpectedImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel]):
-    """
-    Builder for the expected improvement function where the "best" value is taken to be the minimum
-    of the posterior mean at observed points.
-    """
-
-    def __repr__(self) -> str:
-        """"""
-        return "ExpectedImprovement()"
-
-    def prepare_acquisition_function(
-        self,
-        model: ProbabilisticModel,
-        dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
-        """
-        :param model: The model.
-        :param dataset: The data from the observer. Must be populated.
-        :return: The expected improvement function. This function will raise
-            :exc:`ValueError` or :exc:`~tf.errors.InvalidArgumentError` if used with a batch size
-            greater than one.
-        :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
-        """
-        tf.debugging.Assert(dataset is not None, [tf.constant([])])
-        dataset = cast(Dataset, dataset)
-        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
-        mean, _ = model.predict(dataset.query_points)
-        eta = tf.reduce_min(mean, axis=0)
-        return expected_improvement(model, eta)
-
-    def update_acquisition_function(
-        self,
-        function: AcquisitionFunction,
-        model: ProbabilisticModel,
-        dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
-        """
-        :param function: The acquisition function to update.
-        :param model: The model.
-        :param dataset: The data from the observer.  Must be populated.
-        """
-        tf.debugging.Assert(dataset is not None, [tf.constant([])])
-        dataset = cast(Dataset, dataset)
-        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
-        tf.debugging.Assert(isinstance(function, expected_improvement), [tf.constant([])])
-        mean, _ = model.predict(dataset.query_points)
-        eta = tf.reduce_min(mean, axis=0)
-        function.update(eta)  # type: ignore
-        return function
-
-
-class expected_improvement(AcquisitionFunctionClass):
+class expected_improvement(AcquisitionFunction):
     def __init__(self, model: ProbabilisticModel, eta: TensorType):
         r"""
         Return the Expected Improvement (EI) acquisition function for single-objective global
@@ -129,21 +78,21 @@ class expected_improvement(AcquisitionFunctionClass):
         return (self._eta - mean) * normal.cdf(self._eta) + variance * normal.prob(self._eta)
 
 
-class AugmentedExpectedImprovement(SingleModelAcquisitionBuilder[SupportsGetObservationNoise]):
+class ExpectedImprovement(SingleModelAcquisitionBuilder[ProbabilisticModel, expected_improvement]):
     """
-    Builder for the augmented expected improvement function for optimization single-objective
-    optimization problems with high levels of observation noise.
+    Builder for the expected improvement function where the "best" value is taken to be the minimum
+    of the posterior mean at observed points.
     """
 
     def __repr__(self) -> str:
         """"""
-        return "AugmentedExpectedImprovement()"
+        return "ExpectedImprovement()"
 
     def prepare_acquisition_function(
         self,
-        model: SupportsGetObservationNoise,
+        model: ProbabilisticModel,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> expected_improvement:
         """
         :param model: The model.
         :param dataset: The data from the observer. Must be populated.
@@ -152,40 +101,35 @@ class AugmentedExpectedImprovement(SingleModelAcquisitionBuilder[SupportsGetObse
             greater than one.
         :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
         """
-        if not isinstance(model, SupportsGetObservationNoise):
-            raise NotImplementedError(
-                f"AugmentedExpectedImprovement only works with models that support "
-                f"get_observation_noise; received {model.__repr__()}"
-            )
         tf.debugging.Assert(dataset is not None, [tf.constant([])])
         dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         mean, _ = model.predict(dataset.query_points)
         eta = tf.reduce_min(mean, axis=0)
-        return augmented_expected_improvement(model, eta)
+        return expected_improvement(model, eta)
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
-        model: SupportsGetObservationNoise,
+        function: expected_improvement,
+        model: ProbabilisticModel,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> expected_improvement:
         """
         :param function: The acquisition function to update.
         :param model: The model.
-        :param dataset: The data from the observer. Must be populated.
+        :param dataset: The data from the observer.  Must be populated.
         """
         tf.debugging.Assert(dataset is not None, [tf.constant([])])
         dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
-        tf.debugging.Assert(isinstance(function, augmented_expected_improvement), [tf.constant([])])
+        tf.debugging.Assert(isinstance(function, expected_improvement), [tf.constant([])])
         mean, _ = model.predict(dataset.query_points)
         eta = tf.reduce_min(mean, axis=0)
-        function.update(eta)  # type: ignore
+        function.update(eta)
         return function
 
 
-class augmented_expected_improvement(AcquisitionFunctionClass):
+class augmented_expected_improvement(AcquisitionFunction):
     def __init__(self, model: SupportsGetObservationNoise, eta: TensorType):
         r"""
         Return the Augmented Expected Improvement (AEI) acquisition function for single-objective
@@ -234,7 +178,67 @@ class augmented_expected_improvement(AcquisitionFunctionClass):
         return expected_improvement * augmentation
 
 
-class NegativeLowerConfidenceBound(SingleModelAcquisitionBuilder[ProbabilisticModel]):
+class AugmentedExpectedImprovement(
+    SingleModelAcquisitionBuilder[SupportsGetObservationNoise, augmented_expected_improvement]
+):
+    """
+    Builder for the augmented expected improvement function for optimization single-objective
+    optimization problems with high levels of observation noise.
+    """
+
+    def __repr__(self) -> str:
+        """"""
+        return "AugmentedExpectedImprovement()"
+
+    def prepare_acquisition_function(
+        self,
+        model: SupportsGetObservationNoise,
+        dataset: Optional[Dataset] = None,
+    ) -> augmented_expected_improvement:
+        """
+        :param model: The model.
+        :param dataset: The data from the observer. Must be populated.
+        :return: The expected improvement function. This function will raise
+            :exc:`ValueError` or :exc:`~tf.errors.InvalidArgumentError` if used with a batch size
+            greater than one.
+        :raise tf.errors.InvalidArgumentError: If ``dataset`` is empty.
+        """
+        if not isinstance(model, SupportsGetObservationNoise):
+            raise NotImplementedError(
+                f"AugmentedExpectedImprovement only works with models that support "
+                f"get_observation_noise; received {model.__repr__()}"
+            )
+        tf.debugging.Assert(dataset is not None, [tf.constant([])])
+        dataset = cast(Dataset, dataset)
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
+        mean, _ = model.predict(dataset.query_points)
+        eta = tf.reduce_min(mean, axis=0)
+        return augmented_expected_improvement(model, eta)
+
+    def update_acquisition_function(
+        self,
+        function: augmented_expected_improvement,
+        model: SupportsGetObservationNoise,
+        dataset: Optional[Dataset] = None,
+    ) -> augmented_expected_improvement:
+        """
+        :param function: The acquisition function to update.
+        :param model: The model.
+        :param dataset: The data from the observer. Must be populated.
+        """
+        tf.debugging.Assert(dataset is not None, [tf.constant([])])
+        dataset = cast(Dataset, dataset)
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
+        tf.debugging.Assert(isinstance(function, augmented_expected_improvement), [tf.constant([])])
+        mean, _ = model.predict(dataset.query_points)
+        eta = tf.reduce_min(mean, axis=0)
+        function.update(eta)
+        return function
+
+
+class NegativeLowerConfidenceBound(
+    SingleModelAcquisitionBuilder[ProbabilisticModel, AcquisitionFunction]
+):
     """
     Builder for the negative of the lower confidence bound. The lower confidence bound is typically
     minimised, so the negative is suitable for maximisation.
@@ -327,7 +331,9 @@ def lower_confidence_bound(model: ProbabilisticModel, beta: float) -> Acquisitio
     return acquisition
 
 
-class ProbabilityOfFeasibility(SingleModelAcquisitionBuilder[ProbabilisticModel]):
+class ProbabilityOfFeasibility(
+    SingleModelAcquisitionBuilder[ProbabilisticModel, AcquisitionFunction]
+):
     r"""
     Builder for the :func:`probability_of_feasibility` acquisition function, defined in
     :cite:`gardner14` as
@@ -423,7 +429,9 @@ def probability_of_feasibility(
     return acquisition
 
 
-class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticModelType]):
+class ExpectedConstrainedImprovement(
+    AcquisitionFunctionBuilder[ProbabilisticModelType, AcquisitionFunction]
+):
     """
     Builder for the *expected constrained improvement* acquisition function defined in
     :cite:`gardner14`. The acquisition function computes the expected improvement from the best
@@ -434,7 +442,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticMod
     def __init__(
         self,
         objective_tag: str,
-        constraint_builder: AcquisitionFunctionBuilder[ProbabilisticModelType],
+        constraint_builder: AcquisitionFunctionBuilder[ProbabilisticModelType, AcquisitionFunction],
         min_feasibility_probability: float | TensorType = 0.5,
     ):
         """
@@ -459,7 +467,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticMod
         self._constraint_builder = constraint_builder
         self._min_feasibility_probability = min_feasibility_probability
         self._constraint_fn: Optional[AcquisitionFunction] = None
-        self._expected_improvement_fn: Optional[AcquisitionFunction] = None
+        self._expected_improvement_fn: Optional[expected_improvement] = None
         self._constrained_improvement_fn: Optional[AcquisitionFunction] = None
 
     def __repr__(self) -> str:
@@ -584,107 +592,10 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticMod
             tf.debugging.Assert(
                 isinstance(self._expected_improvement_fn, expected_improvement), [tf.constant([])]
             )
-            self._expected_improvement_fn.update(eta)  # type: ignore
+            self._expected_improvement_fn.update(eta)
 
 
-class MonteCarloExpectedImprovement(SingleModelAcquisitionBuilder[HasReparamSampler]):
-    """
-    Builder for a Monte Carlo-based expected improvement function for use with a model without
-    analytical expected improvement (e.g. a deep GP). The "best" value is taken to be
-    the minimum of the posterior mean at observed points. See
-    :class:`monte_carlo_expected_improvement` for details.
-    """
-
-    def __init__(self, sample_size: int, *, jitter: float = DEFAULTS.JITTER):
-        """
-        :param sample_size: The number of samples for each batch of points.
-        :param jitter: The jitter for the reparametrization sampler.
-        :raise tf.errors.InvalidArgumentError: If ``sample_size`` is not positive, or ``jitter`` is
-            negative.
-        """
-        tf.debugging.assert_positive(sample_size)
-        tf.debugging.assert_greater_equal(jitter, 0.0)
-
-        super().__init__()
-
-        self._sample_size = sample_size
-        self._jitter = jitter
-
-    def __repr__(self) -> str:
-        """"""
-        return f"MonteCarloExpectedImprovement({self._sample_size!r}, jitter={self._jitter!r})"
-
-    def prepare_acquisition_function(
-        self,
-        model: HasReparamSampler,
-        dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
-        """
-        :param model: The model over the specified ``dataset``. Must have output dimension [1].
-        :param dataset: The data from the observer. Cannot be empty.
-        :return: The estimated *expected improvement* acquisition function.
-        :raise ValueError (or InvalidArgumentError): If ``dataset`` is not populated, ``model``
-            does not have an output dimension of [1] or does not have a ``reparam_sample`` method.
-        """
-        if not isinstance(model, HasReparamSampler):
-            raise ValueError(
-                f"MonteCarloExpectedImprovement only supports models with a reparam_sampler method;"
-                f"received {model.__repr__()}"
-            )
-
-        sampler = model.reparam_sampler(self._sample_size)
-
-        tf.debugging.Assert(dataset is not None, [tf.constant([])])
-        dataset = cast(Dataset, dataset)
-        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
-
-        samples_at_query_points = sampler.sample(
-            dataset.query_points[..., None, :], jitter=self._jitter
-        )
-        mean = tf.reduce_mean(samples_at_query_points, axis=-3, keepdims=True)  # [N, 1, 1, L]
-
-        tf.debugging.assert_shapes(
-            [(mean, [..., 1])], message="Expected model with output dimension [1]."
-        )
-
-        eta = tf.squeeze(tf.reduce_min(mean, axis=0))
-
-        return monte_carlo_expected_improvement(sampler, eta)
-
-    def update_acquisition_function(
-        self,
-        function: AcquisitionFunction,
-        model: HasReparamSampler,
-        dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
-        """
-        :param function: The acquisition function to update.
-        :param model: The model. Must have output dimension [1]. Unused here.
-        :param dataset: The data from the observer. Cannot be empty
-        """
-        tf.debugging.Assert(dataset is not None, [tf.constant([])])
-        dataset = cast(Dataset, dataset)
-        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
-        tf.debugging.Assert(
-            isinstance(function, monte_carlo_expected_improvement), [tf.constant([])]
-        )
-        sampler = function._sampler  # type: ignore
-        sampler.reset_sampler()
-        samples_at_query_points = sampler.sample(
-            dataset.query_points[..., None, :], jitter=self._jitter
-        )
-        mean = tf.reduce_mean(samples_at_query_points, axis=-3, keepdims=True)
-
-        tf.debugging.assert_shapes(
-            [(mean, [..., 1])], message="Expected model with output dimension [1]."
-        )
-
-        eta = tf.squeeze(tf.reduce_min(mean, axis=0))
-        function.update(eta)  # type: ignore
-        return function
-
-
-class monte_carlo_expected_improvement(AcquisitionFunctionClass):
+class monte_carlo_expected_improvement(AcquisitionFunction):
     r"""
     Return a Monte Carlo based Expected Improvement (EI) acquisition function for
     single-objective global optimization. Improvement is with respect to the current "best"
@@ -724,14 +635,14 @@ class monte_carlo_expected_improvement(AcquisitionFunctionClass):
         return tf.reduce_mean(improvement, axis=-2)  # [..., 1]
 
 
-class MonteCarloAugmentedExpectedImprovement(
-    SingleModelAcquisitionBuilder[SupportsReparamSamplerObservationNoise]
+class MonteCarloExpectedImprovement(
+    SingleModelAcquisitionBuilder[HasReparamSampler, monte_carlo_expected_improvement]
 ):
     """
-    Builder for a Monte Carlo-based augmented expected improvement function for use with a model
-    without analytical augmented expected improvement (e.g. a deep GP). The "best" value is taken to
-    be the minimum of the posterior mean at observed points. See
-    :class:`monte_carlo_augmented_expected_improvement` for details.
+    Builder for a Monte Carlo-based expected improvement function for use with a model without
+    analytical expected improvement (e.g. a deep GP). The "best" value is taken to be
+    the minimum of the posterior mean at observed points. See
+    :class:`monte_carlo_expected_improvement` for details.
     """
 
     def __init__(self, sample_size: int, *, jitter: float = DEFAULTS.JITTER):
@@ -751,29 +662,24 @@ class MonteCarloAugmentedExpectedImprovement(
 
     def __repr__(self) -> str:
         """"""
-        return (
-            f"MonteCarloAugmentedExpectedImprovement({self._sample_size!r}, "
-            f"jitter={self._jitter!r})"
-        )
+        return f"MonteCarloExpectedImprovement({self._sample_size!r}, jitter={self._jitter!r})"
 
     def prepare_acquisition_function(
         self,
-        model: SupportsReparamSamplerObservationNoise,
+        model: HasReparamSampler,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> monte_carlo_expected_improvement:
         """
         :param model: The model over the specified ``dataset``. Must have output dimension [1].
         :param dataset: The data from the observer. Cannot be empty.
         :return: The estimated *expected improvement* acquisition function.
         :raise ValueError (or InvalidArgumentError): If ``dataset`` is not populated, ``model``
-            does not have an output dimension of [1], does not have a ``reparam_sample`` method, or
-            does not support observation noise.
+            does not have an output dimension of [1] or does not have a ``reparam_sample`` method.
         """
-        if not isinstance(model, SupportsReparamSamplerObservationNoise):
+        if not isinstance(model, HasReparamSampler):
             raise ValueError(
-                f"MonteCarloAugmentedExpectedImprovement only supports models with a "
-                f"reparam_sampler method and that support observation noise; received "
-                f"{model.__repr__()}."
+                f"MonteCarloExpectedImprovement only supports models with a reparam_sampler method;"
+                f"received {model.__repr__()}"
             )
 
         sampler = model.reparam_sampler(self._sample_size)
@@ -793,42 +699,42 @@ class MonteCarloAugmentedExpectedImprovement(
 
         eta = tf.squeeze(tf.reduce_min(mean, axis=0))
 
-        return monte_carlo_augmented_expected_improvement(model, sampler, eta)
+        return monte_carlo_expected_improvement(sampler, eta)
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
-        model: SupportsReparamSamplerObservationNoise,
+        function: monte_carlo_expected_improvement,
+        model: HasReparamSampler,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> monte_carlo_expected_improvement:
         """
         :param function: The acquisition function to update.
-        :param model: The model. Must have output dimension [1]. Unused here
-        :param dataset: The data from the observer. Cannot be empty.
+        :param model: The model. Must have output dimension [1]. Unused here.
+        :param dataset: The data from the observer. Cannot be empty
         """
         tf.debugging.Assert(dataset is not None, [tf.constant([])])
         dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(
-            isinstance(function, monte_carlo_augmented_expected_improvement), [tf.constant([])]
+            isinstance(function, monte_carlo_expected_improvement), [tf.constant([])]
         )
-        sampler = function._sampler  # type: ignore
+        sampler = function._sampler
         sampler.reset_sampler()
         samples_at_query_points = sampler.sample(
             dataset.query_points[..., None, :], jitter=self._jitter
         )
-        mean = tf.reduce_mean(samples_at_query_points, axis=-3, keepdims=True)  # [N, 1, 1, L]
+        mean = tf.reduce_mean(samples_at_query_points, axis=-3, keepdims=True)
 
         tf.debugging.assert_shapes(
             [(mean, [..., 1])], message="Expected model with output dimension [1]."
         )
 
         eta = tf.squeeze(tf.reduce_min(mean, axis=0))
-        function.update(eta)  # type: ignore
+        function.update(eta)
         return function
 
 
-class monte_carlo_augmented_expected_improvement(AcquisitionFunctionClass):
+class monte_carlo_augmented_expected_improvement(AcquisitionFunction):
     r"""
     Return a Monte Carlo based Augmented Expected Improvement (AEI) acquisition function for
     single-objective global optimization with high levels of observation noise. See
@@ -875,83 +781,113 @@ class monte_carlo_augmented_expected_improvement(AcquisitionFunctionClass):
         return augmentation * tf.reduce_mean(improvement, axis=-2)  # [..., 1]
 
 
-class BatchMonteCarloExpectedImprovement(SingleModelAcquisitionBuilder[HasReparamSampler]):
+class MonteCarloAugmentedExpectedImprovement(
+    SingleModelAcquisitionBuilder[
+        SupportsReparamSamplerObservationNoise, monte_carlo_augmented_expected_improvement
+    ]
+):
     """
-    Expected improvement for batches of points (or :math:`q`-EI), approximated using Monte Carlo
-    estimation with the reparametrization trick. See :cite:`Ginsbourger2010` for details.
-    Improvement is measured with respect to the minimum predictive mean at observed query points.
-    This is calculated in :class:`BatchMonteCarloExpectedImprovement` by assuming observations
-    at new points are independent from those at known query points. This is faster, but is an
-    approximation for noisy observers.
+    Builder for a Monte Carlo-based augmented expected improvement function for use with a model
+    without analytical augmented expected improvement (e.g. a deep GP). The "best" value is taken to
+    be the minimum of the posterior mean at observed points. See
+    :class:`monte_carlo_augmented_expected_improvement` for details.
     """
 
     def __init__(self, sample_size: int, *, jitter: float = DEFAULTS.JITTER):
         """
         :param sample_size: The number of samples for each batch of points.
-        :param jitter: The size of the jitter to use when stabilising the Cholesky decomposition of
-            the covariance matrix.
-        :raise tf.errors.InvalidArgumentError: If ``sample_size`` is not positive, or ``jitter``
-            is negative.
+        :param jitter: The jitter for the reparametrization sampler.
+        :raise tf.errors.InvalidArgumentError: If ``sample_size`` is not positive, or ``jitter`` is
+            negative.
         """
         tf.debugging.assert_positive(sample_size)
         tf.debugging.assert_greater_equal(jitter, 0.0)
+
+        super().__init__()
 
         self._sample_size = sample_size
         self._jitter = jitter
 
     def __repr__(self) -> str:
         """"""
-        return f"BatchMonteCarloExpectedImprovement({self._sample_size!r}, jitter={self._jitter!r})"
+        return (
+            f"MonteCarloAugmentedExpectedImprovement({self._sample_size!r}, "
+            f"jitter={self._jitter!r})"
+        )
 
     def prepare_acquisition_function(
         self,
-        model: HasReparamSampler,
+        model: SupportsReparamSamplerObservationNoise,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> monte_carlo_augmented_expected_improvement:
         """
-        :param model: The model. Must have event shape [1].
-        :param dataset: The data from the observer. Must be populated.
-        :return: The batch *expected improvement* acquisition function.
-        :raise ValueError (or InvalidArgumentError): If ``dataset`` is not populated, or ``model``
-            does not have an event shape of [1].
+        :param model: The model over the specified ``dataset``. Must have output dimension [1].
+        :param dataset: The data from the observer. Cannot be empty.
+        :return: The estimated *expected improvement* acquisition function.
+        :raise ValueError (or InvalidArgumentError): If ``dataset`` is not populated, ``model``
+            does not have an output dimension of [1], does not have a ``reparam_sample`` method, or
+            does not support observation noise.
         """
+        if not isinstance(model, SupportsReparamSamplerObservationNoise):
+            raise ValueError(
+                f"MonteCarloAugmentedExpectedImprovement only supports models with a "
+                f"reparam_sampler method and that support observation noise; received "
+                f"{model.__repr__()}."
+            )
+
+        sampler = model.reparam_sampler(self._sample_size)
+
         tf.debugging.Assert(dataset is not None, [tf.constant([])])
         dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
 
-        mean, _ = model.predict(dataset.query_points)
+        samples_at_query_points = sampler.sample(
+            dataset.query_points[..., None, :], jitter=self._jitter
+        )
+        mean = tf.reduce_mean(samples_at_query_points, axis=-3, keepdims=True)  # [N, 1, 1, L]
 
         tf.debugging.assert_shapes(
-            [(mean, ["_", 1])], message="Expected model with event shape [1]."
+            [(mean, [..., 1])], message="Expected model with output dimension [1]."
         )
 
-        eta = tf.reduce_min(mean, axis=0)
-        return batch_monte_carlo_expected_improvement(self._sample_size, model, eta, self._jitter)
+        eta = tf.squeeze(tf.reduce_min(mean, axis=0))
+
+        return monte_carlo_augmented_expected_improvement(model, sampler, eta)
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
-        model: HasReparamSampler,
+        function: monte_carlo_augmented_expected_improvement,
+        model: SupportsReparamSamplerObservationNoise,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> monte_carlo_augmented_expected_improvement:
         """
         :param function: The acquisition function to update.
-        :param model: The model. Must have event shape [1].
-        :param dataset: The data from the observer. Must be populated.
+        :param model: The model. Must have output dimension [1]. Unused here
+        :param dataset: The data from the observer. Cannot be empty.
         """
         tf.debugging.Assert(dataset is not None, [tf.constant([])])
         dataset = cast(Dataset, dataset)
         tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(
-            isinstance(function, batch_monte_carlo_expected_improvement), [tf.constant([])]
+            isinstance(function, monte_carlo_augmented_expected_improvement), [tf.constant([])]
         )
-        mean, _ = model.predict(dataset.query_points)
-        eta = tf.reduce_min(mean, axis=0)
-        function.update(eta)  # type: ignore
+        sampler = function._sampler
+        sampler.reset_sampler()
+        samples_at_query_points = sampler.sample(
+            dataset.query_points[..., None, :], jitter=self._jitter
+        )
+        mean = tf.reduce_mean(samples_at_query_points, axis=-3, keepdims=True)  # [N, 1, 1, L]
+
+        tf.debugging.assert_shapes(
+            [(mean, [..., 1])], message="Expected model with output dimension [1]."
+        )
+
+        eta = tf.squeeze(tf.reduce_min(mean, axis=0))
+        function.update(eta)
         return function
 
 
-class batch_monte_carlo_expected_improvement(AcquisitionFunctionClass):
+class batch_monte_carlo_expected_improvement(AcquisitionFunction):
     def __init__(self, sample_size: int, model: HasReparamSampler, eta: TensorType, jitter: float):
         """
         :param sample_size: The number of Monte-Carlo samples.
@@ -991,56 +927,85 @@ class batch_monte_carlo_expected_improvement(AcquisitionFunctionClass):
         return tf.reduce_mean(batch_improvement, axis=-1, keepdims=True)  # [..., 1]
 
 
-class MultipleOptimismNegativeLowerConfidenceBound(
-    SingleModelVectorizedAcquisitionBuilder[ProbabilisticModel]
+class BatchMonteCarloExpectedImprovement(
+    SingleModelAcquisitionBuilder[HasReparamSampler, batch_monte_carlo_expected_improvement]
 ):
     """
-    A simple parallelization of the lower confidence bound acquisition function that produces
-    a vectorized acquisition function which can efficiently optimized even for large batches.
-
-    See :cite:`torossian2020bayesian` for details.
+    Expected improvement for batches of points (or :math:`q`-EI), approximated using Monte Carlo
+    estimation with the reparametrization trick. See :cite:`Ginsbourger2010` for details.
+    Improvement is measured with respect to the minimum predictive mean at observed query points.
+    This is calculated in :class:`BatchMonteCarloExpectedImprovement` by assuming observations
+    at new points are independent from those at known query points. This is faster, but is an
+    approximation for noisy observers.
     """
 
-    def __init__(self, search_space: SearchSpace):
+    def __init__(self, sample_size: int, *, jitter: float = DEFAULTS.JITTER):
         """
-        :param search_space: The global search space over which the optimisation is defined.
+        :param sample_size: The number of samples for each batch of points.
+        :param jitter: The size of the jitter to use when stabilising the Cholesky decomposition of
+            the covariance matrix.
+        :raise tf.errors.InvalidArgumentError: If ``sample_size`` is not positive, or ``jitter``
+            is negative.
         """
-        self._search_space = search_space
+        tf.debugging.assert_positive(sample_size)
+        tf.debugging.assert_greater_equal(jitter, 0.0)
+
+        self._sample_size = sample_size
+        self._jitter = jitter
 
     def __repr__(self) -> str:
         """"""
-        return f"MultipleOptimismNegativeLowerConfidenceBound({self._search_space!r})"
+        return f"BatchMonteCarloExpectedImprovement({self._sample_size!r}, jitter={self._jitter!r})"
 
     def prepare_acquisition_function(
         self,
-        model: ProbabilisticModel,
+        model: HasReparamSampler,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> batch_monte_carlo_expected_improvement:
         """
-        :param model: The model.
-        :param dataset: Unused.
-        :return: The multiple optimism negative lower confidence bound function.
+        :param model: The model. Must have event shape [1].
+        :param dataset: The data from the observer. Must be populated.
+        :return: The batch *expected improvement* acquisition function.
+        :raise ValueError (or InvalidArgumentError): If ``dataset`` is not populated, or ``model``
+            does not have an event shape of [1].
         """
-        return multiple_optimism_lower_confidence_bound(model, self._search_space.dimension)
+        tf.debugging.Assert(dataset is not None, [tf.constant([])])
+        dataset = cast(Dataset, dataset)
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
+
+        mean, _ = model.predict(dataset.query_points)
+
+        tf.debugging.assert_shapes(
+            [(mean, ["_", 1])], message="Expected model with event shape [1]."
+        )
+
+        eta = tf.reduce_min(mean, axis=0)
+        return batch_monte_carlo_expected_improvement(self._sample_size, model, eta, self._jitter)
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
-        model: ProbabilisticModel,
+        function: batch_monte_carlo_expected_improvement,
+        model: HasReparamSampler,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> batch_monte_carlo_expected_improvement:
         """
         :param function: The acquisition function to update.
-        :param model: The model.
-        :param dataset: Unused.
+        :param model: The model. Must have event shape [1].
+        :param dataset: The data from the observer. Must be populated.
         """
+        tf.debugging.Assert(dataset is not None, [tf.constant([])])
+        dataset = cast(Dataset, dataset)
+        tf.debugging.assert_positive(len(dataset), message="Dataset must be populated.")
         tf.debugging.Assert(
-            isinstance(function, multiple_optimism_lower_confidence_bound), [tf.constant([])]
+            isinstance(function, batch_monte_carlo_expected_improvement), [tf.constant([])]
         )
-        return function  # nothing to update
+        mean, _ = model.predict(dataset.query_points)
+        eta = tf.reduce_min(mean, axis=0)
+        function.update(eta)
+        return function
 
 
-class multiple_optimism_lower_confidence_bound(AcquisitionFunctionClass):
+class multiple_optimism_lower_confidence_bound(AcquisitionFunction):
     r"""
     The multiple optimism lower confidence bound (MOLCB) acquisition function for single-objective
     global optimization.
@@ -1098,7 +1063,58 @@ class multiple_optimism_lower_confidence_bound(AcquisitionFunctionClass):
         return -mean + tf.sqrt(variance) * self._betas  # [..., B]
 
 
-class MakePositive(SingleModelAcquisitionBuilder[ProbabilisticModelType]):
+class MultipleOptimismNegativeLowerConfidenceBound(
+    SingleModelVectorizedAcquisitionBuilder[
+        ProbabilisticModel, multiple_optimism_lower_confidence_bound
+    ]
+):
+    """
+    A simple parallelization of the lower confidence bound acquisition function that produces
+    a vectorized acquisition function which can efficiently optimized even for large batches.
+
+    See :cite:`torossian2020bayesian` for details.
+    """
+
+    def __init__(self, search_space: SearchSpace):
+        """
+        :param search_space: The global search space over which the optimisation is defined.
+        """
+        self._search_space = search_space
+
+    def __repr__(self) -> str:
+        """"""
+        return f"MultipleOptimismNegativeLowerConfidenceBound({self._search_space!r})"
+
+    def prepare_acquisition_function(
+        self,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
+    ) -> multiple_optimism_lower_confidence_bound:
+        """
+        :param model: The model.
+        :param dataset: Unused.
+        :return: The multiple optimism negative lower confidence bound function.
+        """
+        return multiple_optimism_lower_confidence_bound(model, self._search_space.dimension)
+
+    def update_acquisition_function(
+        self,
+        function: multiple_optimism_lower_confidence_bound,
+        model: ProbabilisticModel,
+        dataset: Optional[Dataset] = None,
+    ) -> multiple_optimism_lower_confidence_bound:
+        """
+        :param function: The acquisition function to update.
+        :param model: The model.
+        :param dataset: Unused.
+        """
+        tf.debugging.Assert(
+            isinstance(function, multiple_optimism_lower_confidence_bound), [tf.constant([])]
+        )
+        return function  # nothing to update
+
+
+class MakePositive(SingleModelAcquisitionBuilder[ProbabilisticModelType, AcquisitionFunctionType]):
     r"""
     Converts an acquisition function builder into one that only returns positive values, via
     :math:`x \mapsto \log(1 + \exp(x))`.
@@ -1110,7 +1126,9 @@ class MakePositive(SingleModelAcquisitionBuilder[ProbabilisticModelType]):
 
     def __init__(
         self,
-        base_acquisition_function_builder: SingleModelAcquisitionBuilder[ProbabilisticModelType],
+        base_acquisition_function_builder: SingleModelAcquisitionBuilder[
+            ProbabilisticModelType, AcquisitionFunctionType
+        ],
     ) -> None:
         """
         :param base_acquisition_function_builder: Base acquisition function to be made positive.
@@ -1125,7 +1143,7 @@ class MakePositive(SingleModelAcquisitionBuilder[ProbabilisticModelType]):
         self,
         model: ProbabilisticModelType,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> AcquisitionFunctionType:
         """
         :param model: The model.
         :param dataset: The data to use to build the acquisition function (optional).
@@ -1141,10 +1159,10 @@ class MakePositive(SingleModelAcquisitionBuilder[ProbabilisticModelType]):
 
     def update_acquisition_function(
         self,
-        function: AcquisitionFunction,
+        function: AcquisitionFunctionType,
         model: ProbabilisticModelType,
         dataset: Optional[Dataset] = None,
-    ) -> AcquisitionFunction:
+    ) -> AcquisitionFunctionType:
         """
         :param function: The acquisition function to update.
         :param model: The model.

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -17,7 +17,7 @@ functions --- functions that estimate the utility of evaluating sets of candidat
 """
 from __future__ import annotations
 
-from typing import Mapping, Optional, cast
+from typing import Generic, Mapping, Optional, cast
 
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -430,7 +430,8 @@ def probability_of_feasibility(
 
 
 class ExpectedConstrainedImprovement(
-    AcquisitionFunctionBuilder[ProbabilisticModelType, AcquisitionFunction]
+    AcquisitionFunctionBuilder[ProbabilisticModelType, AcquisitionFunction],
+    Generic[ProbabilisticModelType, AcquisitionFunctionType],
 ):
     """
     Builder for the *expected constrained improvement* acquisition function defined in
@@ -442,7 +443,9 @@ class ExpectedConstrainedImprovement(
     def __init__(
         self,
         objective_tag: str,
-        constraint_builder: AcquisitionFunctionBuilder[ProbabilisticModelType, AcquisitionFunction],
+        constraint_builder: AcquisitionFunctionBuilder[
+            ProbabilisticModelType, AcquisitionFunctionType
+        ],
         min_feasibility_probability: float | TensorType = 0.5,
     ):
         """
@@ -466,7 +469,7 @@ class ExpectedConstrainedImprovement(
         self._objective_tag = objective_tag
         self._constraint_builder = constraint_builder
         self._min_feasibility_probability = min_feasibility_probability
-        self._constraint_fn: Optional[AcquisitionFunction] = None
+        self._constraint_fn: Optional[AcquisitionFunctionType] = None
         self._expected_improvement_fn: Optional[expected_improvement] = None
         self._constrained_improvement_fn: Optional[AcquisitionFunction] = None
 
@@ -549,7 +552,7 @@ class ExpectedConstrainedImprovement(
         )
         tf.debugging.Assert(self._constraint_fn is not None, [tf.constant([])])
 
-        constraint_fn = cast(AcquisitionFunction, self._constraint_fn)
+        constraint_fn = cast(AcquisitionFunctionType, self._constraint_fn)
         self._constraint_builder.update_acquisition_function(
             constraint_fn, models, datasets=datasets
         )

--- a/trieste/acquisition/function/greedy_batch.py
+++ b/trieste/acquisition/function/greedy_batch.py
@@ -47,7 +47,9 @@ from .entropy import MinValueEntropySearch
 from .function import ExpectedImprovement, MakePositive, expected_improvement
 
 
-class LocalPenalization(SingleModelGreedyAcquisitionBuilder[ProbabilisticModel]):
+class LocalPenalization(
+    SingleModelGreedyAcquisitionBuilder[ProbabilisticModel, AcquisitionFunction]
+):
     r"""
     Builder of the acquisition function maker for greedily collecting batches by local
     penalization.  The resulting :const:`AcquisitionFunctionMaker` takes in a set of pending
@@ -79,7 +81,7 @@ class LocalPenalization(SingleModelGreedyAcquisitionBuilder[ProbabilisticModel])
         ] = None,
         base_acquisition_function_builder: ExpectedImprovement
         | MinValueEntropySearch[ProbabilisticModel]
-        | MakePositive[ProbabilisticModel]
+        | MakePositive[ProbabilisticModel, AcquisitionFunction]
         | None = None,
     ):
         """
@@ -101,12 +103,10 @@ class LocalPenalization(SingleModelGreedyAcquisitionBuilder[ProbabilisticModel])
 
         self._lipschitz_penalizer = soft_local_penalizer if penalizer is None else penalizer
 
-        if base_acquisition_function_builder is None:
-            self._base_builder: SingleModelAcquisitionBuilder[
-                ProbabilisticModel
-            ] = ExpectedImprovement()
-        else:
+        if base_acquisition_function_builder is not None:
             self._base_builder = base_acquisition_function_builder
+        else:
+            self._base_builder = ExpectedImprovement()
 
         self._lipschitz_constant = None
         self._eta = None
@@ -223,7 +223,7 @@ class LocalPenalization(SingleModelGreedyAcquisitionBuilder[ProbabilisticModel])
 
         if self._base_acquisition_function is not None:
             self._base_acquisition_function = self._base_builder.update_acquisition_function(
-                self._base_acquisition_function,
+                self._base_acquisition_function,  # type: ignore
                 model,
                 dataset=dataset,
             )

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -32,7 +32,6 @@ from ...utils import DEFAULTS
 from ..interface import (
     AcquisitionFunction,
     AcquisitionFunctionBuilder,
-    AcquisitionFunctionClass,
     GreedyAcquisitionFunctionBuilder,
     PenalizationFunction,
     ProbabilisticModelType,
@@ -142,7 +141,7 @@ class ExpectedHypervolumeImprovement(SingleModelAcquisitionBuilder[Probabilistic
         return function
 
 
-class expected_hv_improvement(AcquisitionFunctionClass):
+class expected_hv_improvement(AcquisitionFunction):
     def __init__(self, model: ProbabilisticModel, partition_bounds: tuple[TensorType, TensorType]):
         r"""
         expected Hyper-volume (HV) calculating using Eq. 44 of :cite:`yang2019efficient` paper.

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -563,9 +563,10 @@ class HIPPO(
         """
         self._objective_tag = objective_tag
         if base_acquisition_function_builder is None:
-            self._base_builder: AcquisitionFunctionBuilder[
-                ProbabilisticModelType, AcquisitionFunctionType
-            ] = ExpectedHypervolumeImprovement().using(self._objective_tag)
+            self._base_builder = cast(
+                AcquisitionFunctionBuilder[ProbabilisticModelType, AcquisitionFunctionType],
+                ExpectedHypervolumeImprovement().using(self._objective_tag),
+            )
         else:
             if isinstance(base_acquisition_function_builder, SingleModelAcquisitionBuilder):
                 self._base_builder = base_acquisition_function_builder.using(self._objective_tag)

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -556,10 +556,10 @@ class HIPPO(
         """
         Initializes the HIPPO acquisition function builder.
 
-        :param objective_tag: The tag for the objective data and model.
         :param base_acquisition_function_builder: Base acquisition function to be
             penalized. Defaults to Expected Hypervolume Improvement, also supports
             its constrained version.
+        :param objective_tag: The tag for the objective data and model.
         """
         self._objective_tag = objective_tag
         if base_acquisition_function_builder is None:

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -32,8 +32,7 @@ from ..models.interfaces import HasReparamSampler, ProbabilisticModelType
 from ..observer import OBJECTIVE
 from ..space import Box, SearchSpace
 from ..types import State, TensorType
-from . import expected_improvement
-from .function import BatchMonteCarloExpectedImprovement, ExpectedImprovement
+from .function import BatchMonteCarloExpectedImprovement, ExpectedImprovement, expected_improvement
 from .function.function import batch_monte_carlo_expected_improvement
 from .interface import (
     AcquisitionFunction,

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -141,7 +141,7 @@ class EfficientGlobalOptimization(
         builder: None = None,
         optimizer: AcquisitionOptimizer[SearchSpaceType] | None = None,
         num_query_points: int = 1,
-        initial_acquisition_function: Optional[expected_improvement] = None,
+        initial_acquisition_function: Optional[AcquisitionFunctionType] = None,
     ):
         ...
 
@@ -197,7 +197,10 @@ class EfficientGlobalOptimization(
 
         if builder is None:
             if num_query_points == 1:
-                builder = ExpectedImprovement()
+                builder = cast(
+                    SingleModelAcquisitionBuilder[ProbabilisticModel, AcquisitionFunctionType],
+                    ExpectedImprovement(),
+                )
             else:
                 raise ValueError(
                     """Need to specify a batch acquisition function when number of query points

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -607,9 +607,10 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                     f" {OBJECTIVE!r}, got keys {datasets.keys()}"
                 )
 
-            acquisition_rule = EfficientGlobalOptimization[
-                SearchSpaceType, TrainableProbabilisticModelType
-            ]()
+            acquisition_rule = cast(
+                AcquisitionRule[TensorType, SearchSpaceType, TrainableProbabilisticModelType],
+                EfficientGlobalOptimization(),
+            )
 
         history: list[FrozenRecord[StateType] | Record[StateType]] = []
         query_plot_dfs: dict[int, pd.DataFrame] = {}

--- a/trieste/models/__init__.py
+++ b/trieste/models/__init__.py
@@ -27,6 +27,5 @@ from .interfaces import (
     TrainableModelStack,
     TrainableProbabilisticModel,
     TrajectoryFunction,
-    TrajectoryFunctionClass,
     TrajectorySampler,
 )

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -39,7 +39,6 @@ from ..interfaces import (
     SupportsGetObservationNoise,
     SupportsPredictJoint,
     TrajectoryFunction,
-    TrajectoryFunctionClass,
     TrajectorySampler,
 )
 
@@ -751,7 +750,7 @@ class ResampleableDecoupledFeatureFunctions(ResampleableRandomFourierFeatureFunc
         return tf.concat([fourier_feature_eval, cannonical_feature_eval], axis=-1)  # [N, L + M]
 
 
-class feature_decomposition_trajectory(TrajectoryFunctionClass):
+class feature_decomposition_trajectory(TrajectoryFunction):
     r"""
     An approximate sample from a Gaussian processes' posterior samples represented as a
     finite weighted sum of features.

--- a/trieste/models/gpflux/sampler.py
+++ b/trieste/models/gpflux/sampler.py
@@ -27,12 +27,7 @@ from gpflux.models import DeepGP
 
 from ...types import TensorType
 from ...utils import DEFAULTS, flatten_leading_dims
-from ..interfaces import (
-    ReparametrizationSampler,
-    TrajectoryFunction,
-    TrajectoryFunctionClass,
-    TrajectorySampler,
-)
+from ..interfaces import ReparametrizationSampler, TrajectoryFunction, TrajectorySampler
 from .interface import GPfluxPredictor
 
 try:
@@ -448,7 +443,7 @@ class ResampleableDecoupledDeepGaussianProcessFeatureFunctions(RFF):  # type: ig
         return tf.concat([fourier_feature_eval, canonical_feature_eval], axis=-1)  # [N, L + M]
 
 
-class dgp_feature_decomposition_trajectory(TrajectoryFunctionClass):
+class dgp_feature_decomposition_trajectory(TrajectoryFunction):
     r"""
     An approximate sample from a deep Gaussian process's posterior, where the samples are
     represented as a finite weighted sum of features. This class essentially takes a list of

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -21,6 +21,7 @@ import gpflow
 import tensorflow as tf
 from typing_extensions import Protocol, runtime_checkable
 
+from ..acquisition import AcquisitionFunction
 from ..data import Dataset
 from ..types import TensorType
 from ..utils import DEFAULTS
@@ -555,31 +556,20 @@ class ReparametrizationSampler(ABC, Generic[ProbabilisticModelType]):
         self._initialized.assign(False)
 
 
-TrajectoryFunction = Callable[[TensorType], TensorType]
-"""
-Type alias for trajectory functions. These have similar behaviour to an :const:`AcquisitionFunction`
-but have additional sampling properties and support multiple model outputs.
-
-An :const:`TrajectoryFunction` evaluates a batch of `B` samples, each across different sets
-of `N` query points (of dimension `D`) i.e. takes input of shape `[N, B, D]` and returns
-shape `[N, B, L]`, where `L` is the number of outputs of the model. Note that we require the `L`
-dimension to be present, even if there is only one output.
-
-A key property of these trajectory functions is that the same sample draw is evaluated
-for all queries. This property is known as consistency.
-"""
-
-
-class TrajectoryFunctionClass(ABC):
+class TrajectoryFunction(AcquisitionFunction):
     """
-    An :class:`TrajectoryFunctionClass` is a trajectory function represented using a class
-    rather than as a standalone function. Using a class to represent a trajectory function
-    makes it easier to update and resample without having to retrace the function.
-    """
+    Type alias for trajectory functions. These have similar behaviour to an
+    :const:`AcquisitionFunction` but have additional sampling properties and support multiple
+    model outputs.
 
-    @abstractmethod
-    def __call__(self, x: TensorType) -> TensorType:
-        """Call trajectory function."""
+    An :const:`TrajectoryFunction` evaluates a batch of `B` samples, each across different sets
+    of `N` query points (of dimension `D`) i.e. takes input of shape `[N, B, D]` and returns
+    shape `[N, B, L]`, where `L` is the number of outputs of the model. Note that we require the `L`
+    dimension to be present, even if there is only one output.
+
+    A key property of these trajectory functions is that the same sample draw is evaluated
+    for all queries. This property is known as consistency.
+    """
 
 
 class TrajectorySampler(ABC, Generic[ProbabilisticModelType]):

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -21,7 +21,6 @@ import gpflow
 import tensorflow as tf
 from typing_extensions import Protocol, runtime_checkable
 
-from ..acquisition import AcquisitionFunction
 from ..data import Dataset
 from ..types import TensorType
 from ..utils import DEFAULTS
@@ -556,7 +555,7 @@ class ReparametrizationSampler(ABC, Generic[ProbabilisticModelType]):
         self._initialized.assign(False)
 
 
-class TrajectoryFunction(AcquisitionFunction):
+class TrajectoryFunction(ABC):
     """
     Type alias for trajectory functions. These have similar behaviour to an
     :const:`AcquisitionFunction` but have additional sampling properties and support multiple
@@ -570,6 +569,10 @@ class TrajectoryFunction(AcquisitionFunction):
     A key property of these trajectory functions is that the same sample draw is evaluated
     for all queries. This property is known as consistency.
     """
+
+    @abstractmethod
+    def __call__(self, x: TensorType) -> TensorType:
+        """Call trajectory function."""
 
 
 class TrajectorySampler(ABC, Generic[ProbabilisticModelType]):

--- a/trieste/models/keras/sampler.py
+++ b/trieste/models/keras/sampler.py
@@ -26,7 +26,7 @@ import tensorflow_probability as tfp
 
 from ...types import TensorType
 from ...utils import flatten_leading_dims
-from ..interfaces import TrajectoryFunction, TrajectoryFunctionClass, TrajectorySampler
+from ..interfaces import TrajectoryFunction, TrajectorySampler
 from .interface import DeepEnsembleModel
 from .utils import sample_model_index
 
@@ -111,7 +111,7 @@ class DeepEnsembleTrajectorySampler(TrajectorySampler[DeepEnsembleModel]):
         return trajectory
 
 
-class deep_ensemble_trajectory(TrajectoryFunctionClass):
+class deep_ensemble_trajectory(TrajectoryFunction):
     """
     Generate an approximate function draw (trajectory) by randomly choosing a batch B of
     networks from the ensemble and using their predicted means as trajectories.


### PR DESCRIPTION
Making `AcquisitionFunctionBuilder` generic in the `AcquisitionFunction` type allows us to better typecheck `update_acquisition_function` calls. This resulted in:

- Some improved builders that no longer need to rely on `assert` and `type: ignore` in their update methods.
- Some fiddly builders which I left as returning AcquisitionFunction for now.
- Some builders that depend on another builder, which I made generic in the type of the sub-builder (with defaults where appropriate).

The downside of all this is more code complexity, but there is little impact on external code (e.g. the notebooks didn't have to change at all).