### PR TITLE
deep ensemble faster sampler

### DIFF
--- a/tests/unit/models/keras/test_sampler.py
+++ b/tests/unit/models/keras/test_sampler.py
@@ -50,14 +50,6 @@ def _batch_size_fixture(request: Any) -> int:
     return request.param
 
 
-def test_ensemble_trajectory_sampler_raises_for_multi_output_model() -> None:
-    example_data = empty_dataset([2], [2])
-    model, _, _ = trieste_deep_ensemble_model(example_data, _ENSEMBLE_SIZE)
-
-    with pytest.raises(NotImplementedError):
-        DeepEnsembleTrajectorySampler(model, diversify=True)
-
-
 @pytest.mark.parametrize("diversify, num_outputs", [(True, 1), (False, 1), (False, 2)])
 def test_ensemble_trajectory_sampler_returns_trajectory_function_with_correctly_shaped_output(
     num_evals: int,
@@ -102,7 +94,7 @@ def test_ensemble_trajectory_sampler_returns_deterministic_trajectory(
     npt.assert_allclose(eval_1, eval_2)
 
 
-@pytest.mark.skip(reason="Seems fragile. Unrelated changes causing it to fail. Issue being raised.")
+# @pytest.mark.skip(reason="Seems fragile. Unrelated changes causing it to fail. Issue being raised.")
 @pytest.mark.parametrize("seed", [42, None])
 def test_ensemble_trajectory_sampler_is_not_too_deterministic(
     seed: Optional[int], diversify: bool
@@ -111,7 +103,7 @@ def test_ensemble_trajectory_sampler_is_not_too_deterministic(
     Different trajectories should have different internal state, even if we set the global RNG seed.
     """
     num_evals, batch_size, dim = 19, 5, 10
-    state = "_quantiles" if diversify else "_indices"
+    state = "_eps" if diversify else "_indices"
     example_data = empty_dataset([dim], [1])
     test_data = tf.random.uniform([num_evals, batch_size, dim])  # [N, B, d]
 
@@ -421,8 +413,8 @@ def test_ensemble_trajectory_sampler_returns_state(batch_size: int, diversify: b
     trajectory = cast(deep_ensemble_trajectory, sampler.get_trajectory())
 
     if diversify:
-        dtype = tf.float32
-        rnd_state_name = "quantiles"
+        dtype = tf.float64
+        rnd_state_name = "eps"
     else:
         dtype = tf.int32
         rnd_state_name = "indices"

--- a/tests/unit/models/keras/test_sampler.py
+++ b/tests/unit/models/keras/test_sampler.py
@@ -50,7 +50,11 @@ def _batch_size_fixture(request: Any) -> int:
     return request.param
 
 
-@pytest.mark.parametrize("diversify, num_outputs", [(True, 1), (False, 1), (False, 2)])
+@pytest.fixture(name="num_outputs", params=[1, 3])
+def _num_outputs_fixture(request: Any) -> int:
+    return request.param
+
+
 def test_ensemble_trajectory_sampler_returns_trajectory_function_with_correctly_shaped_output(
     num_evals: int,
     batch_size: int,
@@ -74,13 +78,13 @@ def test_ensemble_trajectory_sampler_returns_trajectory_function_with_correctly_
 
 
 def test_ensemble_trajectory_sampler_returns_deterministic_trajectory(
-    num_evals: int, batch_size: int, dim: int, diversify: bool
+    num_evals: int, batch_size: int, dim: int, diversify: bool, num_outputs: int
 ) -> None:
     """
     Evaluating the same data with the same trajectory multiple times should yield
     exactly the same output.
     """
-    example_data = empty_dataset([dim], [1])
+    example_data = empty_dataset([dim], [num_outputs])
     test_data = tf.random.uniform([num_evals, batch_size, dim])  # [N, B, d]
 
     model, _, _ = trieste_deep_ensemble_model(example_data, _ENSEMBLE_SIZE)
@@ -94,7 +98,6 @@ def test_ensemble_trajectory_sampler_returns_deterministic_trajectory(
     npt.assert_allclose(eval_1, eval_2)
 
 
-# @pytest.mark.skip(reason="Seems fragile. Unrelated changes causing it to fail. Issue being raised.")
 @pytest.mark.parametrize("seed", [42, None])
 def test_ensemble_trajectory_sampler_is_not_too_deterministic(
     seed: Optional[int], diversify: bool

--- a/tests/unit/models/keras/test_sampler.py
+++ b/tests/unit/models/keras/test_sampler.py
@@ -218,7 +218,6 @@ def test_ensemble_trajectory_sampler_samples_are_distinct_within_batch(diversify
     )  # distinct for two samples within same draw
 
 
-@pytest.mark.skip
 @random_seed
 def test_ensemble_trajectory_sampler_eps_broadcasted_correctly() -> None:
     """
@@ -235,14 +234,14 @@ def test_ensemble_trajectory_sampler_eps_broadcasted_correctly() -> None:
     trajectory = trajectory_sampler.get_trajectory()
 
     _ = trajectory(test_data)  # first call needed to initialize the state
-    trajectory._eps = tf.constant([[0], [1]], dtype=tf.float64)  # type: ignore
+    trajectory._eps.assign(tf.constant([[0], [1]], dtype=tf.float64))  # type: ignore
     evals = trajectory(test_data)
 
     npt.assert_array_less(
         1e-1, tf.reduce_max(tf.abs(evals[:, 0] - evals[:, 1]))
     )  # distinct for two samples within same draw
     npt.assert_allclose(
-        evals[:, 0], model.predict(test_data[:, 0])[0]
+        evals[:, 0], model.predict(test_data[:, 0])[0], rtol=5e-6
     )  # since we set first eps to 0, that trajectory should equal predicted means
 
 

--- a/tests/unit/models/keras/test_sampler.py
+++ b/tests/unit/models/keras/test_sampler.py
@@ -218,6 +218,7 @@ def test_ensemble_trajectory_sampler_samples_are_distinct_within_batch(diversify
     )  # distinct for two samples within same draw
 
 
+@pytest.mark.skip
 @random_seed
 def test_ensemble_trajectory_sampler_eps_broadcasted_correctly() -> None:
     """
@@ -230,19 +231,18 @@ def test_ensemble_trajectory_sampler_eps_broadcasted_correctly() -> None:
 
     model, _, _ = trieste_deep_ensemble_model(example_data, _ENSEMBLE_SIZE)
 
-
     trajectory_sampler = DeepEnsembleTrajectorySampler(model, diversify=True)
     trajectory = trajectory_sampler.get_trajectory()
 
     _ = trajectory(test_data)  # first call needed to initialize the state
-    trajectory._eps = tf.constant([[0],[1]], dtype=tf.float64)
+    trajectory._eps = tf.constant([[0], [1]], dtype=tf.float64)  # type: ignore
     evals = trajectory(test_data)
 
     npt.assert_array_less(
         1e-1, tf.reduce_max(tf.abs(evals[:, 0] - evals[:, 1]))
     )  # distinct for two samples within same draw
     npt.assert_allclose(
-        evals[:,0], model.predict(test_data[:,0])[0]
+        evals[:, 0], model.predict(test_data[:, 0])[0]
     )  # since we set first eps to 0, that trajectory should equal predicted means
 
 

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -94,11 +94,10 @@ class DeepEnsemble(
             arguments.
         :param bootstrap: Sample with replacement data for training each network in the ensemble.
             By default set to `False`.
-        :param diversify: Whether to use quantiles from final probabilistic layer as trajectories
-            instead of mean predictions when calling :meth:`trajectory_sampler`. Quantiles are
-            sampled uniformly from a unit interval. This mode can be used to increase the diversity
-            in case of optimizing very large batches of trajectories. When batch size is larger
-            than the ensemble size, multiple quantiles will be used with the same network. By
+        :param diversify: Whether to use quantiles from the approximate Gaussian distribution of
+            the ensemble as trajectories instead of mean predictions when calling
+            :meth:`trajectory_sampler`. This mode can be used to increase the diversity
+            in case of optimizing very large batches of trajectories. By
             default set to `False`.
         :param continuous_optimisation: If True (default), the optimizer will keep track of the
             number of epochs across BO iterations and use this number as initial_epoch. This is
@@ -327,7 +326,6 @@ class DeepEnsemble(
         Return a trajectory sampler. For :class:`DeepEnsemble`, we use an ensemble
         sampler that randomly picks a network from the ensemble and uses its predicted means
         for generating a trajectory, or optionally randomly sampled quantiles rather than means.
-        Only models with single output are supported with diversify option.
 
         :return: The trajectory sampler.
         """

--- a/trieste/models/keras/sampler.py
+++ b/trieste/models/keras/sampler.py
@@ -171,7 +171,7 @@ class deep_ensemble_trajectory(TrajectoryFunctionClass):
             predicted_vars = predicted_vars + tf.cast(DEFAULTS.JITTER, predicted_vars.dtype)
             predictions = predicted_means + tf.sqrt(predicted_vars) * tf.tile(
                 tf.cast(self._eps, predicted_vars.dtype), [x.shape[0], 1]
-            )   # [N*B, 1]
+            )  # [N*B, 1]
             return unflatten(predictions)  # [N, B, 1]
         else:
             ensemble_distributions = self._model.ensemble_distributions(flat_x)

--- a/trieste/models/keras/sampler.py
+++ b/trieste/models/keras/sampler.py
@@ -129,7 +129,6 @@ class deep_ensemble_trajectory(TrajectoryFunctionClass):
 
         self._initialized = tf.Variable(False, trainable=False)
         self._batch_size = tf.Variable(0, dtype=tf.int32, trainable=False)
-        self._num_outputs = tf.Variable(0, dtype=tf.int32, trainable=False)
 
         if self._diversify:
             self._eps = tf.Variable(


### PR DESCRIPTION
it turns out using reparametrisation trick for `diversify=True` option is much faster :)
bonus: now we can do multi output case as well
