### PR TITLE
Allow qmc_normal_samples to be called with tensor parameter values

### DIFF
--- a/tests/unit/models/gpflow/test_sampler.py
+++ b/tests/unit/models/gpflow/test_sampler.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import math
 import unittest
-from typing import List, Type, Any
+from typing import Any, List, Type
 from unittest.mock import MagicMock
 
 import gpflow

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -43,12 +43,20 @@ from ..interfaces import (
     TrajectorySampler,
 )
 
+_IntTensorType = Union[tf.Tensor, int]
 
-def qmc_normal_samples(num_samples: int, n_sample_dim: int, skip: int = 0) -> tf.Tensor:
+
+def qmc_normal_samples(
+    num_samples: _IntTensorType, n_sample_dim: _IntTensorType, skip: _IntTensorType = 0
+) -> tf.Tensor:
     """
     Generates `num_samples` sobol samples, skipping the first `skip`, where each
     sample has dimension `n_sample_dim`.
     """
+
+    if num_samples == 0 or n_sample_dim == 0:
+        return tf.zeros(shape=(num_samples, n_sample_dim), dtype=tf.float64)
+
     sobol_samples = tf.math.sobol_sample(
         dim=n_sample_dim,
         num_results=num_samples,
@@ -61,7 +69,6 @@ def qmc_normal_samples(num_samples: int, n_sample_dim: int, skip: int = 0) -> tf
         scale=tf.constant(1.0, dtype=tf.float64),
     )
     normal_samples = dist.quantile(sobol_samples)
-    tf.debugging.assert_shapes([(normal_samples, (num_samples, n_sample_dim))])
     return normal_samples
 
 


### PR DESCRIPTION
Allow qmc_normal_samples to be called with tensor parameter values, this is useful when trying to call it in the context of a tf function, where it's more natural to use tensors than ints.

The only thing preventing this being possible already was the shape assertion. I'd argue that that is something which we can, and should, be able to verify using unit tests rather than runtime checks. I've added some tests to verify this, and have removed the assertion. I've also added some tests to check handling of invalid values.