### PR TITLE
Fix docs buikld issue

### DIFF
--- a/docs/notebooks/requirements.txt
+++ b/docs/notebooks/requirements.txt
@@ -22,4 +22,3 @@ jupyterlab
 jupytext
 gym<0.22
 box2d
-wheel<0.40

--- a/docs/notebooks/requirements.txt
+++ b/docs/notebooks/requirements.txt
@@ -22,3 +22,4 @@ jupyterlab
 jupytext
 gym<0.22
 box2d
+wheel<0.40

--- a/tox.ini
+++ b/tox.ini
@@ -65,24 +65,20 @@ commands =
 
 [testenv:docs]
 basepython = python3.7
-deps =
-    # pinned for now due to https://github.com/openai/gym/issues/3202
-    wheel==0.38.4
-    pip
 commands =
     # docs build
+    # pinned for now due to https://github.com/openai/gym/issues/3202
+    docs: pip install wheel==0.38.4
     docs: pip install .[qhsri] -r notebooks/requirements.txt -c notebooks/constraints.txt
     docs: pip install -r docs/requirements.txt -c docs/constraints.txt
     docs: bash -c "cd docs; make html"
 
 [testenv:quickdocs]
 basepython = python3.7
-deps =
-    # pinned for now due to https://github.com/openai/gym/issues/3202
-    wheel==0.38.4
-    pip
 commands =
     # quickdocs build
+    # pinned for now due to https://github.com/openai/gym/issues/3202
+    quickdocs: pip install wheel==0.38.4
     quickdocs: pip install .[qhsri] -r notebooks/requirements.txt -c notebooks/constraints.txt
     quickdocs: pip install -r docs/requirements.txt -c docs/constraints.txt
     quickdocs: bash -c "cd docs; if (python notebooks/quickrun/quickrun.py && make html); then python notebooks/quickrun/quickrun.py --revert; else python notebooks/quickrun/quickrun.py --revert; exit 1; fi"

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,7 @@ commands =
 basepython = python3.7
 commands =
     # quickdocs build
+    quickdocs: pip install wheel==0.38.4
     quickdocs: pip install .[qhsri] -r notebooks/requirements.txt -c notebooks/constraints.txt
     quickdocs: pip install -r docs/requirements.txt -c docs/constraints.txt
     quickdocs: bash -c "cd docs; if (python notebooks/quickrun/quickrun.py && make html); then python notebooks/quickrun/quickrun.py --revert; else python notebooks/quickrun/quickrun.py --revert; exit 1; fi"

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,10 @@ commands =
 
 [testenv:docs]
 basepython = python3.7
+deps =
+    # pinned for now due to https://github.com/openai/gym/issues/3202
+    wheel==0.38.4
+    pip
 commands =
     # docs build
     docs: pip install .[qhsri] -r notebooks/requirements.txt -c notebooks/constraints.txt
@@ -73,9 +77,12 @@ commands =
 
 [testenv:quickdocs]
 basepython = python3.7
+deps =
+    # pinned for now due to https://github.com/openai/gym/issues/3202
+    wheel==0.38.4
+    pip
 commands =
     # quickdocs build
-    quickdocs: pip install wheel==0.38.4
     quickdocs: pip install .[qhsri] -r notebooks/requirements.txt -c notebooks/constraints.txt
     quickdocs: pip install -r docs/requirements.txt -c docs/constraints.txt
     quickdocs: bash -c "cd docs; if (python notebooks/quickrun/quickrun.py && make html); then python notebooks/quickrun/quickrun.py --revert; else python notebooks/quickrun/quickrun.py --revert; exit 1; fi"


### PR DESCRIPTION
Temporary workaround for the gym bug exposed by the latest version of wheel. In future we'll want to unpin gym and remove the pins to wheel and setuptools somehow (see https://github.com/secondmind-labs/trieste/issues/733).