### PR TITLE
Allow dataset/model tags to be arbitrary hashables

### DIFF
--- a/docs/notebooks/explicit_constraints.pct.py
+++ b/docs/notebooks/explicit_constraints.pct.py
@@ -46,7 +46,9 @@ constraints = [
         lb=tf.constant([-0.4, 0.15, 0.2]),
         ub=tf.constant([0.5, 0.9, 0.9]),
     ),
-    NonlinearConstraint(_nlc_func, tf.constant([-1.0, -0.8]), tf.constant([0.0, 0.0])),
+    NonlinearConstraint(
+        _nlc_func, tf.constant([-1.0, -0.8]), tf.constant([0.0, 0.0])
+    ),
 ]
 
 search_space = Box([0, 0], [1, 1], constraints=constraints)  # type: ignore
@@ -89,7 +91,9 @@ from trieste.experimental.plotting import plot_function_2d
     np.linspace(search_space.lower[0], search_space.upper[0], 100),
     np.linspace(search_space.lower[1], search_space.upper[1], 100),
 )
-xplot = np.vstack((xi.ravel(), xj.ravel())).T  # Change our input grid to list of coordinates.
+xplot = np.vstack(
+    (xi.ravel(), xj.ravel())
+).T  # Change our input grid to list of coordinates.
 constraint_values = np.reshape(search_space.is_feasible(xplot), xi.shape)
 
 _, ax = plot_function_2d(
@@ -102,10 +106,22 @@ _, ax = plot_function_2d(
 
 points = search_space.sample_halton_feasible(200)
 
-ax[0, 0].scatter(points[:, 0], points[:, 1], s=15, c="tab:orange", edgecolors="black", marker="o")
+ax[0, 0].scatter(
+    points[:, 0],
+    points[:, 1],
+    s=15,
+    c="tab:orange",
+    edgecolors="black",
+    marker="o",
+)
 
 ax[0, 0].contourf(
-    xi, xj, constraint_values, levels=1, colors=[(0.2, 0.2, 0.2, 0.7), (1, 1, 1, 0)], zorder=1
+    xi,
+    xj,
+    constraint_values,
+    levels=1,
+    colors=[(0.2, 0.2, 0.2, 0.7), (1, 1, 1, 0)],
+    zorder=1,
 )
 
 ax[0, 0].set_xlabel(r"$x_1$")
@@ -132,7 +148,10 @@ model = GaussianProcessRegression(gpflow_model)
 # Note this method penalises the expected improvement acquisition outside the feasible region. The optimizer uses unconstrained L-BFGS method to find the max of the acquistion function.
 
 # %%
-from trieste.acquisition.function import ExpectedConstrainedImprovement, FastConstraintsFeasibility
+from trieste.acquisition.function import (
+    ExpectedConstrainedImprovement,
+    FastConstraintsFeasibility,
+)
 from trieste.acquisition.rule import EfficientGlobalOptimization
 from trieste.observer import OBJECTIVE
 
@@ -182,11 +201,21 @@ _, ax = plot_function_2d(
 )
 
 plot_bo_points(
-    query_points, ax[0, 0], num_initial_points, arg_min_idx, c_pass="green", c_best="purple"
+    query_points,
+    ax[0, 0],
+    num_initial_points,
+    arg_min_idx,
+    c_pass="green",
+    c_best="purple",
 )
 
 ax[0, 0].contourf(
-    xi, xj, constraint_values, levels=1, colors=[(0.2, 0.2, 0.2, 0.7), (1, 1, 1, 0)], zorder=2
+    xi,
+    xj,
+    constraint_values,
+    levels=1,
+    colors=[(0.2, 0.2, 0.2, 0.7), (1, 1, 1, 0)],
+    zorder=2,
 )
 
 ax[0, 0].set_xlabel(r"$x_1$")

--- a/docs/notebooks/failure_ego.pct.py
+++ b/docs/notebooks/failure_ego.pct.py
@@ -116,9 +116,10 @@ from trieste.models.gpflow.models import (
     VariationalGaussianProcess,
 )
 from trieste.models.optimizer import BatchOptimizer
+from trieste.types import Tag
 
 
-models: dict[str, TrainableProbabilisticModel] = {
+models: dict[Tag, TrainableProbabilisticModel] = {
     OBJECTIVE: GaussianProcessRegression(regression_model),
     FAILURE: VariationalGaussianProcess(
         classification_model,

--- a/docs/notebooks/multifidelity_modelling.pct.py
+++ b/docs/notebooks/multifidelity_modelling.pct.py
@@ -48,9 +48,9 @@ tf.random.set_seed(1793)
 # Define the multifidelity simulator
 def simulator(x_input, fidelity, add_noise=False):
 
-    f = 0.5 * ((6.0 * x_input - 2.0) ** 2) * tf.math.sin(12.0 * x_input - 4.0) + 10.0 * (
-        x_input - 1.0
-    )
+    f = 0.5 * ((6.0 * x_input - 2.0) ** 2) * tf.math.sin(
+        12.0 * x_input - 4.0
+    ) + 10.0 * (x_input - 1.0)
     f = f + fidelity * (f - 20.0 * (x_input - 1.0))
     if add_noise:
         noise = tf.random.normal(f.shape, stddev=1e-1, dtype=f.dtype)
@@ -129,7 +129,9 @@ xs = [tf.linspace(0, 1, sample_sizes[0])[:, None]]
 # Take a subsample of each lower fidelity to sample at the next fidelity up
 for fidelity in range(1, n_fidelities):
     samples = tf.Variable(
-        np.random.choice(xs[fidelity - 1][:, 0], size=sample_sizes[fidelity], replace=False)
+        np.random.choice(
+            xs[fidelity - 1][:, 0], size=sample_sizes[fidelity], replace=False
+        )
     )[:, None]
     xs.append(samples)
 # Add fidelity columns to training data
@@ -163,7 +165,9 @@ from trieste.models.gpflow import (
 
 # Initialise model
 multifidelity_model = MultifidelityAutoregressive(
-    build_multifidelity_autoregressive_models(initial_data, n_fidelities, input_search_space)
+    build_multifidelity_autoregressive_models(
+        initial_data, n_fidelities, input_search_space
+    )
 )
 
 # Update and optimize model
@@ -187,9 +191,24 @@ gt_colors = ["tab:red", "tab:purple", "tab:brown"]
 
 for fidelity, prediction in enumerate(predictions):
     mean, var = prediction
-    ax.plot(X, mean, label=f"Predicted fidelity {fidelity}", color=pred_colors[fidelity])
-    ax.plot(X, mean + 1.96 * tf.math.sqrt(var), alpha=0.2, color=pred_colors[fidelity])
-    ax.plot(X, mean - 1.96 * tf.math.sqrt(var), alpha=0.2, color=pred_colors[fidelity])
+    ax.plot(
+        X,
+        mean,
+        label=f"Predicted fidelity {fidelity}",
+        color=pred_colors[fidelity],
+    )
+    ax.plot(
+        X,
+        mean + 1.96 * tf.math.sqrt(var),
+        alpha=0.2,
+        color=pred_colors[fidelity],
+    )
+    ax.plot(
+        X,
+        mean - 1.96 * tf.math.sqrt(var),
+        alpha=0.2,
+        color=pred_colors[fidelity],
+    )
     ax.plot(
         X,
         observer(X_list[fidelity], add_noise=False).observations,
@@ -256,7 +275,9 @@ ax.plot(
 )
 
 # Scatter the data
-ax.scatter(hf_data.query_points, hf_data.observations, label=f"Data", color="tab:green")
+ax.scatter(
+    hf_data.query_points, hf_data.observations, label=f"Data", color="tab:green"
+)
 plt.legend()
 plt.show()
 

--- a/docs/notebooks/qhsri-tutorial.pct.py
+++ b/docs/notebooks/qhsri-tutorial.pct.py
@@ -85,7 +85,9 @@ plt.show()
 # %%
 from trieste.acquisition.multi_objective.dominance import non_dominated
 
-uniform_non_dominated = non_dominated(tf.concat([uniform_pts_mean, uniform_pts_std], axis=1))[0]
+uniform_non_dominated = non_dominated(
+    tf.concat([uniform_pts_mean, uniform_pts_std], axis=1)
+)[0]
 
 plt.scatter(uniform_pts_mean, uniform_pts_std)
 plt.scatter(uniform_non_dominated[:, 0], uniform_non_dominated[:, 1], c="r")
@@ -158,7 +160,9 @@ from trieste.acquisition.multi_objective import Pareto
 # Since we've already ensured the set is non-dominated we don't need to repeat this
 front = Pareto(optimised_non_dominated, already_non_dominated=True)
 
-sampled_points, _ = front.sample_diverse_subset(sample_size=5, allow_repeats=False)
+sampled_points, _ = front.sample_diverse_subset(
+    sample_size=5, allow_repeats=False
+)
 
 # %% [markdown]
 # Now we can see which points we selected from the Pareto front
@@ -218,7 +222,9 @@ results = bo.optimize(
 # %%
 from trieste.experimental.plotting import plot_regret
 
-observations = results.try_get_final_dataset().observations - ScaledBranin.minimum
+observations = (
+    results.try_get_final_dataset().observations - ScaledBranin.minimum
+)
 
 min_idx = tf.squeeze(tf.argmin(observations, axis=0))
 min_regret = tf.reduce_min(observations)

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -81,7 +81,7 @@ from trieste.objectives import ScaledBranin, SimpleQuadratic
 from trieste.objectives.utils import mk_observer
 from trieste.observer import OBJECTIVE
 from trieste.space import Box, SearchSpace
-from trieste.types import State, Tag, TensorType
+from trieste.types import State, TensorType
 
 try:
     import pymoo
@@ -515,7 +515,7 @@ def _test_optimizer_finds_minimum(
         TrainableProbabilisticModelType,
     ],
     optimize_branin: bool = False,
-    model_args: Optional[Mapping[Tag, Any]] = None,
+    model_args: Optional[Mapping[str, Any]] = None,
     check_regret: bool = False,
 ) -> None:
     model_args = model_args or {}

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -81,7 +81,7 @@ from trieste.objectives import ScaledBranin, SimpleQuadratic
 from trieste.objectives.utils import mk_observer
 from trieste.observer import OBJECTIVE
 from trieste.space import Box, SearchSpace
-from trieste.types import State, TensorType
+from trieste.types import State, Tag, TensorType
 
 try:
     import pymoo
@@ -515,7 +515,7 @@ def _test_optimizer_finds_minimum(
         TrainableProbabilisticModelType,
     ],
     optimize_branin: bool = False,
-    model_args: Optional[Mapping[str, Any]] = None,
+    model_args: Optional[Mapping[Tag, Any]] = None,
     check_regret: bool = False,
 ) -> None:
     model_args = model_args or {}

--- a/tests/integration/test_constrained_bayesian_optimization.py
+++ b/tests/integration/test_constrained_bayesian_optimization.py
@@ -26,6 +26,7 @@ from trieste.bayesian_optimizer import BayesianOptimizer
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.models.gpflow import GaussianProcessRegression, build_gpr
+from trieste.observer import OBJECTIVE
 from trieste.space import Box
 from trieste.types import Tag, TensorType
 
@@ -60,7 +61,6 @@ def test_optimizer_finds_minima_of_Gardners_Simulation_1(
     MINIMUM = -2.0
     MINIMIZER = [math.pi * 1.5, 0.0]
 
-    OBJECTIVE = "OBJECTIVE"
     CONSTRAINT = "CONSTRAINT"
 
     # observe both objective and constraint data

--- a/tests/integration/test_constrained_bayesian_optimization.py
+++ b/tests/integration/test_constrained_bayesian_optimization.py
@@ -27,7 +27,7 @@ from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.models.gpflow import GaussianProcessRegression, build_gpr
 from trieste.space import Box
-from trieste.types import TensorType
+from trieste.types import Tag, TensorType
 
 
 @random_seed
@@ -64,7 +64,7 @@ def test_optimizer_finds_minima_of_Gardners_Simulation_1(
     CONSTRAINT = "CONSTRAINT"
 
     # observe both objective and constraint data
-    def observer(query_points: TensorType) -> dict[str, Dataset]:
+    def observer(query_points: TensorType) -> dict[Tag, Dataset]:
         return {
             OBJECTIVE: Dataset(query_points, objective(query_points)),
             CONSTRAINT: Dataset(query_points, constraint(query_points)),

--- a/tests/unit/acquisition/function/test_function.py
+++ b/tests/unit/acquisition/function/test_function.py
@@ -69,7 +69,7 @@ from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.objectives import Branin
 from trieste.space import Box, LinearConstraint
-from trieste.types import TensorType
+from trieste.types import Tag, TensorType
 
 
 def test_probability_of_improvement_builder_builds_pi_using_best_from_model() -> None:
@@ -882,8 +882,8 @@ def test_expected_constrained_improvement_can_reproduce_expected_improvement() -
     class _Certainty(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             return lambda x: tf.ones_like(tf.squeeze(x, -2))
 
@@ -913,8 +913,8 @@ def test_expected_constrained_improvement_is_relative_to_feasible_point() -> Non
     class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             return lambda x: tf.cast(tf.squeeze(x, -2) >= 0, x.dtype)
 
@@ -936,8 +936,8 @@ def test_expected_constrained_improvement_is_less_for_constrained_points() -> No
     class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             return lambda x: tf.cast(tf.squeeze(x, -2) >= 0, x.dtype)
 
@@ -960,8 +960,8 @@ def test_expected_constrained_improvement_raises_for_empty_data() -> None:
     class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             return raise_exc
 
@@ -979,8 +979,8 @@ def test_expected_constrained_improvement_is_constraint_when_no_feasible_points(
     class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             def acquisition(x: TensorType) -> TensorType:
                 x_ = tf.squeeze(x, -2)
@@ -1008,8 +1008,8 @@ def test_expected_constrained_improvement_min_feasibility_probability_bound_is_i
     class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             return pof
 

--- a/tests/unit/acquisition/function/test_greedy_batch.py
+++ b/tests/unit/acquisition/function/test_greedy_batch.py
@@ -45,6 +45,7 @@ from trieste.acquisition.function.greedy_batch import (
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.models.gpflow import GaussianProcessRegression
+from trieste.observer import OBJECTIVE
 from trieste.space import Box
 from trieste.types import Tag, TensorType
 
@@ -185,14 +186,14 @@ def test_lipschitz_penalizers_raises_for_invalid_pending_points_shape(
 
 def test_fantasized_expected_improvement_builder_raises_for_invalid_fantasize_method() -> None:
     with pytest.raises(tf.errors.InvalidArgumentError):
-        Fantasizer(ExpectedImprovement().using("OBJECTIVE"), "notKB")
+        Fantasizer(ExpectedImprovement().using(OBJECTIVE), "notKB")
 
 
 def test_fantasized_expected_improvement_builder_raises_for_invalid_model() -> None:
     data = {
-        "OBJECTIVE": Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 1], dtype=tf.float64))
+        OBJECTIVE: Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 1], dtype=tf.float64))
     }
-    models = {"OBJECTIVE": QuadraticMeanAndRBFKernel()}
+    models = {OBJECTIVE: QuadraticMeanAndRBFKernel()}
     pending_points = tf.zeros([3, 2], dtype=tf.float64)
     builder = Fantasizer()
 
@@ -205,8 +206,8 @@ def test_fantasized_expected_improvement_builder_raises_for_invalid_observation_
     y1 = tf.ones([3, 1], dtype=tf.float64)
     y2 = tf.ones([3, 2], dtype=tf.float64)
 
-    data = {"OBJECTIVE": Dataset(x, y1)}
-    models = {"OBJECTIVE": GaussianProcessRegression(gpr_model(x, y2))}
+    data = {OBJECTIVE: Dataset(x, y1)}
+    models = {OBJECTIVE: GaussianProcessRegression(gpr_model(x, y2))}
     pending_points = tf.zeros([3, 2], dtype=tf.float64)
     builder = Fantasizer()
 
@@ -221,8 +222,8 @@ def test_fantasized_expected_improvement_builder_raises_for_invalid_pending_poin
     x = tf.zeros([3, 2], dtype=tf.float64)
     y = tf.ones([3, 1], dtype=tf.float64)
 
-    data = {"OBJECTIVE": Dataset(x, y)}
-    models = {"OBJECTIVE": GaussianProcessRegression(gpr_model(x, y))}
+    data = {OBJECTIVE: Dataset(x, y)}
+    models = {OBJECTIVE: GaussianProcessRegression(gpr_model(x, y))}
 
     builder = Fantasizer()
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
@@ -239,14 +240,12 @@ def test_fantasize_with_kriging_believer_does_not_change_negative_predictive_mea
     x_test = to_default_float(tf.constant(np.arange(1, 13).reshape(-1, 1) / 12.0))[..., None]
     pending_points = to_default_float(tf.constant([0.51, 0.81])[:, None])
 
-    data = {"OBJECTIVE": Dataset(x, y)}
+    data = {OBJECTIVE: Dataset(x, y)}
     models: Mapping[Tag, FantasizerModelOrStack]
     if model_type == "stack":
-        models = {
-            "OBJECTIVE": FantasizerModelStack((GaussianProcessRegression(gpr_model(x, y)), 1))
-        }
+        models = {OBJECTIVE: FantasizerModelStack((GaussianProcessRegression(gpr_model(x, y)), 1))}
     else:
-        models = {"OBJECTIVE": GaussianProcessRegression(gpr_model(x, y))}
+        models = {OBJECTIVE: GaussianProcessRegression(gpr_model(x, y))}
 
     builder = Fantasizer(NegativePredictiveMean())
     acq0 = builder.prepare_acquisition_function(models, data)
@@ -267,14 +266,12 @@ def test_fantasize_reduces_predictive_variance(model_type: str, fantasize_method
     x_test = to_default_float(tf.constant(np.arange(1, 13).reshape(-1, 1) / 12.0))[..., None]
     pending_points = to_default_float(tf.constant([0.51, 0.81])[:, None])
 
-    data = {"OBJECTIVE": Dataset(x, y)}
+    data = {OBJECTIVE: Dataset(x, y)}
     models: Mapping[Tag, FantasizerModelOrStack]
     if model_type == "stack":
-        models = {
-            "OBJECTIVE": FantasizerModelStack((GaussianProcessRegression(gpr_model(x, y)), 1))
-        }
+        models = {OBJECTIVE: FantasizerModelStack((GaussianProcessRegression(gpr_model(x, y)), 1))}
     else:
-        models = {"OBJECTIVE": GaussianProcessRegression(gpr_model(x, y))}
+        models = {OBJECTIVE: GaussianProcessRegression(gpr_model(x, y))}
 
     builder = Fantasizer(PredictiveVariance(), fantasize_method=fantasize_method)
     acq0 = builder.prepare_acquisition_function(models, data)

--- a/tests/unit/acquisition/function/test_greedy_batch.py
+++ b/tests/unit/acquisition/function/test_greedy_batch.py
@@ -46,7 +46,7 @@ from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.models.gpflow import GaussianProcessRegression
 from trieste.space import Box
-from trieste.types import TensorType
+from trieste.types import Tag, TensorType
 
 
 def test_locally_penalized_expected_improvement_builder_raises_for_empty_data() -> None:
@@ -240,7 +240,7 @@ def test_fantasize_with_kriging_believer_does_not_change_negative_predictive_mea
     pending_points = to_default_float(tf.constant([0.51, 0.81])[:, None])
 
     data = {"OBJECTIVE": Dataset(x, y)}
-    models: Mapping[str, FantasizerModelOrStack]
+    models: Mapping[Tag, FantasizerModelOrStack]
     if model_type == "stack":
         models = {
             "OBJECTIVE": FantasizerModelStack((GaussianProcessRegression(gpr_model(x, y)), 1))
@@ -268,7 +268,7 @@ def test_fantasize_reduces_predictive_variance(model_type: str, fantasize_method
     pending_points = to_default_float(tf.constant([0.51, 0.81])[:, None])
 
     data = {"OBJECTIVE": Dataset(x, y)}
-    models: Mapping[str, FantasizerModelOrStack]
+    models: Mapping[Tag, FantasizerModelOrStack]
     if model_type == "stack":
         models = {
             "OBJECTIVE": FantasizerModelStack((GaussianProcessRegression(gpr_model(x, y)), 1))

--- a/tests/unit/acquisition/multi_objective/test_function.py
+++ b/tests/unit/acquisition/multi_objective/test_function.py
@@ -61,7 +61,7 @@ from trieste.acquisition.multi_objective.partition import (
 )
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel, ProbabilisticModelType, ReparametrizationSampler
-from trieste.types import TensorType
+from trieste.types import Tag, TensorType
 from trieste.utils import DEFAULTS
 
 
@@ -79,8 +79,8 @@ def _mo_test_model(
 class _Certainty(AcquisitionFunctionBuilder[ProbabilisticModel]):
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         return lambda x: tf.ones((tf.shape(x)[0], 1), dtype=tf.float64)
 
@@ -752,8 +752,8 @@ def test_expected_constrained_hypervolume_improvement_based_on_specified_ref_poi
     class _Certainty(AcquisitionFunctionBuilder[ProbabilisticModelType]):
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             return lambda x: tf.ones_like(tf.squeeze(x, -2))
 
@@ -794,8 +794,8 @@ def test_echvi_is_constraint_when_no_feasible_points() -> None:
     class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             def acquisition(x: TensorType) -> TensorType:
                 x_ = tf.squeeze(x, -2)
@@ -831,8 +831,8 @@ def test_echvi_raises_for_empty_data() -> None:
     class _Constraint(AcquisitionFunctionBuilder[ProbabilisticModel]):
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             return raise_exc
 

--- a/tests/unit/acquisition/multi_objective/test_function.py
+++ b/tests/unit/acquisition/multi_objective/test_function.py
@@ -64,6 +64,10 @@ from trieste.models import ProbabilisticModel, ProbabilisticModelType, Reparamet
 from trieste.types import Tag, TensorType
 from trieste.utils import DEFAULTS
 
+# tags
+FOO: Tag = "foo"
+NA: Tag = ""
+
 
 def _mo_test_model(
     num_obj: int, *kernel_amplitudes: float | TensorType | None, with_reparam_sampler: bool = True
@@ -669,13 +673,13 @@ def test_batch_monte_carlo_expected_hypervolume_improvement_utility_on_specified
 def test_expected_constrained_hypervolume_improvement_raises_for_invalid_batch_size(
     at: TensorType,
 ) -> None:
-    pof = ProbabilityOfFeasibility(0.0).using("")
-    builder = ExpectedConstrainedHypervolumeImprovement("", pof, tf.constant(0.5))
+    pof = ProbabilityOfFeasibility(0.0).using(NA)
+    builder = ExpectedConstrainedHypervolumeImprovement(NA, pof, tf.constant(0.5))
     initial_query_points = tf.constant([[-1.0]])
     initial_objective_function_values = tf.constant([[1.0, 1.0]])
-    data = {"": Dataset(initial_query_points, initial_objective_function_values)}
+    data = {NA: Dataset(initial_query_points, initial_objective_function_values)}
 
-    echvi = builder.prepare_acquisition_function({"": QuadraticMeanAndRBFKernel()}, datasets=data)
+    echvi = builder.prepare_acquisition_function({NA: QuadraticMeanAndRBFKernel()}, datasets=data)
 
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
         echvi(at)
@@ -690,32 +694,32 @@ def test_expected_constrained_hypervolume_improvement_can_reproduce_ehvi() -> No
     obj_model = _mo_test_model(num_obj, *[None] * num_obj)
     model_pred_observation = obj_model.predict(train_x)[0]
 
-    data = {"foo": Dataset(train_x[:5], model_pred_observation[:5])}
-    models_ = {"foo": obj_model}
+    data = {FOO: Dataset(train_x[:5], model_pred_observation[:5])}
+    models_ = {FOO: obj_model}
 
     builder = ExpectedConstrainedHypervolumeImprovement(
-        "foo",
+        FOO,
         _Certainty(),
         0,
-        reference_point_spec=get_reference_point(Pareto(data["foo"].observations).front),
+        reference_point_spec=get_reference_point(Pareto(data[FOO].observations).front),
     )
     echvi = builder.prepare_acquisition_function(models_, datasets=data)
 
     ehvi = (
         ExpectedHypervolumeImprovement()
-        .using("foo")
+        .using(FOO)
         .prepare_acquisition_function(models_, datasets=data)
     )
 
     at = tf.constant([[[-0.1]], [[1.23]], [[-6.78]]], dtype=tf.float64)
     npt.assert_allclose(echvi(at), ehvi(at))
 
-    new_data = {"foo": Dataset(train_x, model_pred_observation)}
+    new_data = {FOO: Dataset(train_x, model_pred_observation)}
     up_echvi = builder.update_acquisition_function(echvi, models_, datasets=new_data)
     assert up_echvi == echvi
     up_ehvi = (
         ExpectedHypervolumeImprovement()
-        .using("foo")
+        .using(FOO)
         .prepare_acquisition_function(models_, datasets=new_data)
     )
 
@@ -757,32 +761,32 @@ def test_expected_constrained_hypervolume_improvement_based_on_specified_ref_poi
         ) -> AcquisitionFunction:
             return lambda x: tf.ones_like(tf.squeeze(x, -2))
 
-    data = {"foo": Dataset(train_x[:5], model_pred_observation[:5])}
-    models_ = {"foo": obj_model}
+    data = {FOO: Dataset(train_x[:5], model_pred_observation[:5])}
+    models_ = {FOO: obj_model}
 
     builder = ExpectedConstrainedHypervolumeImprovement(  # type: ignore
-        "foo",
+        FOO,
         _Certainty(),
         0,
-        reference_point_spec=get_reference_point(Pareto(data["foo"].observations).front),
+        reference_point_spec=get_reference_point(Pareto(data[FOO].observations).front),
     )
     echvi = builder.prepare_acquisition_function(models_, datasets=data)
 
     ehvi = (
         ExpectedHypervolumeImprovement()
-        .using("foo")
+        .using(FOO)
         .prepare_acquisition_function(models_, datasets=data)
     )
 
     at = tf.constant([[[-0.1]], [[1.23]], [[-6.78]]], dtype=tf.float64)
     npt.assert_allclose(echvi(at), ehvi(at))
 
-    new_data = {"foo": Dataset(train_x, model_pred_observation)}
+    new_data = {FOO: Dataset(train_x, model_pred_observation)}
     up_echvi = builder.update_acquisition_function(echvi, models_, datasets=new_data)
     assert up_echvi == echvi
     up_ehvi = (
         ExpectedHypervolumeImprovement()
-        .using("foo")
+        .using(FOO)
         .prepare_acquisition_function(models_, datasets=new_data)
     )
 
@@ -803,10 +807,10 @@ def test_echvi_is_constraint_when_no_feasible_points() -> None:
 
             return acquisition
 
-    data = {"foo": Dataset(tf.constant([[-2.0], [1.0]]), tf.constant([[4.0], [1.0]]))}
-    models_ = {"foo": QuadraticMeanAndRBFKernel()}
+    data = {FOO: Dataset(tf.constant([[-2.0], [1.0]]), tf.constant([[4.0], [1.0]]))}
+    models_ = {FOO: QuadraticMeanAndRBFKernel()}
     echvi = ExpectedConstrainedHypervolumeImprovement(
-        "foo", _Constraint()
+        FOO, _Constraint()
     ).prepare_acquisition_function(models_, datasets=data)
 
     constraint_fn = _Constraint().prepare_acquisition_function(models_, datasets=data)
@@ -816,15 +820,15 @@ def test_echvi_is_constraint_when_no_feasible_points() -> None:
 
 
 def test_echvi_raises_for_non_scalar_min_pof() -> None:
-    pof = ProbabilityOfFeasibility(0.0).using("")
+    pof = ProbabilityOfFeasibility(0.0).using(NA)
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
-        ExpectedConstrainedHypervolumeImprovement("", pof, tf.constant([0.0]))
+        ExpectedConstrainedHypervolumeImprovement(NA, pof, tf.constant([0.0]))
 
 
 def test_echvi_raises_for_out_of_range_min_pof() -> None:
-    pof = ProbabilityOfFeasibility(0.0).using("")
+    pof = ProbabilityOfFeasibility(0.0).using(NA)
     with pytest.raises(tf.errors.InvalidArgumentError):
-        ExpectedConstrainedHypervolumeImprovement("", pof, 1.5)
+        ExpectedConstrainedHypervolumeImprovement(NA, pof, 1.5)
 
 
 def test_echvi_raises_for_empty_data() -> None:
@@ -836,9 +840,9 @@ def test_echvi_raises_for_empty_data() -> None:
         ) -> AcquisitionFunction:
             return raise_exc
 
-    data = {"foo": Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))}
-    models_ = {"foo": QuadraticMeanAndRBFKernel()}
-    builder = ExpectedConstrainedHypervolumeImprovement("foo", _Constraint())
+    data = {FOO: Dataset(tf.zeros([0, 2]), tf.zeros([0, 1]))}
+    models_ = {FOO: QuadraticMeanAndRBFKernel()}
+    builder = ExpectedConstrainedHypervolumeImprovement(FOO, _Constraint())
 
     with pytest.raises(tf.errors.InvalidArgumentError):
         builder.prepare_acquisition_function(models_, datasets=data)
@@ -848,9 +852,9 @@ def test_echvi_raises_for_empty_data() -> None:
 
 def test_hippo_builder_raises_for_empty_data() -> None:
     num_obj = 3
-    dataset = {"": empty_dataset([2], [num_obj])}
-    model = {"": QuadraticMeanAndRBFKernel()}
-    hippo = cast(GreedyAcquisitionFunctionBuilder[QuadraticMeanAndRBFKernel], HIPPO(""))
+    dataset = {NA: empty_dataset([2], [num_obj])}
+    model = {NA: QuadraticMeanAndRBFKernel()}
+    hippo = cast(GreedyAcquisitionFunctionBuilder[QuadraticMeanAndRBFKernel], HIPPO(NA))
 
     with pytest.raises(tf.errors.InvalidArgumentError):
         hippo.prepare_acquisition_function(model, dataset)
@@ -903,18 +907,18 @@ def test_hippo_penalizer_penalizes_pending_point(point_to_penalize: TensorType) 
 @pytest.mark.parametrize(
     "base_builder",
     [
-        ExpectedHypervolumeImprovement().using(""),
-        ExpectedConstrainedHypervolumeImprovement("", _Certainty(), 0.0),
+        ExpectedHypervolumeImprovement().using(NA),
+        ExpectedConstrainedHypervolumeImprovement(NA, _Certainty(), 0.0),
     ],
 )
 def test_hippo_penalized_acquisitions_match_base_acquisition(
     base_builder: AcquisitionFunctionBuilder[ProbabilisticModel],
 ) -> None:
-    data = {"": Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))}
-    model = {"": _mo_test_model(2, *[None] * 2)}
+    data = {NA: Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))}
+    model = {NA: _mo_test_model(2, *[None] * 2)}
 
     hippo_acq_builder: HIPPO[ProbabilisticModel] = HIPPO(
-        "", base_acquisition_function_builder=base_builder
+        NA, base_acquisition_function_builder=base_builder
     )
     hippo_acq = hippo_acq_builder.prepare_acquisition_function(model, data, None)
 
@@ -933,23 +937,23 @@ def test_hippo_penalized_acquisitions_match_base_acquisition(
 @pytest.mark.parametrize(
     "base_builder",
     [
-        ExpectedHypervolumeImprovement().using(""),
-        ExpectedConstrainedHypervolumeImprovement("", _Certainty(), 0.0),
+        ExpectedHypervolumeImprovement().using(NA),
+        ExpectedConstrainedHypervolumeImprovement(NA, _Certainty(), 0.0),
     ],
 )
 def test_hippo_penalized_acquisitions_combine_base_and_penalization_correctly(
     base_builder: AcquisitionFunctionBuilder[ProbabilisticModel],
 ) -> None:
-    data = {"": Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))}
-    model = {"": _mo_test_model(2, *[None] * 2)}
+    data = {NA: Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))}
+    model = {NA: _mo_test_model(2, *[None] * 2)}
     pending_points = tf.zeros([2, 2], dtype=tf.float64)
 
     hippo_acq_builder: HIPPO[ProbabilisticModel] = HIPPO(
-        "", base_acquisition_function_builder=base_builder
+        NA, base_acquisition_function_builder=base_builder
     )
     hippo_acq = hippo_acq_builder.prepare_acquisition_function(model, data, pending_points)
     base_acq = base_builder.prepare_acquisition_function(model, data)
-    penalizer = hippo_penalizer(model[""], pending_points)
+    penalizer = hippo_penalizer(model[NA], pending_points)
     assert hippo_acq._get_tracing_count() == 0  # type: ignore
 
     x_range = tf.linspace(0.0, 1.0, 11)

--- a/tests/unit/acquisition/test_combination.py
+++ b/tests/unit/acquisition/test_combination.py
@@ -29,6 +29,9 @@ from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.types import Tag
 
+# tags
+TAG: Tag = ""
+
 
 def test_reducer_raises_for_no_builders() -> None:
     class UseFirst(Reducer):
@@ -90,7 +93,7 @@ def test_reducer__reduce() -> None:
             return tf.reduce_mean(inputs, axis=0)
 
     mean = Mean(_Static(lambda x: -2.0 * x), _Static(lambda x: 3.0 * x))
-    data, models = {"": empty_dataset([1], [1])}, {"": QuadraticMeanAndRBFKernel()}
+    data, models = {TAG: empty_dataset([1], [1])}, {TAG: QuadraticMeanAndRBFKernel()}
     acq = mean.prepare_acquisition_function(models, datasets=data)
     xs = tf.random.uniform([3, 5, 1], minval=-1.0)
     npt.assert_allclose(acq(xs), 0.5 * xs)
@@ -98,7 +101,7 @@ def test_reducer__reduce() -> None:
 
 def test_sum() -> None:
     sum_ = Sum(_Static(lambda x: x), _Static(lambda x: x ** 2), _Static(lambda x: x ** 3))
-    data, models = {"": empty_dataset([1], [1])}, {"": QuadraticMeanAndRBFKernel()}
+    data, models = {TAG: empty_dataset([1], [1])}, {TAG: QuadraticMeanAndRBFKernel()}
     acq = sum_.prepare_acquisition_function(models, datasets=data)
     xs = tf.random.uniform([3, 5, 1], minval=-1.0)
     npt.assert_allclose(acq(xs), xs + xs ** 2 + xs ** 3)
@@ -106,7 +109,7 @@ def test_sum() -> None:
 
 def test_product() -> None:
     prod = Product(_Static(lambda x: x + 1), _Static(lambda x: x + 2))
-    data, models = {"": empty_dataset([1], [1])}, {"": QuadraticMeanAndRBFKernel()}
+    data, models = {TAG: empty_dataset([1], [1])}, {TAG: QuadraticMeanAndRBFKernel()}
     acq = prod.prepare_acquisition_function(models, datasets=data)
     xs = tf.random.uniform([3, 5, 1], minval=-1.0, dtype=tf.float64)
     npt.assert_allclose(acq(xs), (xs + 1) * (xs + 2))
@@ -114,7 +117,7 @@ def test_product() -> None:
 
 def test_reducer_calls_update() -> None:
     prod = Product(_Static(lambda x: x + 1), _Static(lambda x: x + 2))
-    data, models = {"": empty_dataset([1], [1])}, {"": QuadraticMeanAndRBFKernel()}
+    data, models = {TAG: empty_dataset([1], [1])}, {TAG: QuadraticMeanAndRBFKernel()}
     acq = prod.prepare_acquisition_function(models, datasets=data)
     acq = prod.update_acquisition_function(acq, models, datasets=data)
     xs = tf.random.uniform([3, 5, 1], minval=-1.0, dtype=tf.float64)
@@ -123,7 +126,7 @@ def test_reducer_calls_update() -> None:
 
 @pytest.mark.parametrize("reducer_class", [Sum, Product])
 def test_sum_and_product_for_single_builder(reducer_class: type[Sum | Product]) -> None:
-    data, models = {"": empty_dataset([1], [1])}, {"": QuadraticMeanAndRBFKernel()}
+    data, models = {TAG: empty_dataset([1], [1])}, {TAG: QuadraticMeanAndRBFKernel()}
     acq = reducer_class(_Static(lambda x: x ** 2)).prepare_acquisition_function(
         models, datasets=data
     )

--- a/tests/unit/acquisition/test_combination.py
+++ b/tests/unit/acquisition/test_combination.py
@@ -27,6 +27,7 @@ from trieste.acquisition.combination import Product, Reducer, Sum
 from trieste.acquisition.rule import AcquisitionFunctionBuilder
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
+from trieste.types import Tag
 
 
 def test_reducer_raises_for_no_builders() -> None:
@@ -54,8 +55,8 @@ def test_reducer__repr_builders() -> None:
 
         def prepare_acquisition_function(
             self,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> AcquisitionFunction:
             return raise_exc
 
@@ -69,16 +70,16 @@ class _Static(AcquisitionFunctionBuilder[ProbabilisticModel]):
 
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         return self._f
 
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         return lambda x: function(x) + 1
 

--- a/tests/unit/acquisition/test_interface.py
+++ b/tests/unit/acquisition/test_interface.py
@@ -39,7 +39,7 @@ from trieste.acquisition.interface import (
 from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.models.interfaces import SupportsPredictJoint
-from trieste.types import TensorType
+from trieste.types import Tag, TensorType
 from trieste.utils import DEFAULTS
 
 
@@ -87,9 +87,11 @@ def test_single_model_acquisition_builder_using_passes_on_correct_dataset_and_mo
             assert model is models["foo"]
             return raise_exc
 
-    data = {"foo": empty_dataset([1], [1]), "bar": empty_dataset([1], [1])}
-    models = {"foo": QuadraticMeanAndRBFKernel(), "bar": QuadraticMeanAndRBFKernel()}
-    Builder().using("foo").prepare_acquisition_function(models, datasets=data)
+    FOO: Tag = "foo"
+    BAR: Tag = "bar"
+    data = {FOO: empty_dataset([1], [1]), BAR: empty_dataset([1], [1])}
+    models = {FOO: QuadraticMeanAndRBFKernel(), BAR: QuadraticMeanAndRBFKernel()}
+    Builder().using(FOO).prepare_acquisition_function(models, datasets=data)
 
 
 def test_single_model_greedy_acquisition_builder_raises_immediately_for_wrong_key() -> None:

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -98,7 +98,7 @@ def test_discrete_thompson_sampling_raises_for_invalid_init_params(
 )
 @pytest.mark.parametrize("datasets", [{}, {OBJECTIVE: empty_dataset([1], [1])}])
 def test_discrete_thompson_sampling_raises_for_invalid_models_keys(
-    datasets: dict[str, Dataset], models: dict[str, ProbabilisticModel]
+    datasets: dict[Tag, Dataset], models: dict[Tag, ProbabilisticModel]
 ) -> None:
     search_space = Box([-1], [1])
     rule = DiscreteThompsonSampling(100, 10)
@@ -116,7 +116,7 @@ def test_discrete_thompson_sampling_raises_for_invalid_models_keys(
     ],
 )
 def test_discrete_thompson_sampling_raises_for_invalid_dataset_keys(
-    datasets: dict[str, Dataset], models: dict[str, ProbabilisticModel]
+    datasets: dict[Tag, Dataset], models: dict[Tag, ProbabilisticModel]
 ) -> None:
     search_space = Box([-1], [1])
     rule = DiscreteThompsonSampling(10, 100)
@@ -539,7 +539,7 @@ def test_async_keeps_track_of_pending_points(
     "models", [{}, {"foo": QuadraticMeanAndRBFKernel()}, {OBJECTIVE: QuadraticMeanAndRBFKernel()}]
 )
 def test_trust_region_raises_for_missing_datasets_key(
-    datasets: dict[str, Dataset], models: dict[str, ProbabilisticModel]
+    datasets: dict[Tag, Dataset], models: dict[Tag, ProbabilisticModel]
 ) -> None:
     search_space = Box([-1], [1])
     rule = TrustRegion()
@@ -902,7 +902,7 @@ def test_qhsri_raises_invalid_parameters(
 @pytest.mark.parametrize("datasets", [{}, {OBJECTIVE: empty_dataset([1], [1])}])
 @pytest.mark.qhsri
 def test_qhsri_raises_for_invalid_models_keys(
-    datasets: dict[str, Dataset], models: dict[str, ProbabilisticModel]
+    datasets: dict[Tag, Dataset], models: dict[Tag, ProbabilisticModel]
 ) -> None:
     search_space = Box([-1], [1])
     rule = BatchHypervolumeSharpeRatioIndicator()
@@ -921,7 +921,7 @@ def test_qhsri_raises_for_invalid_models_keys(
 )
 @pytest.mark.qhsri
 def test_qhsri_raises_for_invalid_dataset_keys(
-    datasets: dict[str, Dataset], models: dict[str, ProbabilisticModel]
+    datasets: dict[Tag, Dataset], models: dict[Tag, ProbabilisticModel]
 ) -> None:
     search_space = Box([-1], [1])
     rule = BatchHypervolumeSharpeRatioIndicator()

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -58,7 +58,7 @@ from trieste.data import Dataset
 from trieste.models import ProbabilisticModel
 from trieste.observer import OBJECTIVE
 from trieste.space import Box
-from trieste.types import State, TensorType
+from trieste.types import State, Tag, TensorType
 
 
 def _line_search_maximize(
@@ -306,8 +306,8 @@ def test_efficient_global_optimization_initial_acquisition_function() -> None:
 class _JointBatchModelMinusMeanMaximumSingleBuilder(AcquisitionFunctionBuilder[ProbabilisticModel]):
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         return lambda at: -tf.reduce_max(models[OBJECTIVE].predict(at)[0], axis=-2)
 
@@ -436,8 +436,8 @@ class _VectorizedBatchModelMinusMeanMaximumSingleBuilder(
 ):
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         return lambda at: tf.squeeze(-models[OBJECTIVE].predict(at)[0], -1)
 
@@ -551,8 +551,8 @@ class _Midpoint(AcquisitionRule[TensorType, Box, ProbabilisticModel]):
     def acquire(
         self,
         search_space: Box,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> TensorType:
         return (search_space.upper[None] + search_space.lower[None]) / 2
 

--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -27,7 +27,7 @@ from trieste.data import Dataset
 from trieste.models.interfaces import ProbabilisticModel, TrainableProbabilisticModel
 from trieste.observer import OBJECTIVE
 from trieste.space import Box
-from trieste.types import State, TensorType
+from trieste.types import State, Tag, TensorType
 
 
 class LinearWithUnitVariance(GaussianProcess, PseudoTrainableProbModel):
@@ -320,8 +320,8 @@ def test_ask_tell_optimizer_uses_specified_acquisition_state(
         def acquire(
             self,
             search_space: Box,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> State[int | None, TensorType]:
             def go(state: int | None) -> tuple[int | None, TensorType]:
                 self.states_received.append(state)

--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -29,6 +29,10 @@ from trieste.observer import OBJECTIVE
 from trieste.space import Box
 from trieste.types import State, Tag, TensorType
 
+# tags
+TAG1: Tag = "1"
+TAG2: Tag = "2"
+
 
 class LinearWithUnitVariance(GaussianProcess, PseudoTrainableProbModel):
     def __init__(self) -> None:
@@ -365,8 +369,8 @@ def test_ask_tell_optimizer_validates_keys(
     model: TrainableProbabilisticModel,
     acquisition_rule: AcquisitionRule[TensorType, Box, TrainableProbabilisticModel],
 ) -> None:
-    dataset_with_key_1 = {"1": init_dataset}
-    model_with_key_2 = {"2": model}
+    dataset_with_key_1 = {TAG1: init_dataset}
+    model_with_key_2 = {TAG2: model}
 
     with pytest.raises(ValueError):
         AskTellOptimizer(search_space, dataset_with_key_1, model_with_key_2, acquisition_rule)
@@ -378,9 +382,9 @@ def test_ask_tell_optimizer_tell_validates_keys(
     model: TrainableProbabilisticModel,
     acquisition_rule: AcquisitionRule[TensorType, Box, TrainableProbabilisticModel],
 ) -> None:
-    dataset_with_key_1 = {"1": init_dataset}
-    model_with_key_1 = {"1": model}
-    new_data_with_key_2 = {"2": mk_dataset([[1.0]], [[1.0]])}
+    dataset_with_key_1 = {TAG1: init_dataset}
+    model_with_key_1 = {TAG1: model}
+    new_data_with_key_2 = {TAG2: mk_dataset([[1.0]], [[1.0]])}
 
     ask_tell = AskTellOptimizer(
         search_space, dataset_with_key_1, model_with_key_1, acquisition_rule
@@ -394,7 +398,7 @@ def test_ask_tell_optimizer_default_acquisition_requires_objective_tag(
     init_dataset: Dataset,
     model: TrainableProbabilisticModel,
 ) -> None:
-    wrong_tag = OBJECTIVE + "_WRONG"
+    wrong_tag: Tag = f"{OBJECTIVE}_WRONG"
     wrong_datasets = {wrong_tag: init_dataset}
     wrong_models = {wrong_tag: model}
 

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -41,11 +41,11 @@ from trieste.data import Dataset
 from trieste.models import ProbabilisticModel, TrainableProbabilisticModel
 from trieste.observer import OBJECTIVE, Observer
 from trieste.space import Box, SearchSpace
-from trieste.types import State, TensorType
+from trieste.types import State, Tag, TensorType
 from trieste.utils import Err, Ok
 
 
-def _quadratic_observer(x: tf.Tensor) -> Mapping[str, Dataset]:
+def _quadratic_observer(x: tf.Tensor) -> Mapping[Tag, Dataset]:
     return {"": Dataset(x, quadratic(x))}
 
 
@@ -275,8 +275,8 @@ def test_bayesian_optimizer_uses_specified_acquisition_state(
         def acquire(
             self,
             search_space: Box,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> State[int | None, TensorType]:
             def go(state: int | None) -> tuple[int | None, TensorType]:
                 self.states_received.append(state)
@@ -347,8 +347,8 @@ class _BrokenRule(AcquisitionRule[NoReturn, SearchSpace, ProbabilisticModel]):
     def acquire(
         self,
         search_space: SearchSpace,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> NoReturn:
         raise _Whoops
 
@@ -406,8 +406,8 @@ def test_bayesian_optimizer_optimize_is_noop_for_zero_steps() -> None:
         def acquire(
             self,
             search_space: Box,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> NoReturn:
             assert False
 
@@ -442,8 +442,8 @@ def test_bayesian_optimizer_can_use_two_gprs_for_objective_defined_by_two_dimens
         def acquire(
             self,
             search_space: Box,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> State[int | None, TensorType]:
             def go(previous_state: int | None) -> tuple[int | None, TensorType]:
                 if previous_state is None:
@@ -468,12 +468,12 @@ def test_bayesian_optimizer_can_use_two_gprs_for_objective_defined_by_two_dimens
             EXPONENTIAL: Dataset(query_points, tf.exp(-query_points)),
         }
 
-    data: Mapping[str, Dataset] = {
+    data: Mapping[Tag, Dataset] = {
         LINEAR: Dataset(tf.constant([[0.0]]), tf.constant([[0.0]])),
         EXPONENTIAL: Dataset(tf.constant([[0.0]]), tf.constant([[1.0]])),
     }
 
-    models: Mapping[str, TrainableProbabilisticModel] = {
+    models: Mapping[Tag, TrainableProbabilisticModel] = {
         LINEAR: LinearWithUnitVariance(),
         EXPONENTIAL: ExponentialWithUnitVariance(),
     }
@@ -525,8 +525,8 @@ def test_bayesian_optimizer_optimize_tracked_state(save_to_disk: bool) -> None:
         def acquire(
             self,
             search_space: Box,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> State[int | None, TensorType]:
             def go(state: int | None) -> tuple[int | None, TensorType]:
                 new_state = 0 if state is None else state + 1

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -243,7 +243,7 @@ def test_bayesian_optimizer_optimizes_initial_model(fit_initial_model: bool) -> 
     ],
 )
 def test_bayesian_optimizer_optimize_raises_for_invalid_keys(
-    datasets: dict[str, Dataset], models: dict[str, TrainableProbabilisticModel]
+    datasets: dict[Tag, Dataset], models: dict[Tag, TrainableProbabilisticModel]
 ) -> None:
     search_space = Box([-1], [1])
     optimizer = BayesianOptimizer(lambda x: {"foo": Dataset(x, x)}, search_space)
@@ -462,7 +462,7 @@ def test_bayesian_optimizer_can_use_two_gprs_for_objective_defined_by_two_dimens
 
             return go
 
-    def linear_and_exponential(query_points: tf.Tensor) -> dict[str, Dataset]:
+    def linear_and_exponential(query_points: tf.Tensor) -> dict[Tag, Dataset]:
         return {
             LINEAR: Dataset(query_points, 2 * query_points),
             EXPONENTIAL: Dataset(query_points, tf.exp(-query_points)),

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -48,7 +48,7 @@ from trieste.logging import (
 )
 from trieste.models import ProbabilisticModel
 from trieste.space import Box, SearchSpace
-from trieste.types import TensorType
+from trieste.types import Tag, TensorType
 
 
 class _PseudoTrainableQuadratic(QuadraticMeanAndRBFKernel, PseudoTrainableProbModel):
@@ -216,8 +216,8 @@ def test_wallclock_time_logging(
         def acquire(
             self,
             search_space: SearchSpace,
-            models: Mapping[str, ProbabilisticModel],
-            datasets: Optional[Mapping[str, Dataset]] = None,
+            models: Mapping[Tag, ProbabilisticModel],
+            datasets: Optional[Mapping[Tag, Dataset]] = None,
         ) -> TensorType:
             sleep(acq_time)
             return self._qp

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -175,10 +175,11 @@ def test_text(mocked_summary_histogram: unittest.mock.MagicMock) -> None:
 def test_tensorboard_logging(mocked_summary_scalar: unittest.mock.MagicMock) -> None:
     mocked_summary_writer = unittest.mock.MagicMock()
     with tensorboard_writer(mocked_summary_writer):
-        data, models = {"A": mk_dataset([[0.0]], [[0.0]])}, {"A": _PseudoTrainableQuadratic()}
+        tag: Tag = "A"
+        data, models = {tag: mk_dataset([[0.0]], [[0.0]])}, {tag: _PseudoTrainableQuadratic()}
         steps = 5
         rule = FixedAcquisitionRule([[0.0]])
-        BayesianOptimizer(lambda x: {"A": Dataset(x, x ** 2)}, Box([-1], [1])).optimize(
+        BayesianOptimizer(lambda x: {tag: Dataset(x, x ** 2)}, Box([-1], [1])).optimize(
             steps, data, models, rule
         )
 
@@ -224,12 +225,13 @@ def test_wallclock_time_logging(
 
     mocked_summary_writer = unittest.mock.MagicMock()
     with tensorboard_writer(mocked_summary_writer):
-        data, models = {"A": mk_dataset([[0.0]], [[0.0]])}, {
-            "A": _PseudoTrainableQuadraticWithWaiting()
+        tag: Tag = "A"
+        data, models = {tag: mk_dataset([[0.0]], [[0.0]])}, {
+            tag: _PseudoTrainableQuadraticWithWaiting()
         }
         steps = 3
         rule = _FixedAcquisitionRuleWithWaiting([[0.0]])
-        BayesianOptimizer(lambda x: {"A": Dataset(x, x ** 2)}, Box([-1], [1])).optimize(
+        BayesianOptimizer(lambda x: {tag: Dataset(x, x ** 2)}, Box([-1], [1])).optimize(
             steps, data, models, rule, fit_initial_model=fit_initial_model
         )
 
@@ -262,12 +264,13 @@ def test_wallclock_time_logging(
 def test_tensorboard_logging_ask_tell(mocked_summary_scalar: unittest.mock.MagicMock) -> None:
     mocked_summary_writer = unittest.mock.MagicMock()
     with tensorboard_writer(mocked_summary_writer):
-        data, models = {"A": mk_dataset([[0.0]], [[0.0]])}, {"A": _PseudoTrainableQuadratic()}
+        tag: Tag = "A"
+        data, models = {tag: mk_dataset([[0.0]], [[0.0]])}, {tag: _PseudoTrainableQuadratic()}
         rule = FixedAcquisitionRule([[0.0]])
         ask_tell = AskTellOptimizer(Box([-1], [1]), data, models, rule)
         with step_number(3):
             new_point = ask_tell.ask()
-            ask_tell.tell({"A": Dataset(new_point, new_point ** 2)})
+            ask_tell.tell({tag: Dataset(new_point, new_point ** 2)})
 
     ordered_scalar_names = [
         "wallclock/model_fitting",

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -30,7 +30,7 @@ from trieste.models import ProbabilisticModel
 from trieste.objectives import Branin, Hartmann6
 from trieste.objectives.utils import mk_observer
 from trieste.space import SearchSpace
-from trieste.types import TensorType
+from trieste.types import Tag, TensorType
 from trieste.utils import shapes_equal
 
 TF_DEBUGGING_ERROR_TYPES: Final[tuple[type[Exception], ...]] = (
@@ -179,8 +179,8 @@ class FixedAcquisitionRule(AcquisitionRule[TensorType, SearchSpace, Probabilisti
     def acquire(
         self,
         search_space: SearchSpace,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> TensorType:
         """
         :param search_space: Unused.

--- a/trieste/acquisition/combination.py
+++ b/trieste/acquisition/combination.py
@@ -21,7 +21,7 @@ import tensorflow as tf
 
 from ..data import Dataset
 from ..models import ProbabilisticModel
-from ..types import TensorType
+from ..types import Tag, TensorType
 from .interface import AcquisitionFunction, AcquisitionFunctionBuilder
 
 
@@ -49,8 +49,8 @@ class Reducer(AcquisitionFunctionBuilder[ProbabilisticModel]):
 
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         r"""
         Return an acquisition function. This acquisition function is defined by first building
@@ -75,8 +75,8 @@ class Reducer(AcquisitionFunctionBuilder[ProbabilisticModel]):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -30,7 +30,7 @@ from ...models.interfaces import (
     SupportsReparamSamplerObservationNoise,
 )
 from ...space import SearchSpace
-from ...types import TensorType
+from ...types import Tag, TensorType
 from ...utils import DEFAULTS
 from ..interface import (
     AcquisitionFunction,
@@ -612,8 +612,8 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticMod
 
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
         :param models: The models over each tag.
@@ -625,7 +625,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticMod
         :raise tf.errors.InvalidArgumentError: If the objective data is empty.
         """
         tf.debugging.Assert(datasets is not None, [tf.constant([])])
-        datasets = cast(Mapping[str, Dataset], datasets)
+        datasets = cast(Mapping[Tag, Dataset], datasets)
 
         objective_model = models[self._objective_tag]
         objective_dataset = datasets[self._objective_tag]
@@ -661,8 +661,8 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticMod
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
         :param function: The acquisition function to update.
@@ -670,7 +670,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticMod
         :param datasets: The data from the observer.
         """
         tf.debugging.Assert(datasets is not None, [tf.constant([])])
-        datasets = cast(Mapping[str, Dataset], datasets)
+        datasets = cast(Mapping[Tag, Dataset], datasets)
 
         objective_model = models[self._objective_tag]
         objective_dataset = datasets[self._objective_tag]

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -574,7 +574,7 @@ class ExpectedConstrainedImprovement(AcquisitionFunctionBuilder[ProbabilisticMod
 
     def __init__(
         self,
-        objective_tag: str,
+        objective_tag: Tag,
         constraint_builder: AcquisitionFunctionBuilder[ProbabilisticModelType],
         min_feasibility_probability: float | TensorType = 0.5,
     ):

--- a/trieste/acquisition/function/greedy_batch.py
+++ b/trieste/acquisition/function/greedy_batch.py
@@ -33,7 +33,7 @@ from ...models.interfaces import (
 )
 from ...observer import OBJECTIVE
 from ...space import SearchSpace
-from ...types import TensorType
+from ...types import Tag, TensorType
 from ..interface import (
     AcquisitionFunction,
     AcquisitionFunctionBuilder,
@@ -456,8 +456,8 @@ class Fantasizer(GreedyAcquisitionFunctionBuilder[FantasizerModelOrStack]):
 
     def _update_base_acquisition_function(
         self,
-        models: Mapping[str, FantasizerModelOrStack],
-        datasets: Optional[Mapping[str, Dataset]],
+        models: Mapping[Tag, FantasizerModelOrStack],
+        datasets: Optional[Mapping[Tag, Dataset]],
     ) -> AcquisitionFunction:
 
         if self._base_acquisition_function is not None:
@@ -472,8 +472,8 @@ class Fantasizer(GreedyAcquisitionFunctionBuilder[FantasizerModelOrStack]):
 
     def _update_fantasized_acquisition_function(
         self,
-        models: Mapping[str, FantasizerModelOrStack],
-        datasets: Optional[Mapping[str, Dataset]],
+        models: Mapping[Tag, FantasizerModelOrStack],
+        datasets: Optional[Mapping[Tag, Dataset]],
         pending_points: TensorType,
     ) -> AcquisitionFunction:
 
@@ -524,8 +524,8 @@ class Fantasizer(GreedyAcquisitionFunctionBuilder[FantasizerModelOrStack]):
 
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, FantasizerModelOrStack],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, FantasizerModelOrStack],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
         """
@@ -555,8 +555,8 @@ class Fantasizer(GreedyAcquisitionFunctionBuilder[FantasizerModelOrStack]):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, FantasizerModelOrStack],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, FantasizerModelOrStack],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
     ) -> AcquisitionFunction:

--- a/trieste/acquisition/function/greedy_batch.py
+++ b/trieste/acquisition/function/greedy_batch.py
@@ -451,7 +451,7 @@ class Fantasizer(GreedyAcquisitionFunctionBuilder[FantasizerModelOrStack]):
         self._base_acquisition_function: Optional[AcquisitionFunction] = None
         self._fantasized_acquisition: Optional[AcquisitionFunction] = None
         self._fantasized_models: Mapping[
-            str, _fantasized_model | ModelStack[SupportsPredictJoint]
+            Tag, _fantasized_model | ModelStack[SupportsPredictJoint]
         ] = {}
 
     def _update_base_acquisition_function(
@@ -499,7 +499,7 @@ class Fantasizer(GreedyAcquisitionFunctionBuilder[FantasizerModelOrStack]):
                 for tag, model in models.items()
             }
             self._fantasized_acquisition = self._builder.prepare_acquisition_function(
-                cast(Dict[str, SupportsPredictJoint], self._fantasized_models), datasets
+                cast(Dict[Tag, SupportsPredictJoint], self._fantasized_models), datasets
             )
         else:
             for tag, model in self._fantasized_models.items():
@@ -516,7 +516,7 @@ class Fantasizer(GreedyAcquisitionFunctionBuilder[FantasizerModelOrStack]):
                     model.update_fantasized_data(fantasized_data[tag])
             self._builder.update_acquisition_function(
                 self._fantasized_acquisition,
-                cast(Dict[str, SupportsPredictJoint], self._fantasized_models),
+                cast(Dict[Tag, SupportsPredictJoint], self._fantasized_models),
                 datasets,
             )
 

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -27,7 +27,7 @@ from ...data import Dataset
 from ...models import ProbabilisticModel, ReparametrizationSampler
 from ...models.interfaces import HasReparamSampler
 from ...observer import OBJECTIVE
-from ...types import TensorType
+from ...types import Tag, TensorType
 from ...utils import DEFAULTS
 from ..interface import (
     AcquisitionFunction,
@@ -550,8 +550,8 @@ class HIPPO(GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]):
 
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
         """
@@ -564,7 +564,7 @@ class HIPPO(GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]):
         :raise tf.errors.InvalidArgumentError: If the ``dataset`` is empty.
         """
         tf.debugging.Assert(datasets is not None, [tf.constant([])])
-        datasets = cast(Mapping[str, Dataset], datasets)
+        datasets = cast(Mapping[Tag, Dataset], datasets)
         tf.debugging.Assert(datasets[self._objective_tag] is not None, [tf.constant([])])
         tf.debugging.assert_positive(
             len(datasets[self._objective_tag]),
@@ -580,8 +580,8 @@ class HIPPO(GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
     ) -> AcquisitionFunction:
@@ -599,7 +599,7 @@ class HIPPO(GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]):
         :return: The updated acquisition function.
         """
         tf.debugging.Assert(datasets is not None, [tf.constant([])])
-        datasets = cast(Mapping[str, Dataset], datasets)
+        datasets = cast(Mapping[Tag, Dataset], datasets)
         tf.debugging.Assert(datasets[self._objective_tag] is not None, [tf.constant([])])
         tf.debugging.assert_positive(
             len(datasets[self._objective_tag]),
@@ -647,8 +647,8 @@ class HIPPO(GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]):
 
     def _update_base_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         if self._base_acquisition_function is None:
             self._base_acquisition_function = self._base_builder.prepare_acquisition_function(

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -520,7 +520,7 @@ class HIPPO(GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]):
 
     def __init__(
         self,
-        objective_tag: str = OBJECTIVE,
+        objective_tag: Tag = OBJECTIVE,
         base_acquisition_function_builder: AcquisitionFunctionBuilder[ProbabilisticModelType]
         | SingleModelAcquisitionBuilder[ProbabilisticModelType]
         | None = None,

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -424,7 +424,7 @@ class ExpectedConstrainedHypervolumeImprovement(
 
     def __init__(
         self,
-        objective_tag: str,
+        objective_tag: Tag,
         constraint_builder: AcquisitionFunctionBuilder[ProbabilisticModelType],
         min_feasibility_probability: float | TensorType = 0.5,
         reference_point_spec: Sequence[float]

--- a/trieste/acquisition/interface.py
+++ b/trieste/acquisition/interface.py
@@ -22,7 +22,7 @@ from typing import Callable, Generic, Mapping, Optional
 
 from ..data import Dataset
 from ..models.interfaces import ProbabilisticModelType
-from ..types import TensorType
+from ..types import Tag, TensorType
 
 AcquisitionFunction = Callable[[TensorType], TensorType]
 """
@@ -55,8 +55,8 @@ class AcquisitionFunctionBuilder(Generic[ProbabilisticModelType], ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
         Prepare an acquisition function. We assume that this requires at least models, but
@@ -70,8 +70,8 @@ class AcquisitionFunctionBuilder(Generic[ProbabilisticModelType], ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> AcquisitionFunction:
         """
         Update an acquisition function. By default this generates a new acquisition function each
@@ -93,7 +93,7 @@ class SingleModelAcquisitionBuilder(Generic[ProbabilisticModelType], ABC):
     composite acquisition function) that requires only one model, dataset pair.
     """
 
-    def using(self, tag: str) -> AcquisitionFunctionBuilder[ProbabilisticModelType]:
+    def using(self, tag: Tag) -> AcquisitionFunctionBuilder[ProbabilisticModelType]:
         """
         :param tag: The tag for the model, dataset pair to use to build this acquisition function.
         :return: An acquisition function builder that selects the model and dataset specified by
@@ -108,8 +108,8 @@ class SingleModelAcquisitionBuilder(Generic[ProbabilisticModelType], ABC):
 
             def prepare_acquisition_function(
                 self,
-                models: Mapping[str, ProbabilisticModelType],
-                datasets: Optional[Mapping[str, Dataset]] = None,
+                models: Mapping[Tag, ProbabilisticModelType],
+                datasets: Optional[Mapping[Tag, Dataset]] = None,
             ) -> AcquisitionFunction:
                 return self.single_builder.prepare_acquisition_function(
                     models[tag], dataset=None if datasets is None else datasets[tag]
@@ -118,8 +118,8 @@ class SingleModelAcquisitionBuilder(Generic[ProbabilisticModelType], ABC):
             def update_acquisition_function(
                 self,
                 function: AcquisitionFunction,
-                models: Mapping[str, ProbabilisticModelType],
-                datasets: Optional[Mapping[str, Dataset]] = None,
+                models: Mapping[Tag, ProbabilisticModelType],
+                datasets: Optional[Mapping[Tag, Dataset]] = None,
             ) -> AcquisitionFunction:
                 return self.single_builder.update_acquisition_function(
                     function, models[tag], dataset=None if datasets is None else datasets[tag]
@@ -171,8 +171,8 @@ class GreedyAcquisitionFunctionBuilder(Generic[ProbabilisticModelType], ABC):
     @abstractmethod
     def prepare_acquisition_function(
         self,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
     ) -> AcquisitionFunction:
         """
@@ -190,8 +190,8 @@ class GreedyAcquisitionFunctionBuilder(Generic[ProbabilisticModelType], ABC):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
         pending_points: Optional[TensorType] = None,
         new_optimization_step: bool = True,
     ) -> AcquisitionFunction:
@@ -222,7 +222,7 @@ class SingleModelGreedyAcquisitionBuilder(Generic[ProbabilisticModelType], ABC):
     composite greedy acquisition function) that requires only one model, dataset pair.
     """
 
-    def using(self, tag: str) -> GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]:
+    def using(self, tag: Tag) -> GreedyAcquisitionFunctionBuilder[ProbabilisticModelType]:
         """
         :param tag: The tag for the model, dataset pair to use to build this acquisition function.
         :return: An acquisition function builder that selects the model and dataset specified by
@@ -237,8 +237,8 @@ class SingleModelGreedyAcquisitionBuilder(Generic[ProbabilisticModelType], ABC):
 
             def prepare_acquisition_function(
                 self,
-                models: Mapping[str, ProbabilisticModelType],
-                datasets: Optional[Mapping[str, Dataset]] = None,
+                models: Mapping[Tag, ProbabilisticModelType],
+                datasets: Optional[Mapping[Tag, Dataset]] = None,
                 pending_points: Optional[TensorType] = None,
             ) -> AcquisitionFunction:
                 return self.single_builder.prepare_acquisition_function(
@@ -250,8 +250,8 @@ class SingleModelGreedyAcquisitionBuilder(Generic[ProbabilisticModelType], ABC):
             def update_acquisition_function(
                 self,
                 function: AcquisitionFunction,
-                models: Mapping[str, ProbabilisticModelType],
-                datasets: Optional[Mapping[str, Dataset]] = None,
+                models: Mapping[Tag, ProbabilisticModelType],
+                datasets: Optional[Mapping[Tag, Dataset]] = None,
                 pending_points: Optional[TensorType] = None,
                 new_optimization_step: bool = True,
             ) -> AcquisitionFunction:
@@ -326,7 +326,7 @@ class SingleModelVectorizedAcquisitionBuilder(
     of a composite vectorized acquisition function) that requires only one model, dataset pair.
     """
 
-    def using(self, tag: str) -> AcquisitionFunctionBuilder[ProbabilisticModelType]:
+    def using(self, tag: Tag) -> AcquisitionFunctionBuilder[ProbabilisticModelType]:
         """
         :param tag: The tag for the model, dataset pair to use to build this acquisition function.
         :return: An acquisition function builder that selects the model and dataset specified by
@@ -342,8 +342,8 @@ class SingleModelVectorizedAcquisitionBuilder(
 
             def prepare_acquisition_function(
                 self,
-                models: Mapping[str, ProbabilisticModelType],
-                datasets: Optional[Mapping[str, Dataset]] = None,
+                models: Mapping[Tag, ProbabilisticModelType],
+                datasets: Optional[Mapping[Tag, Dataset]] = None,
             ) -> AcquisitionFunction:
                 return self.single_builder.prepare_acquisition_function(
                     models[tag], dataset=None if datasets is None else datasets[tag]
@@ -352,8 +352,8 @@ class SingleModelVectorizedAcquisitionBuilder(
             def update_acquisition_function(
                 self,
                 function: AcquisitionFunction,
-                models: Mapping[str, ProbabilisticModelType],
-                datasets: Optional[Mapping[str, Dataset]] = None,
+                models: Mapping[Tag, ProbabilisticModelType],
+                datasets: Optional[Mapping[Tag, Dataset]] = None,
             ) -> AcquisitionFunction:
                 return self.single_builder.update_acquisition_function(
                     function, models[tag], dataset=None if datasets is None else datasets[tag]

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -42,7 +42,7 @@ from ..models import ProbabilisticModel
 from ..models.interfaces import HasReparamSampler, ModelStack, ProbabilisticModelType
 from ..observer import OBJECTIVE
 from ..space import Box, SearchSpace
-from ..types import State, TensorType
+from ..types import State, Tag, TensorType
 from .function import (
     BatchMonteCarloExpectedImprovement,
     ExpectedImprovement,
@@ -95,8 +95,8 @@ class AcquisitionRule(ABC, Generic[ResultType, SearchSpaceType, ProbabilisticMod
     def acquire(
         self,
         search_space: SearchSpaceType,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> ResultType:
         """
         Return a value of type `T_co`. Typically this will be a set of query points, either on its
@@ -260,8 +260,8 @@ class EfficientGlobalOptimization(
     def acquire(
         self,
         search_space: SearchSpaceType,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> TensorType:
         """
         Return the query point(s) that optimizes the acquisition function produced by ``builder``
@@ -529,8 +529,8 @@ class AsynchronousOptimization(
     def acquire(
         self,
         search_space: SearchSpaceType,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> types.State[AsynchronousRuleState | None, TensorType]:
         """
         Constructs a function that, given ``AsynchronousRuleState``,
@@ -685,8 +685,8 @@ class AsynchronousGreedy(
     def acquire(
         self,
         search_space: SearchSpaceType,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> types.State[AsynchronousRuleState | None, TensorType]:
         """
         Constructs a function that, given ``AsynchronousRuleState``,
@@ -796,8 +796,8 @@ class RandomSampling(AcquisitionRule[TensorType, SearchSpace, ProbabilisticModel
     def acquire(
         self,
         search_space: SearchSpace,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> TensorType:
         """
         Sample ``num_query_points`` (see :meth:`__init__`) points from the
@@ -897,8 +897,8 @@ class DiscreteThompsonSampling(AcquisitionRule[TensorType, SearchSpace, Probabil
     def acquire(
         self,
         search_space: SearchSpace,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> TensorType:
         """
         Sample `num_search_space_samples` (see :meth:`__init__`) points from the
@@ -1011,8 +1011,8 @@ class TrustRegion(
     def acquire(
         self,
         search_space: Box,
-        models: Mapping[str, ProbabilisticModelType],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModelType],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> types.State[State | None, TensorType]:
         """
         Construct a local search space from ``search_space`` according the trust region algorithm,

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1198,8 +1198,8 @@ class BatchHypervolumeSharpeRatioIndicator(
     def acquire(
         self,
         search_space: SearchSpace,
-        models: Mapping[str, ProbabilisticModel],
-        datasets: Optional[Mapping[str, Dataset]] = None,
+        models: Mapping[Tag, ProbabilisticModel],
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
     ) -> TensorType:
         """Acquire a batch of points to observe based on the batch hypervolume
         Sharpe ratio indicator method.

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -189,8 +189,8 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
             models = {OBJECTIVE: models}  # type: ignore[dict-item]
 
         # reassure the type checker that everything is tagged
-        datasets = cast(Dict[str, Dataset], datasets)
-        models = cast(Dict[str, TrainableProbabilisticModelType], models)
+        datasets = cast(Dict[Tag, Dataset], datasets)
+        models = cast(Dict[Tag, TrainableProbabilisticModelType], models)
 
         if datasets.keys() != models.keys():
             raise ValueError(

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -43,7 +43,7 @@ from .data import Dataset
 from .models import TrainableProbabilisticModel
 from .observer import OBJECTIVE
 from .space import SearchSpace
-from .types import State, TensorType
+from .types import State, Tag, TensorType
 from .utils import Ok, Timer
 
 StateType = TypeVar("StateType")
@@ -69,8 +69,8 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
     def __init__(
         self,
         search_space: SearchSpaceType,
-        datasets: Mapping[str, Dataset],
-        models: Mapping[str, TrainableProbabilisticModelType],
+        datasets: Mapping[Tag, Dataset],
+        models: Mapping[Tag, TrainableProbabilisticModelType],
         *,
         fit_model: bool = True,
     ):
@@ -80,8 +80,8 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
     def __init__(
         self,
         search_space: SearchSpaceType,
-        datasets: Mapping[str, Dataset],
-        models: Mapping[str, TrainableProbabilisticModelType],
+        datasets: Mapping[Tag, Dataset],
+        models: Mapping[Tag, TrainableProbabilisticModelType],
         acquisition_rule: AcquisitionRule[
             TensorType, SearchSpaceType, TrainableProbabilisticModelType
         ],
@@ -94,8 +94,8 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
     def __init__(
         self,
         search_space: SearchSpaceType,
-        datasets: Mapping[str, Dataset],
-        models: Mapping[str, TrainableProbabilisticModelType],
+        datasets: Mapping[Tag, Dataset],
+        models: Mapping[Tag, TrainableProbabilisticModelType],
         acquisition_rule: AcquisitionRule[
             State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
         ],
@@ -148,8 +148,8 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
     def __init__(
         self,
         search_space: SearchSpaceType,
-        datasets: Mapping[str, Dataset] | Dataset,
-        models: Mapping[str, TrainableProbabilisticModelType] | TrainableProbabilisticModelType,
+        datasets: Mapping[Tag, Dataset] | Dataset,
+        models: Mapping[Tag, TrainableProbabilisticModelType] | TrainableProbabilisticModelType,
         acquisition_rule: AcquisitionRule[
             TensorType | State[StateType | None, TensorType],
             SearchSpaceType,
@@ -239,7 +239,7 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
                {self._acquisition_state!r}"""
 
     @property
-    def datasets(self) -> Mapping[str, Dataset]:
+    def datasets(self) -> Mapping[Tag, Dataset]:
         """The current datasets."""
         return self._datasets
 
@@ -252,12 +252,12 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
             raise ValueError(f"Expected a single dataset, found {len(self.datasets)}")
 
     @property
-    def models(self) -> Mapping[str, TrainableProbabilisticModelType]:
+    def models(self) -> Mapping[Tag, TrainableProbabilisticModelType]:
         """The current models."""
         return self._models
 
     @models.setter
-    def models(self, models: Mapping[str, TrainableProbabilisticModelType]) -> None:
+    def models(self, models: Mapping[Tag, TrainableProbabilisticModelType]) -> None:
         """Update the current models."""
         if models.keys() != self.models.keys():
             raise ValueError(
@@ -323,7 +323,7 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
         return cls(
             search_space,
             record.datasets,
-            cast(Mapping[str, TrainableProbabilisticModelType], record.models),
+            cast(Mapping[Tag, TrainableProbabilisticModelType], record.models),
             acquisition_rule=acquisition_rule,  # type: ignore
             acquisition_state=record.acquisition_state,
             fit_model=False,
@@ -402,7 +402,7 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
 
         return query_points
 
-    def tell(self, new_data: Mapping[str, Dataset] | Dataset) -> None:
+    def tell(self, new_data: Mapping[Tag, Dataset] | Dataset) -> None:
         """Updates optimizer state with new data.
 
         :param new_data: New observed data.

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -57,7 +57,7 @@ from .data import Dataset
 from .models import TrainableProbabilisticModel
 from .observer import OBJECTIVE, Observer
 from .space import SearchSpace
-from .types import State, TensorType
+from .types import State, Tag, TensorType
 from .utils import Err, Ok, Result, Timer
 
 StateType = TypeVar("StateType")
@@ -72,7 +72,7 @@ TrainableProbabilisticModelType = TypeVar(
 """ Contravariant type variable bound to :class:`TrainableProbabilisticModel`. """
 
 EarlyStopCallback = Callable[
-    [Mapping[str, Dataset], Mapping[str, TrainableProbabilisticModelType], Optional[StateType]],
+    [Mapping[Tag, Dataset], Mapping[Tag, TrainableProbabilisticModelType], Optional[StateType]],
     bool,
 ]
 """ Early stop callback type, generic in the model and state types. """
@@ -82,10 +82,10 @@ EarlyStopCallback = Callable[
 class Record(Generic[StateType]):
     """Container to record the state of each step of the optimization process."""
 
-    datasets: Mapping[str, Dataset]
+    datasets: Mapping[Tag, Dataset]
     """ The known data from the observer. """
 
-    models: Mapping[str, TrainableProbabilisticModel]
+    models: Mapping[Tag, TrainableProbabilisticModel]
     """ The models over the :attr:`datasets`. """
 
     acquisition_state: StateType | None
@@ -133,12 +133,12 @@ class FrozenRecord(Generic[StateType]):
             return dill.load(f)
 
     @property
-    def datasets(self) -> Mapping[str, Dataset]:
+    def datasets(self) -> Mapping[Tag, Dataset]:
         """The known data from the observer."""
         return self.load().datasets
 
     @property
-    def models(self) -> Mapping[str, TrainableProbabilisticModel]:
+    def models(self) -> Mapping[Tag, TrainableProbabilisticModel]:
         """The models over the :attr:`datasets`."""
         return self.load().models
 
@@ -196,7 +196,7 @@ class OptimizationResult(Generic[StateType]):
         """
         return self.final_result, self.history
 
-    def try_get_final_datasets(self) -> Mapping[str, Dataset]:
+    def try_get_final_datasets(self) -> Mapping[Tag, Dataset]:
         """
         Convenience method to attempt to get the final data.
 
@@ -232,7 +232,7 @@ class OptimizationResult(Generic[StateType]):
         arg_min_idx = tf.squeeze(tf.argmin(dataset.observations, axis=0))
         return dataset.query_points[arg_min_idx], dataset.observations[arg_min_idx], arg_min_idx
 
-    def try_get_final_models(self) -> Mapping[str, TrainableProbabilisticModel]:
+    def try_get_final_models(self) -> Mapping[Tag, TrainableProbabilisticModel]:
         """
         Convenience method to attempt to get the final models.
 
@@ -314,8 +314,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
     def optimize(
         self,
         num_steps: int,
-        datasets: Mapping[str, Dataset],
-        models: Mapping[str, TrainableProbabilisticModel],
+        datasets: Mapping[Tag, Dataset],
+        models: Mapping[Tag, TrainableProbabilisticModel],
         *,
         track_state: bool = True,
         track_path: Optional[Path | str] = None,
@@ -330,8 +330,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
     def optimize(
         self,
         num_steps: int,
-        datasets: Mapping[str, Dataset],
-        models: Mapping[str, TrainableProbabilisticModelType],
+        datasets: Mapping[Tag, Dataset],
+        models: Mapping[Tag, TrainableProbabilisticModelType],
         acquisition_rule: AcquisitionRule[
             TensorType, SearchSpaceType, TrainableProbabilisticModelType
         ],
@@ -352,8 +352,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
     def optimize(
         self,
         num_steps: int,
-        datasets: Mapping[str, Dataset],
-        models: Mapping[str, TrainableProbabilisticModelType],
+        datasets: Mapping[Tag, Dataset],
+        models: Mapping[Tag, TrainableProbabilisticModelType],
         acquisition_rule: AcquisitionRule[
             TensorType, SearchSpaceType, TrainableProbabilisticModelType
         ],
@@ -371,8 +371,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
     def optimize(
         self,
         num_steps: int,
-        datasets: Mapping[str, Dataset],
-        models: Mapping[str, TrainableProbabilisticModelType],
+        datasets: Mapping[Tag, Dataset],
+        models: Mapping[Tag, TrainableProbabilisticModelType],
         acquisition_rule: AcquisitionRule[
             State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
         ],
@@ -391,8 +391,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
     def optimize(
         self,
         num_steps: int,
-        datasets: Mapping[str, Dataset],
-        models: Mapping[str, TrainableProbabilisticModelType],
+        datasets: Mapping[Tag, Dataset],
+        models: Mapping[Tag, TrainableProbabilisticModelType],
         acquisition_rule: AcquisitionRule[
             State[StateType | None, TensorType], SearchSpaceType, TrainableProbabilisticModelType
         ],
@@ -504,8 +504,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
     def optimize(
         self,
         num_steps: int,
-        datasets: Mapping[str, Dataset] | Dataset,
-        models: Mapping[str, TrainableProbabilisticModelType] | TrainableProbabilisticModelType,
+        datasets: Mapping[Tag, Dataset] | Dataset,
+        models: Mapping[Tag, TrainableProbabilisticModelType] | TrainableProbabilisticModelType,
         acquisition_rule: AcquisitionRule[
             TensorType | State[StateType | None, TensorType],
             SearchSpaceType,
@@ -759,8 +759,8 @@ def write_summary_init(
         SearchSpaceType,
         TrainableProbabilisticModelType,
     ],
-    datasets: Mapping[str, Dataset],
-    models: Mapping[str, TrainableProbabilisticModel],
+    datasets: Mapping[Tag, Dataset],
+    models: Mapping[Tag, TrainableProbabilisticModel],
     num_steps: int,
 ) -> None:
     """Write initial BO loop TensorBoard summary."""
@@ -779,8 +779,8 @@ def write_summary_init(
 
 
 def write_summary_initial_model_fit(
-    datasets: Mapping[str, Dataset],
-    models: Mapping[str, TrainableProbabilisticModel],
+    datasets: Mapping[Tag, Dataset],
+    models: Mapping[Tag, TrainableProbabilisticModel],
     model_fitting_timer: Timer,
 ) -> None:
     """Write TensorBoard summary for the model fitting to the initial data."""
@@ -794,7 +794,7 @@ def write_summary_initial_model_fit(
 
 
 def observation_plot_init(
-    datasets: Mapping[str, Dataset],
+    datasets: Mapping[Tag, Dataset],
 ) -> dict[str, pd.DataFrame]:
     """Initialise query point pairplot dataframes with initial observations.
     Also logs warnings if pairplot dependencies are not installed."""
@@ -827,11 +827,11 @@ def observation_plot_init(
 
 
 def write_summary_observations(
-    datasets: Mapping[str, Dataset],
-    models: Mapping[str, TrainableProbabilisticModel],
-    tagged_output: Mapping[str, TensorType],
+    datasets: Mapping[Tag, Dataset],
+    models: Mapping[Tag, TrainableProbabilisticModel],
+    tagged_output: Mapping[Tag, TensorType],
     model_fitting_timer: Timer,
-    observation_plot_dfs: MutableMapping[str, pd.DataFrame],
+    observation_plot_dfs: MutableMapping[Tag, pd.DataFrame],
 ) -> None:
     """Write TensorBoard summary for the current step observations."""
     for tag in datasets:
@@ -925,8 +925,8 @@ def write_summary_observations(
 
 
 def write_summary_query_points(
-    datasets: Mapping[str, Dataset],
-    models: Mapping[str, TrainableProbabilisticModel],
+    datasets: Mapping[Tag, Dataset],
+    models: Mapping[Tag, TrainableProbabilisticModel],
     search_space: SearchSpace,
     query_points: TensorType,
     query_point_generation_timer: Timer,
@@ -1000,8 +1000,8 @@ def stop_at_minimum(
     """
 
     def early_stop_callback(
-        datasets: Mapping[str, Dataset],
-        _models: Mapping[str, TrainableProbabilisticModel],
+        datasets: Mapping[Tag, Dataset],
+        _models: Mapping[Tag, TrainableProbabilisticModel],
         _acquisition_state: object,
     ) -> bool:
         dataset = datasets[objective_tag]

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -585,8 +585,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
             models = {OBJECTIVE: models}  # type: ignore[dict-item]
 
         # reassure the type checker that everything is tagged
-        datasets = cast(Dict[str, Dataset], datasets)
-        models = cast(Dict[str, TrainableProbabilisticModelType], models)
+        datasets = cast(Dict[Tag, Dataset], datasets)
+        models = cast(Dict[Tag, TrainableProbabilisticModelType], models)
 
         if num_steps < 0:
             raise ValueError(f"num_steps must be at least 0, got {num_steps}")
@@ -795,10 +795,10 @@ def write_summary_initial_model_fit(
 
 def observation_plot_init(
     datasets: Mapping[Tag, Dataset],
-) -> dict[str, pd.DataFrame]:
+) -> dict[Tag, pd.DataFrame]:
     """Initialise query point pairplot dataframes with initial observations.
     Also logs warnings if pairplot dependencies are not installed."""
-    observation_plot_dfs: dict[str, pd.DataFrame] = {}
+    observation_plot_dfs: dict[Tag, pd.DataFrame] = {}
     if logging.get_tensorboard_writer():
 
         seaborn_warning = False
@@ -982,7 +982,7 @@ def stop_at_minimum(
     minimum_rtol: float = 0.05,
     minimizers_atol: float = 0,
     minimizers_rtol: float = 0.05,
-    objective_tag: str = OBJECTIVE,
+    objective_tag: Tag = OBJECTIVE,
 ) -> EarlyStopCallback[TrainableProbabilisticModel, object]:
     """
     Generate an early stop function that terminates a BO loop when it gets close enough to the

--- a/trieste/objectives/utils.py
+++ b/trieste/objectives/utils.py
@@ -24,7 +24,7 @@ from typing import Optional, overload
 
 from ..data import Dataset
 from ..observer import MultiObserver, Observer, SingleObserver
-from ..types import TensorType
+from ..types import Tag, TensorType
 
 
 @overload
@@ -33,12 +33,12 @@ def mk_observer(objective: Callable[[TensorType], TensorType]) -> SingleObserver
 
 
 @overload
-def mk_observer(objective: Callable[[TensorType], TensorType], key: str) -> MultiObserver:
+def mk_observer(objective: Callable[[TensorType], TensorType], key: Tag) -> MultiObserver:
     ...
 
 
 def mk_observer(
-    objective: Callable[[TensorType], TensorType], key: Optional[str] = None
+    objective: Callable[[TensorType], TensorType], key: Optional[Tag] = None
 ) -> Observer:
     """
     :param objective: An objective function designed to be used with a single data set and model.

--- a/trieste/observer.py
+++ b/trieste/observer.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 from typing_extensions import Final
 
 from .data import Dataset
-from .types import TensorType
+from .types import Tag, TensorType
 
 SingleObserver = Callable[[TensorType], Dataset]
 """
@@ -28,7 +28,7 @@ Type alias for an observer of the objective function (that takes query points an
 unlabelled dataset).
 """
 
-MultiObserver = Callable[[TensorType], Mapping[str, Dataset]]
+MultiObserver = Callable[[TensorType], Mapping[Tag, Dataset]]
 """
 Type alias for an observer of the objective function (that takes query points and returns labelled
 datasets).
@@ -39,7 +39,7 @@ Observer = Union[SingleObserver, MultiObserver]
 Type alias for an observer, returning either labelled datasets or a single unlabelled dataset.
 """
 
-OBJECTIVE: Final[str] = "OBJECTIVE"
+OBJECTIVE: Final[Tag] = "OBJECTIVE"
 """
 A tag typically used by acquisition rules to denote the data sets and models corresponding to the
 optimization objective.

--- a/trieste/types.py
+++ b/trieste/types.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This module contains type aliases."""
-from typing import Callable, Tuple, TypeVar, Union
+from typing import Callable, Hashable, Tuple, TypeVar, Union
 
 import tensorflow as tf
 
@@ -32,5 +32,5 @@ state. If the state is updated, it is not updated in-place. Instead, a new state
 is a referentially transparent alternative to mutable state.
 """
 
-Tag = str
+Tag = Hashable
 """Type alias for a tag used to label datasets and models."""

--- a/trieste/types.py
+++ b/trieste/types.py
@@ -31,3 +31,6 @@ A `State` produces a value of type `T`, given a state of type `S`, and in doing 
 state. If the state is updated, it is not updated in-place. Instead, a new state is created. This
 is a referentially transparent alternative to mutable state.
 """
+
+Tag = str
+"""Type alias for a tag used to label datasets and models."""


### PR DESCRIPTION
This handles the case when datasets/models are indexed by something more complicated than a unique string.

Only annoyance is in some of the unit tests: because `Mapping[KT, VT]` is invariant in KT, we have to tell the type checker that the various  dictionaries of the form `{"foo": model}` that the tests use are actually `Mapping[Tag, Model]` not `Mapping[str, Model]`. The simplest way to do this is to predefine the tags, e.g. `FOO: Tag = "foo"`.