### PR TITLE
random scalarization - part 1

### DIFF
--- a/tests/integration/test_multi_objective_bayesian_optimization.py
+++ b/tests/integration/test_multi_objective_bayesian_optimization.py
@@ -21,8 +21,9 @@ from trieste.acquisition import (
     HIPPO,
     BatchMonteCarloExpectedHypervolumeImprovement,
     ExpectedHypervolumeImprovement,
+    RandomScalarization,
 )
-from trieste.acquisition.multi_objective.pareto import Pareto, get_reference_point
+from trieste.acquisition.multi_objective import Pareto, get_reference_point, Chebyshev
 from trieste.acquisition.optimizer import generate_continuous_optimizer
 from trieste.acquisition.rule import (
     AcquisitionRule,
@@ -55,81 +56,96 @@ except ImportError:
 @pytest.mark.parametrize(
     "num_steps, acquisition_rule, convergence_threshold",
     [
+        # pytest.param(
+        #     20,
+        #     EfficientGlobalOptimization(
+        #         ExpectedHypervolumeImprovement(tf.constant([1.1, 1.1], dtype=tf.float64)).using(
+        #             OBJECTIVE
+        #         )
+        #     ),
+        #     -3.65,
+        #     id="ehvi_fixed_reference_pts",
+        # ),
+        # pytest.param(
+        #     20,
+        #     EfficientGlobalOptimization(ExpectedHypervolumeImprovement().using(OBJECTIVE)),
+        #     -3.65,
+        #     id="ExpectedHypervolumeImprovement",
+        # ),
+        # pytest.param(
+        #     15,
+        #     EfficientGlobalOptimization(
+        #         BatchMonteCarloExpectedHypervolumeImprovement(sample_size=500).using(OBJECTIVE),
+        #         num_query_points=2,
+        #         optimizer=generate_continuous_optimizer(num_initial_samples=500),
+        #     ),
+        #     -3.44,
+        #     id="BatchMonteCarloExpectedHypervolumeImprovement/2",
+        # ),
+        # pytest.param(
+        #     15,
+        #     EfficientGlobalOptimization(
+        #         BatchMonteCarloExpectedHypervolumeImprovement(
+        #             sample_size=500,
+        #             reference_point_spec=tf.constant([1.1, 1.1], dtype=tf.float64),
+        #         ).using(OBJECTIVE),
+        #         num_query_points=2,
+        #         optimizer=generate_continuous_optimizer(num_initial_samples=500),
+        #     ),
+        #     -3.44,
+        #     id="qehvi_vlmop2_q_2_fixed_reference_pts",
+        # ),
+        # pytest.param(
+        #     10,
+        #     EfficientGlobalOptimization(
+        #         BatchMonteCarloExpectedHypervolumeImprovement(sample_size=250).using(OBJECTIVE),
+        #         num_query_points=4,
+        #         optimizer=generate_continuous_optimizer(num_initial_samples=500),
+        #     ),
+        #     -3.2095,
+        #     id="BatchMonteCarloExpectedHypervolumeImprovement/4",
+        # ),
+        # pytest.param(
+        #     10,
+        #     EfficientGlobalOptimization(
+        #         HIPPO(),
+        #         num_query_points=4,
+        #         optimizer=generate_continuous_optimizer(num_initial_samples=500),
+        #     ),
+        #     -3.2095,
+        #     id="HIPPO/4",
+        # ),
+        # pytest.param(
+        #     10,
+        #     AsynchronousOptimization(
+        #         BatchMonteCarloExpectedHypervolumeImprovement(sample_size=250).using(OBJECTIVE),
+        #         num_query_points=4,
+        #         optimizer=generate_continuous_optimizer(num_initial_samples=500),
+        #     ),
+        #     -3.2095,
+        #     id="BatchMonteCarloExpectedHypervolumeImprovement/4",
+        # ),
+        # pytest.param(
+        #     15,
+        #     BatchHypervolumeSharpeRatioIndicator(num_query_points=20) if pymoo else None,
+        #     -3.2095,
+        #     id="BatchHypervolumeSharpeRatioIndicator",
+        #     marks=pytest.mark.qhsri,
+        # ),
         pytest.param(
-            20,
+            10,
             EfficientGlobalOptimization(
-                ExpectedHypervolumeImprovement(tf.constant([1.1, 1.1], dtype=tf.float64)).using(
-                    OBJECTIVE
-                )
-            ),
-            -3.65,
-            id="ehvi_fixed_reference_pts",
-        ),
-        pytest.param(
-            20,
-            EfficientGlobalOptimization(ExpectedHypervolumeImprovement().using(OBJECTIVE)),
-            -3.65,
-            id="ExpectedHypervolumeImprovement",
-        ),
-        pytest.param(
-            15,
-            EfficientGlobalOptimization(
-                BatchMonteCarloExpectedHypervolumeImprovement(sample_size=500).using(OBJECTIVE),
-                num_query_points=2,
-                optimizer=generate_continuous_optimizer(num_initial_samples=500),
+                RandomScalarization(
+                    scalarizer = Chebyshev(
+                        batch_size=4,
+                        num_objectives=2,
+                        ideal_spec=tf.zeros(shape=[2, 1], dtype=tf.float64),
+                    )
+                ),
+                num_query_points=4,
             ),
             -3.44,
-            id="BatchMonteCarloExpectedHypervolumeImprovement/2",
-        ),
-        pytest.param(
-            15,
-            EfficientGlobalOptimization(
-                BatchMonteCarloExpectedHypervolumeImprovement(
-                    sample_size=500,
-                    reference_point_spec=tf.constant([1.1, 1.1], dtype=tf.float64),
-                ).using(OBJECTIVE),
-                num_query_points=2,
-                optimizer=generate_continuous_optimizer(num_initial_samples=500),
-            ),
-            -3.44,
-            id="qehvi_vlmop2_q_2_fixed_reference_pts",
-        ),
-        pytest.param(
-            10,
-            EfficientGlobalOptimization(
-                BatchMonteCarloExpectedHypervolumeImprovement(sample_size=250).using(OBJECTIVE),
-                num_query_points=4,
-                optimizer=generate_continuous_optimizer(num_initial_samples=500),
-            ),
-            -3.2095,
-            id="BatchMonteCarloExpectedHypervolumeImprovement/4",
-        ),
-        pytest.param(
-            10,
-            EfficientGlobalOptimization(
-                HIPPO(),
-                num_query_points=4,
-                optimizer=generate_continuous_optimizer(num_initial_samples=500),
-            ),
-            -3.2095,
-            id="HIPPO/4",
-        ),
-        pytest.param(
-            10,
-            AsynchronousOptimization(
-                BatchMonteCarloExpectedHypervolumeImprovement(sample_size=250).using(OBJECTIVE),
-                num_query_points=4,
-                optimizer=generate_continuous_optimizer(num_initial_samples=500),
-            ),
-            -3.2095,
-            id="BatchMonteCarloExpectedHypervolumeImprovement/4",
-        ),
-        pytest.param(
-            15,
-            BatchHypervolumeSharpeRatioIndicator(num_query_points=20) if pymoo else None,
-            -3.2095,
-            id="BatchHypervolumeSharpeRatioIndicator",
-            marks=pytest.mark.qhsri,
+            id="RandomScalarization_fixed_reference_pts",
         ),
     ],
 )

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -34,7 +34,7 @@ acquisition function should take. Additionally, acquisition functions and builde
 are designed to minimize the objective function. For example, we do not provide an implementation of
 UCB.
 """
-from . import optimizer, rule
+from . import optimizer, rule, multi_objective
 from .combination import Product, Reducer, Sum
 from .function import (
     GIBBON,
@@ -103,9 +103,4 @@ from .sampler import (
     GumbelSampler,
     ThompsonSampler,
     ThompsonSamplerFromTrajectory,
-)
-from .multi_objective import (
-    Pareto, get_reference_point,
-    Scalarizer,
-    Chebyshev,
 )

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -82,6 +82,9 @@ from .function import (
     predictive_variance,
     probability_below_threshold,
     soft_local_penalizer,
+    RandomScalarization,
+    random_scalarization,
+    hippo_penalizer,
 )
 from .interface import (
     AcquisitionFunction,
@@ -100,4 +103,9 @@ from .sampler import (
     GumbelSampler,
     ThompsonSampler,
     ThompsonSamplerFromTrajectory,
+)
+from .multi_objective import (
+    Pareto, get_reference_point,
+    Scalarizer,
+    Chebyshev,
 )

--- a/trieste/acquisition/function/__init__.py
+++ b/trieste/acquisition/function/__init__.py
@@ -64,5 +64,8 @@ from .multi_objective import (
     ExpectedHypervolumeImprovement,
     batch_ehvi,
     expected_hv_improvement,
+    RandomScalarization,
+    random_scalarization,
+    hippo_penalizer,
 )
 from .utils import MultivariateNormalCDF

--- a/trieste/acquisition/function/multi_objective.py
+++ b/trieste/acquisition/function/multi_objective.py
@@ -25,7 +25,7 @@ import tensorflow_probability as tfp
 
 from ...data import Dataset
 from ...models import ProbabilisticModel, ReparametrizationSampler
-from ...models.interfaces import HasReparamSampler
+from ...models.interfaces import HasReparamSampler, HasTrajectorySampler
 from ...observer import OBJECTIVE
 from ...types import Tag, TensorType
 from ...utils import DEFAULTS
@@ -43,6 +43,7 @@ from ..multi_objective.pareto import (
     get_reference_point,
     prepare_default_non_dominated_partition_bounds,
 )
+from ..multi_objective.scalarization import Scalarizer
 from .function import ExpectedConstrainedImprovement
 
 
@@ -755,3 +756,123 @@ class hippo_penalizer:
         penalty = tf.reduce_prod(warped_d, axis=-1)  # [N,]
 
         return tf.reshape(penalty, (-1, 1))
+
+
+class RandomScalarization(VectorizedAcquisitionFunctionBuilder[HasTrajectorySampler]):
+    """
+    Acquisition function builder for performing batch random scalarization. For details see:    
+    http://proceedings.mlr.press/v115/paria20a/paria20a.pdf
+
+    For a convenient way to control the total memory usage of this acquisition function, see
+    :const:`split_acquisition_function_calls` wrapper.
+    """
+
+    def __init__(
+        self,
+        scalarizer: Scalarizer,
+    ):
+        """
+        :param scalarizer: The scalarizer that should be used to combine the outputs.
+        """
+        self._scalarizer = scalarizer
+
+    def prepare_acquisition_function(
+        self, models: Mapping[Tag, HasTrajectorySampler], datasets: Mapping[Tag, Dataset],
+    ) -> TrajectoryFunction:
+        """
+        :param models: The models for each tag.
+        :param datasets: The data from the observer.
+        :return: A mapping of negated trajectory sampled from the model.
+        :raise ValueError: If the model is not of a correct class or one of the objectives is not
+            present among the model tags.
+        """
+        for tag, model in models.items():
+            if not isinstance(model, HasTrajectorySampler):
+                raise ValueError(
+                    f"We only support models with a trajectory_sampler "
+                    f"method; received {model.__repr__()}"
+                    f"for output {tag}"
+                )
+
+        self._scalarizer.prepare(models, datasets)
+
+        self._trajectory_sampler = {  # pylint: disable=attribute-defined-outside-init
+            tag: model.trajectory_sampler() for tag, model in models.items()
+        }
+        self._trajectories = {  # pylint: disable=attribute-defined-outside-init
+            tag: sampler.get_trajectory() for tag, sampler in self._trajectory_sampler.items()
+        }
+        self._negated_trajectory = random_scalarization(  # pylint: disable=attribute-defined-outside-init
+            self._scalarizer,
+            self._trajectories,
+        )
+
+        return self._negated_trajectory
+
+    def update_acquisition_function(
+        self,
+        function: TrajectoryFunction,
+        models: Mapping[Tag, HasTrajectorySampler],
+        datasets: Mapping[Tag, Dataset],
+    ) -> TrajectoryFunction:
+        """
+        :param function: The trajectory function to update.
+        :param models: The models.
+        :param datasets: The data from the observer.
+        :return: A new trajectory sampled from the model.
+        """
+        self._scalarizer.update(models, datasets)
+
+        updated_trajectories = {
+            tag: sampler.update_trajectory(self._trajectories[tag])
+            for tag, sampler in self._trajectory_sampler.items()
+        }
+
+        if any(
+            updated_trajectories[tag] is not self._trajectories[tag]
+            for tag in self._trajectory_sampler
+        ):
+            self._trajectories = (  # pylint: disable=attribute-defined-outside-init
+                updated_trajectories
+            )
+            self._negated_trajectory = random_scalarization(  # pylint: disable=attribute-defined-outside-init
+                self._scalarizer,
+            )
+
+        return self._negated_trajectory
+
+
+def random_scalarization(
+    scalarizer: Scalarizer,
+    trajectories: Mapping[Tag, TrajectoryFunction],
+) -> TrajectoryFunction:
+    """
+    Returns a function that evaluates individual trajectories at ``x``, combines the trajectories
+    with the ``scalarizer`` and returns scalar values.
+    
+    Importantly, we assume that all objectives point in the same direction, in particular that
+    we are minimizing objectives or the smaller the better. We also assume objectives are scaled
+    to same units, in particular we assume a - stveinterval.
+
+    :param scalarizer: The scalarizer that should be used to combine the outputs.
+    :param trajectories: trajectories for all outputs.
+    :return: A single negated trajectory function.
+    """
+
+    @tf.function
+    def scalarized_objectives(x: TensorType) -> TensorType:
+        """
+        :param x: inputs in form [N, B, D]
+        """
+        objectives_trajectories = [
+            traj(x)[:, :, 0] for tag, traj in trajectories.items() if tag in objectives
+        ]
+        scalarized = scalarizer(tf.convert_to_tensor(objectives_trajectories))  # [N, B]
+
+        # we negate and then transform the scalarised to be positive, so that our acquisition
+        # function optimizers (which are maximizers) can be used to extract the minimizers
+        scalarized = tf.math.log(1 + tf.math.exp(tf.math.negative(scalarized)))
+
+        return scalarized
+
+    return scalarized_objectives

--- a/trieste/acquisition/multi_objective/__init__.py
+++ b/trieste/acquisition/multi_objective/__init__.py
@@ -19,3 +19,7 @@ from .partition import (
     ExactPartition2dNonDominated,
     prepare_default_non_dominated_partition_bounds,
 )
+from .scalarization import (
+    Scalarizer,
+    Chebyshev,
+)

--- a/trieste/acquisition/multi_objective/scalarization.py
+++ b/trieste/acquisition/multi_objective/scalarization.py
@@ -1,0 +1,212 @@
+# Copyright 2020 The Trieste Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" This module contains interface for scalarization functions and some example functions. """
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable, Mapping
+
+import tensorflow as tf
+
+from trieste.data import Dataset
+from trieste.models.interfaces import (
+    HasTrajectorySampler,
+)
+from trieste.types import Tag, TensorType
+
+
+IdealSpecCallable = Callable[..., TensorType]
+"""
+Type alias for ideal spec callable type that takes ``models`` and ``datasets`` as arguments and
+returns an ideal point with shape [K, 1].
+"""
+
+
+class Scalarizer(ABC):
+    """
+    This class provides an interface for scalarization functions. 
+    It has two tasks: 1) scalarize the objectives, 2) sample the parameters that are used for
+    diversifying the batch.
+
+    There are many choices for sacalarization functions, for an overview of some number of them
+    and empirical performance comparison, see https://arxiv.org/pdf/1904.05760.pdf
+    """
+
+    def __init__(
+        self,
+        batch_size: int,
+        num_objectives: int,
+        ideal_spec: Union[TensorType, IdealSpecCallable],
+    ):
+        """
+        :param batch_size: Number of elements in the batch, B.
+        :param num_objectives: Number of the objectives in the problem, K.
+        :param ideal_spec: This argument is used to determine how the ideal point is
+            calculated. If a Callable function specified, it is expected to take existing
+            ``models`` and ``datasets`` as arguments and return an ideal point with shape [K, 1]. 
+            If the Pareto front location is known, this arg can be used to specify a fixed ideal
+            point in each active learning iteration, as a tensor with minimum values, [K, 1].
+        """
+        self._batch_size = batch_size
+        self._num_objectives = num_objectives
+
+        if callable(ideal_spec):
+            self._ideal_spec: Union[TensorType, IdealSpecCallable] = ideal_spec
+        else:
+            self._ideal_spec = tf.convert_to_tensor(ideal_spec)
+
+    @staticmethod
+    def _infer_dtype(datasets: Mapping[Tag, Dataset]) -> tf.DType:
+        return next(iter(datasets.values())).query_points.dtype
+
+    def _get_ideal(
+        self, models: Mapping[Tag, HasTrajectorySampler], datasets: Mapping[Tag, Dataset]
+    ) -> TensorType:
+        dtype = self._infer_dtype(datasets)
+        if callable(self._ideal_spec):
+            ideal = tf.cast(self._ideal_spec(models, datasets), dtype=dtype)
+        else:
+            ideal = tf.cast(self._ideal_spec, dtype=dtype)
+        tf.debugging.assert_shapes([(ideal, (self._num_objectives, 1))])
+        return ideal
+
+    @abstractmethod
+    def __call__(self, trajectories_at_x: TensorType) -> TensorType:
+        """
+        Perform the scalarization on objectives evaluated on some inputs ``trajectories_at_x``.
+
+        :param trajectories_at_x: K objectives evaluated on N inputs, [K, N, B].
+        :return: Scalarized objectives, [N, B].
+        """
+
+    @abstractmethod
+    def prepare(
+        self, models: Mapping[Tag, HasTrajectorySampler], datasets: Mapping[Tag, Dataset]
+    ) -> None:
+        """
+        Generate all the internal variables on initialization. For example, weights in a linear
+        weighted sum scalarization could be sampled.
+        """
+
+    @abstractmethod
+    def update(
+        self, models: Mapping[Tag, HasTrajectorySampler], datasets: Mapping[Tag, Dataset]
+    ) -> None:
+        """
+        Update all the internal variables. Meant to be used between the bayesian optimization
+        steps to change the state of the variables. For example, weights in a linear weighted
+        sum scalarization could be resampled.
+        """
+
+
+class Chebyshev(Scalarizer):
+    """
+    A popular scalarization function, improvement over linear weighted sum in that it can deal
+    with non-convex Pareto fronts. Along with weights, it has an ideal point parameter
+    which acts as a reference point for computing the Chebyshev distance.
+    In case we know the minimum of the Pareto front, we can set it to that. Otherwise
+    a function can be used that would adaptively choose the ideal point based on the models or
+    acquired data.
+
+    By setting ``alpha`` to a value larger than zero we can switch to augmented Chebyshev
+    scalarisation function which can help with avoiding weakly Pareto optimal solutions.
+
+    See number 6 and 7 in https://arxiv.org/pdf/1904.05760.pdf for details, and for empirical
+    comparison to other functions.
+    """
+
+    def __init__(
+        self,
+        batch_size: int,
+        num_objectives: int,
+        ideal_spec: Union[TensorType, IdealSpecCallable],
+        alpha: float = 0.0,
+    ):
+        """
+        :param batch_size: Number of elements in the batch, B.
+        :param num_objectives: Number of the objectives in the problem, K.
+        :param ideal_spec: This argument is used to determine how the ideal point is
+            calculated. If a Callable function specified, it is expected to take existing
+            ``models`` and ``datasets`` as arguments and return an ideal point with shape [K, 1]. 
+            If the Pareto front location is known, this arg can be used to specify a fixed ideal
+            point in each active learning iteration, as a tensor with minimum values, [K, 1].
+        :param alpha: Parameter for augmented Chebyshev, set to zero by default. A good
+            value for this parameter might be 0.0001, suggested in the reference above.
+        """
+        super().__init__(batch_size, num_objectives, ideal_spec)
+
+        tf.debugging.assert_non_negative(alpha, f"alpha should be nonnegative but received {alpha}")
+        self._alpha = alpha
+
+    def __repr__(self) -> str:
+        """"""
+        if callable(self._ideal_spec):
+            return (
+                f"Chebyshev({self._batch_size!r},"
+                f"{self._num_objectives!r},"
+                f"{self._ideal_spec.__name__},"
+                f"{self._alpha!r})"
+            )
+        else:
+            return (
+                f"Chebyshev({self._batch_size!r},"
+                f"{self._num_objectives!r},"
+                f"{self._ideal_spec!r},"
+                f"{self._alpha!r})"
+            )
+
+    def __call__(self, trajectories_at_x: TensorType) -> TensorType:
+
+        tf.debugging.assert_shapes(
+            [
+                (trajectories_at_x, (self._num_objectives, None, self._batch_size)),
+                (self._weights, (self._num_objectives, self._batch_size)),
+            ]
+        )
+        differences = tf.abs(trajectories_at_x - self._ideal[:, :, None])
+        scalar = tf.reduce_max(
+            self._weights[:, None, :] * differences, axis=0
+        ) + self._alpha * tf.reduce_sum(differences, axis=0)
+        tf.debugging.assert_shapes([(scalar, (None, self._batch_size))])
+
+        return scalar
+
+    def _sample_weights(self, dtype: tf.DType) -> TensorType:
+        """
+        Sample weights used for scalarizing the objectives.
+
+        :return: Sampled weights [K, B].
+        """
+        weights = tf.random.normal([self._num_objectives, self._batch_size], dtype=dtype)
+        return tf.abs(weights / tf.sqrt(tf.reduce_sum(weights ** 2, axis=0, keepdims=True)))
+
+    def prepare(
+        self, models: Mapping[Tag, HasTrajectorySampler], datasets: Mapping[Tag, Dataset]
+    ) -> None:
+        dtype = self._infer_dtype(datasets)
+        self._weights = tf.Variable(  # pylint: disable=attribute-defined-outside-init
+            self._sample_weights(dtype), trainable=False
+        )
+        self._ideal = tf.Variable(  # pylint: disable=attribute-defined-outside-init
+            self._get_ideal(models, datasets), trainable=False
+        )
+
+    def update(
+        self, models: Mapping[Tag, HasTrajectorySampler], datasets: Mapping[Tag, Dataset]
+    ) -> None:
+        dtype = self._infer_dtype(datasets)
+        self._weights.assign(self._sample_weights(dtype))
+        self._ideal.assign(self._get_ideal(models, datasets))


### PR DESCRIPTION
this PR implements Random scalarization acquisition builder and function, interface for scalarization functions and one example of a scalarization function

part 2 will follow with a notebook
part 3 will follow with some functions for adaptive ideal points (and possible 1-2 more scalarization functions)

still at a draft stage to collect opinions on the design
(tests are missing and docs are not ironed out)

main questions about the design:
- I went with a dict of models approach to combine trajectories instead of a model stack, but its a bit inconsistent with the rest of multi-objective code, I kinda like the dict approach, but don't have a strong preference and we could use a model stack I guess (we would need a new type of model stack for trajectories I think, similar to `HasReparamSamplerModelStack`)
- I have separated the random scalarization from scalarization functions themselves, as we could have many forms of scalarizations - since they can be quite complex, they are objects. As a result `random_scalarization` is more of a container, most of the work is done by `Scalarizer`. Not sure what's the best approach here, perhaps we should integrate the scalarizer in the `random_scalarization` , but then it might be more difficult to use a different scalarization function. I'm also not sure how this separation affects retracing.

@vpicheny @uri-granta @henrymoss any thoughts on these? 