### PR TITLE
Allow zero kernel samples in gpr hyper init

### DIFF
--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -501,7 +501,7 @@ def test_gaussian_process_regression_correctly_counts_params_that_can_be_sampled
     else:
         mocked_model_initializer.assert_called_once()
         num_samples = mocked_model_initializer.call_args[0][0]
-        npt.assert_array_equal(num_samples, 10 * (dim + 1))
+        npt.assert_array_equal(num_samples, num_kernel_samples * (dim + 1))
 
 
 def test_gaussian_process_regression_best_initialization_changes_params_with_priors(

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -102,7 +102,7 @@ class GaussianProcessRegression(
 
         check_optimizer(self.optimizer)
 
-        if num_kernel_samples <= 0:
+        if num_kernel_samples < 0:
             raise ValueError(
                 f"num_kernel_samples must be greater or equal to zero but got {num_kernel_samples}."
             )
@@ -110,7 +110,7 @@ class GaussianProcessRegression(
 
         if num_rff_features <= 0:
             raise ValueError(
-                f"num_rff_features must be greater or equal to zero but got {num_rff_features}."
+                f"num_rff_features must be greater than zero but got {num_rff_features}."
             )
         self._num_rff_features = num_rff_features
         self._use_decoupled_sampler = use_decoupled_sampler


### PR DESCRIPTION
Also fix an incorrect error message regarding num_rff_features.