### PR TITLE
Fix SVGP update equations

### DIFF
--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -1655,7 +1655,7 @@ def test_sparse_variational_inducing_updates_preserves_posterior(
 
     old_mu, old_sqrt = model.model.predict_f(xnew, full_cov=True)  # predict old posterior
 
-    model.update(Dataset(x, y1))
+    model.update(Dataset(x, y1))  # this changes inducing points to xnew
 
     npt.assert_raises(
         AssertionError,

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -1651,8 +1651,6 @@ def test_sparse_variational_inducing_updates_preserves_posterior(
         inducing_point_selector=inducing_point_selector,
     )
 
-    model.optimize(Dataset(x, y1))
-
     np.testing.assert_array_equal(model.model.inducing_variable.Z, x[:num_inducing_points])
 
     old_mu, old_sqrt = model.predict_joint(xnew)  # predict old posterior

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -1655,16 +1655,16 @@ def test_sparse_variational_inducing_updates_preserves_posterior(
 
     np.testing.assert_array_equal(model.model.inducing_variable.Z, x[:num_inducing_points])
 
-    old_mu, old_sqrt = model.model.predict_f(xnew, full_cov=True)  # predict old posterior
+    old_mu, old_sqrt = model.predict_joint(xnew)  # predict old posterior
 
     model.update(Dataset(x, y1))  # this changes inducing points to xnew
 
     np.testing.assert_array_equal(model.model.inducing_variable.Z, xnew)
 
-    new_mu, new_sqrt = model.model.predict_f(xnew, full_cov=True)  # predict new posterior
+    new_mu, new_sqrt = model.predict_joint(xnew)  # predict new posterior
 
     np.testing.assert_allclose(old_mu, new_mu, atol=1e-4)
-    np.testing.assert_allclose(old_sqrt, new_sqrt, atol=1e-4)
+    np.testing.assert_allclose(old_sqrt, new_sqrt, atol=1.1e-4, rtol=1e-4)
 
 
 def multifidelity_autoregressive_nd_dataset(n_dims: int = 1) -> Dataset:

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -35,6 +35,7 @@ import numpy.testing as npt
 import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
+from gpflow.config import Config, as_context
 from gpflow.inducing_variables import (
     SeparateIndependentInducingVariables,
     SharedIndependentInducingVariables,
@@ -85,6 +86,7 @@ from trieste.models.gpflow.sampler import (
 from trieste.models.optimizer import BatchOptimizer, DatasetTransformer, Optimizer
 from trieste.space import Box
 from trieste.types import TensorType
+from trieste.utils import DEFAULTS
 
 
 def _3x_plus_gaussian_noise(x: tf.Tensor) -> tf.Tensor:
@@ -1635,13 +1637,10 @@ class DummyInducingPointSelector(InducingPointSelector[GPflowPredictor]):
 def test_sparse_variational_inducing_updates_preserves_posterior(
     whiten: bool,
 ) -> None:
-    from gpflow.config import Config, as_context
-
-    from trieste.utils import DEFAULTS
-
     default_jitter = 0.0
-    DEFAULTS.JITTER = default_jitter
-    with as_context(Config(jitter=default_jitter)):
+    with as_context(Config(jitter=default_jitter)), unittest.mock.patch.object(
+        DEFAULTS, "JITTER", default_jitter
+    ):
         x = tf.constant(np.linspace(0.0, 1.0, 8).reshape(-1, 1), dtype=gpflow.default_float())
         y1 = fnc_3x_plus_10(x)
 

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -1635,8 +1635,10 @@ class DummyInducingPointSelector(InducingPointSelector[GPflowPredictor]):
 def test_sparse_variational_inducing_updates_preserves_posterior(
     whiten: bool,
 ) -> None:
-    from gpflow.config import as_context, Config
+    from gpflow.config import Config, as_context
+
     from trieste.utils import DEFAULTS
+
     default_jitter = 0.0
     DEFAULTS.JITTER = default_jitter
     with as_context(Config(jitter=default_jitter)):
@@ -1645,7 +1647,8 @@ def test_sparse_variational_inducing_updates_preserves_posterior(
 
         num_inducing_points = 4
         xnew = tf.constant(
-            np.linspace(0.31, 0.77, num_inducing_points).reshape(-1, 1), dtype=gpflow.default_float()
+            np.linspace(0.31, 0.77, num_inducing_points).reshape(-1, 1),
+            dtype=gpflow.default_float(),
         )
 
         svgp = svgp_model_with_mean(x, y1, whiten, num_inducing_points)

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -1653,16 +1653,13 @@ def test_sparse_variational_inducing_updates_preserves_posterior(
 
     model.optimize(Dataset(x, y1))
 
+    np.testing.assert_array_equal(model.model.inducing_variable.Z, x[:num_inducing_points])
+
     old_mu, old_sqrt = model.model.predict_f(xnew, full_cov=True)  # predict old posterior
 
     model.update(Dataset(x, y1))  # this changes inducing points to xnew
 
-    npt.assert_raises(
-        AssertionError,
-        npt.assert_array_equal,
-        model.model.inducing_variable.Z,
-        x[:num_inducing_points],
-    )
+    np.testing.assert_array_equal(model.model.inducing_variable.Z, xnew)
 
     new_mu, new_sqrt = model.model.predict_f(xnew, full_cov=True)  # predict new posterior
 

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -1601,7 +1601,7 @@ def test_sparse_variational_pairwise_covariance_for_non_whitened(
     y1 = fnc_3x_plus_10(x)
     y2 = y1 * 0.5
 
-    svgp = svgp_model(x, mo_type, whiten)
+    svgp = two_output_svgp_model(x, mo_type, whiten)
     model = SparseVariational(svgp, BatchOptimizer(tf.optimizers.Adam(), max_iter=3, batch_size=10))
     model.model.whiten = whiten
 

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -317,7 +317,7 @@ def svgp_model(x: tf.Tensor, y: tf.Tensor, num_latent_gps: int = 1) -> SVGP:
 def svgp_model_with_mean(
     x: tf.Tensor, y: tf.Tensor, whiten: bool, num_inducing_points: int, num_latent_gps: int = 1
 ) -> SVGP:
-    return SVGP(
+    m = SVGP(
         gpflow.kernels.Matern32(),
         gpflow.likelihoods.Gaussian(),
         x[:num_inducing_points],
@@ -326,6 +326,8 @@ def svgp_model_with_mean(
         mean_function=gpflow.mean_functions.Linear(),
         whiten=whiten,
     )
+    gpflow.set_trainable(m.inducing_variable.Z, False)
+    return m
 
 
 def vgp_model(x: tf.Tensor, y: tf.Tensor, num_latent_gps: int = 1) -> VGP:

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -315,7 +315,7 @@ def svgp_model(x: tf.Tensor, y: tf.Tensor, num_latent_gps: int = 1) -> SVGP:
 
 
 def svgp_model_with_mean(
-    x: tf.Tensor, y: tf.Tensor, whiten: bool, num_inducing_points: bool, num_latent_gps: int = 1
+    x: tf.Tensor, y: tf.Tensor, whiten: bool, num_inducing_points: int, num_latent_gps: int = 1
 ) -> SVGP:
     return SVGP(
         gpflow.kernels.Matern32(),

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -322,6 +322,8 @@ def svgp_model_with_mean(
         A=0.37 * np.ones((1, 1), dtype=gpflow.default_float()),
         b=0.19 * np.ones((1,), dtype=gpflow.default_float()),
     )
+    q_mu = np.random.randn(num_inducing_points, 1)
+    q_sqrt = np.tril(np.random.randn(1, num_inducing_points, num_inducing_points))
     m = SVGP(
         gpflow.kernels.Matern32(),
         gpflow.likelihoods.Gaussian(),
@@ -330,9 +332,11 @@ def svgp_model_with_mean(
         num_latent_gps=num_latent_gps,
         mean_function=mean_function,
         whiten=whiten,
+        q_mu=q_mu,
+        q_sqrt=q_sqrt,
     )
     gpflow.set_trainable(mean_function, False)
-    gpflow.set_trainable(m.inducing_variable.Z, False)
+    gpflow.set_trainable(m.inducing_variable, False)
     return m
 
 

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -314,11 +314,13 @@ def svgp_model(x: tf.Tensor, y: tf.Tensor, num_latent_gps: int = 1) -> SVGP:
     )
 
 
-def svgp_model_with_mean(x: tf.Tensor, y: tf.Tensor, whiten: bool, num_latent_gps: int = 1) -> SVGP:
+def svgp_model_with_mean(
+    x: tf.Tensor, y: tf.Tensor, whiten: bool, num_inducing_points: bool, num_latent_gps: int = 1
+) -> SVGP:
     return SVGP(
         gpflow.kernels.Matern32(),
         gpflow.likelihoods.Gaussian(),
-        x[:4],
+        x[:num_inducing_points],
         num_data=len(x),
         num_latent_gps=num_latent_gps,
         mean_function=gpflow.mean_functions.Linear(),

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -314,6 +314,18 @@ def svgp_model(x: tf.Tensor, y: tf.Tensor, num_latent_gps: int = 1) -> SVGP:
     )
 
 
+def svgp_model_with_mean(x: tf.Tensor, y: tf.Tensor, whiten: bool, num_latent_gps: int = 1) -> SVGP:
+    return SVGP(
+        gpflow.kernels.Matern32(),
+        gpflow.likelihoods.Gaussian(),
+        x[:4],
+        num_data=len(x),
+        num_latent_gps=num_latent_gps,
+        mean_function=gpflow.mean_functions.Linear(),
+        whiten=whiten,
+    )
+
+
 def vgp_model(x: tf.Tensor, y: tf.Tensor, num_latent_gps: int = 1) -> VGP:
     likelihood = gpflow.likelihoods.Gaussian()
     kernel = gpflow.kernels.Matern32()

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 
 import gpflow
+import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 from gpflow.models import GPR, SGPR, SVGP, VGP, GPModel
@@ -317,15 +318,20 @@ def svgp_model(x: tf.Tensor, y: tf.Tensor, num_latent_gps: int = 1) -> SVGP:
 def svgp_model_with_mean(
     x: tf.Tensor, y: tf.Tensor, whiten: bool, num_inducing_points: int, num_latent_gps: int = 1
 ) -> SVGP:
+    mean_function = gpflow.mean_functions.Linear(
+        A=0.37 * np.ones((1, 1), dtype=gpflow.default_float()),
+        b=0.19 * np.ones((1,), dtype=gpflow.default_float()),
+    )
     m = SVGP(
         gpflow.kernels.Matern32(),
         gpflow.likelihoods.Gaussian(),
         x[:num_inducing_points],
         num_data=len(x),
         num_latent_gps=num_latent_gps,
-        mean_function=gpflow.mean_functions.Linear(),
+        mean_function=mean_function,
         whiten=whiten,
     )
+    gpflow.set_trainable(mean_function, False)
     gpflow.set_trainable(m.inducing_variable.Z, False)
     return m
 

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -325,8 +325,8 @@ def svgp_model_with_mean(
     q_mu = np.random.randn(num_inducing_points, 1)
     q_sqrt = np.tril(np.random.randn(1, num_inducing_points, num_inducing_points))
     m = SVGP(
-        gpflow.kernels.Matern32(),
-        gpflow.likelihoods.Gaussian(),
+        gpflow.kernels.Matern32(variance=0.91),
+        gpflow.likelihoods.Gaussian(variance=0.23),
         x[:num_inducing_points],
         num_data=len(x),
         num_latent_gps=num_latent_gps,

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -1016,7 +1016,7 @@ class SparseVariational(
             jitter_mat = DEFAULTS.JITTER * tf.eye(
                 tf.shape(new_inducing_points)[0], dtype=new_f_cov.dtype
             )
-            new_q_sqrt = tf.linalg.cholesky(new_f_cov ) # + jitter_mat)
+            new_q_sqrt = tf.linalg.cholesky(new_f_cov + jitter_mat)
 
         self.model.q_mu.assign(new_q_mu)  # [N, L]
         self.model.q_sqrt.assign(new_q_sqrt)  # [L, N, N]

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -1016,7 +1016,7 @@ class SparseVariational(
             jitter_mat = DEFAULTS.JITTER * tf.eye(
                 tf.shape(new_inducing_points)[0], dtype=new_f_cov.dtype
             )
-            new_q_sqrt = tf.linalg.cholesky(new_f_cov + jitter_mat)
+            new_q_sqrt = tf.linalg.cholesky(new_f_cov ) # + jitter_mat)
 
         self.model.q_mu.assign(new_q_mu)  # [N, L]
         self.model.q_sqrt.assign(new_q_sqrt)  # [L, N, N]

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -1012,6 +1012,7 @@ class SparseVariational(
             new_q_mu, new_q_sqrt = _whiten_points(self, new_inducing_points)
         else:
             new_q_mu, new_f_cov = self.predict_joint(new_inducing_points)  # [N, L], [L, N, N]
+            new_q_mu -= self.model.mean_function(new_inducing_points)
             jitter_mat = DEFAULTS.JITTER * tf.eye(
                 tf.shape(new_inducing_points)[0], dtype=new_f_cov.dtype
             )

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -960,7 +960,6 @@ class SparseVariational(
         num_data = dataset.query_points.shape[0]
         assert self.model.num_data is not None
         self.model.num_data.assign(num_data)
-        self.update_posterior_cache()
 
         if self._inducing_point_selector is not None:
             new_inducing_points = self._inducing_point_selector.calculate_inducing_points(
@@ -973,6 +972,7 @@ class SparseVariational(
                 )
             ):  # only bother updating if points actually change
                 self._update_inducing_variables(new_inducing_points)
+                self.update_posterior_cache()
 
     def optimize(self, dataset: Dataset) -> None:
         """

--- a/trieste/models/gpflow/utils.py
+++ b/trieste/models/gpflow/utils.py
@@ -328,9 +328,8 @@ def _whiten_points(
     :return: The updated q_mu and q_sqrt with shapes [N, L] and [L, N, N], respectively.
     """
 
-    old_mean = model.model.mean_function(inducing_points)
     f_mu, f_cov = model.model.predict_f(inducing_points, full_cov=True)  # [N, L], [L, N, N]
-    f_mu -= old_mean
+    f_mu -= model.model.mean_function(inducing_points)
     Knn = model.get_kernel()(inducing_points, full_cov=True)  # [N, N]
     jitter_mat = DEFAULTS.JITTER * tf.eye(tf.shape(inducing_points)[0], dtype=Knn.dtype)
     Lnn = tf.linalg.cholesky(Knn + jitter_mat)  # [N, N]

--- a/trieste/models/gpflow/utils.py
+++ b/trieste/models/gpflow/utils.py
@@ -330,7 +330,7 @@ def _whiten_points(
 
     old_mean = model.model.mean_function(inducing_points)
     f_mu, f_cov = model.model.predict_f(inducing_points, full_cov=True)  # [N, L], [L, N, N]
-    new_q_mu -= old_mean
+    f_mu -= old_mean
     Knn = model.get_kernel()(inducing_points, full_cov=True)  # [N, N]
     jitter_mat = DEFAULTS.JITTER * tf.eye(tf.shape(inducing_points)[0], dtype=Knn.dtype)
     Lnn = tf.linalg.cholesky(Knn + jitter_mat)  # [N, N]

--- a/trieste/models/gpflow/utils.py
+++ b/trieste/models/gpflow/utils.py
@@ -327,7 +327,10 @@ def _whiten_points(
     :para inducing_points: The new inducing point locations.
     :return: The updated q_mu and q_sqrt with shapes [N, L] and [L, N, N], respectively.
     """
+
+    old_mean = model.model.mean_function(inducing_points)
     f_mu, f_cov = model.model.predict_f(inducing_points, full_cov=True)  # [N, L], [L, N, N]
+    new_q_mu -= old_mean
     Knn = model.get_kernel()(inducing_points, full_cov=True)  # [N, N]
     jitter_mat = DEFAULTS.JITTER * tf.eye(tf.shape(inducing_points)[0], dtype=Knn.dtype)
     Lnn = tf.linalg.cholesky(Knn + jitter_mat)  # [N, N]


### PR DESCRIPTION
This PR solves [this issue](https://github.com/secondmind-labs/trieste/issues/707):

When we change the inducing points before re-training SVGPs and Deep GPs, we need to update q_mu and q_sqrt such that the posterior distribution is unchanged at the new inducing points. The previous equations only work when the mean function is zero. 

This PR fixes the equations and adds a test to check that equations are correct, by verifying that the posterior distributions at the new inducing points remains unchanged after the model is updated.

closes #707 