### PR TITLE
rename whitelist_external to allowlist_external

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ extend-exclude = docs/notebooks/,.venv,build/
 [testenv]
 basepython = python3.7
 deps = pip
-whitelist_externals = bash
+allowlist_externals = bash
 setenv =
     CUDA_VISIBLE_DEVICES =
 commands =


### PR DESCRIPTION
whitelist_external has been deprecated in recent versions of tox