### PR TITLE
fixing an issue with resetting learning rate in gpflux and keras

### DIFF
--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -291,7 +291,7 @@ def test_deep_gaussian_process_with_lr_scheduler(
     }
 
     lr_schedule = tf.keras.optimizers.schedules.ExponentialDecay(
-        initial_learning_rate=0.01, decay_steps=1, decay_rate=0.5
+        initial_learning_rate=init_lr, decay_steps=1, decay_rate=0.5
     )
     optimizer = KerasOptimizer(tf.optimizers.Adam(lr_schedule), fit_args)
     model = DeepGaussianProcess(two_layer_model(x), optimizer)

--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -275,6 +275,33 @@ def test_deep_gaussian_process_resets_lr_with_lr_schedule(
     npt.assert_allclose(model.model_keras.optimizer.lr.numpy(), init_lr, rtol=1e-6)
 
 
+def test_deep_gaussian_process_with_lr_scheduler(
+    two_layer_model: Callable[[TensorType], DeepGP]
+) -> None:
+    x = tf.constant(np.arange(5).reshape(-1, 1), dtype=gpflow.default_float())
+    y = fnc_3x_plus_10(x)
+
+    epochs = 2
+    init_lr = 1.0
+
+    fit_args = {
+        "epochs": epochs,
+        "batch_size": 20,
+        "verbose": 0,
+    }
+
+    lr_schedule = tf.keras.optimizers.schedules.ExponentialDecay(
+        initial_learning_rate=0.01, decay_steps=1, decay_rate=0.5
+    )
+    optimizer = KerasOptimizer(tf.optimizers.Adam(lr_schedule), fit_args)
+    model = DeepGaussianProcess(two_layer_model(x), optimizer)
+
+    dataset = Dataset(x, y)
+    model.optimize(dataset)
+
+    assert not np.any(np.isnan(model.model_keras.history.history["loss"]))
+
+
 def test_deep_gaussian_process_default_optimizer_is_correct(
     two_layer_model: Callable[[TensorType], DeepGP]
 ) -> None:

--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -247,7 +247,7 @@ def test_deep_gaussian_process_resets_lr_with_lr_schedule(
     x = tf.constant(np.arange(5).reshape(-1, 1), dtype=gpflow.default_float())
     y = fnc_3x_plus_10(x)
 
-    epochs = 10
+    epochs = 2
     init_lr = 0.01
 
     def scheduler(epoch: int, lr: float) -> float:
@@ -268,9 +268,7 @@ def test_deep_gaussian_process_resets_lr_with_lr_schedule(
 
     npt.assert_allclose(model.model_keras.optimizer.lr.numpy(), init_lr, rtol=1e-6)
 
-    dataset = Dataset(x, y)
-
-    model.optimize(dataset)
+    model.optimize(Dataset(x, y))
 
     npt.assert_allclose(model.model_keras.optimizer.lr.numpy(), init_lr, rtol=1e-6)
 
@@ -296,10 +294,9 @@ def test_deep_gaussian_process_with_lr_scheduler(
     optimizer = KerasOptimizer(tf.optimizers.Adam(lr_schedule), fit_args)
     model = DeepGaussianProcess(two_layer_model(x), optimizer)
 
-    dataset = Dataset(x, y)
-    model.optimize(dataset)
+    model.optimize(Dataset(x, y))
 
-    assert not np.any(np.isnan(model.model_keras.history.history["loss"]))
+    assert len(model.model.history.history["loss"]) == epochs
 
 
 def test_deep_gaussian_process_default_optimizer_is_correct(

--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -296,7 +296,7 @@ def test_deep_gaussian_process_with_lr_scheduler(
 
     model.optimize(Dataset(x, y))
 
-    assert len(model.model.history.history["loss"]) == epochs
+    assert len(model.model_keras.history.history["loss"]) == epochs
 
 
 def test_deep_gaussian_process_default_optimizer_is_correct(

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -236,7 +236,7 @@ def test_deep_ensemble_with_lr_scheduler() -> None:
 
     model.optimize(example_data)
 
-    assert not np.any(np.isnan(model.model.history.history["loss"]))
+    assert len(model.model.history.history["loss"]) == epochs
 
 
 def test_deep_ensemble_ensemble_distributions(ensemble_size: int, dataset_size: int) -> None:
@@ -244,7 +244,7 @@ def test_deep_ensemble_ensemble_distributions(ensemble_size: int, dataset_size: 
     model, _, _ = trieste_deep_ensemble_model(example_data, ensemble_size, False, False)
 
     distributions = model.ensemble_distributions(example_data.query_points)
-    # breakpoint()
+
     assert len(distributions) == ensemble_size
     for dist in distributions:
         assert isinstance(dist, tfp.distributions.Distribution)

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -191,14 +191,11 @@ def test_deep_ensemble_resets_lr_with_lr_schedule() -> None:
 
     keras_ensemble = trieste_keras_ensemble_model(example_data, _ENSEMBLE_SIZE)
 
-    epochs = 10
-    init_lr = 0.01
+    epochs = 2
+    init_lr = 1.0
 
     def scheduler(epoch: int, lr: float) -> float:
-        if epoch == epoch // 2:
-            return lr * 0.1
-        else:
-            return lr
+        return lr * 0.5
 
     fit_args = {
         "epochs": epochs,
@@ -213,7 +210,33 @@ def test_deep_ensemble_resets_lr_with_lr_schedule() -> None:
 
     model.optimize(example_data)
 
+    npt.assert_allclose(model.model.history.history["lr"], [0.5, 0.25])
     npt.assert_allclose(model.model.optimizer.lr.numpy(), init_lr, rtol=1e-6)
+
+
+def test_deep_ensemble_with_lr_scheduler() -> None:
+    example_data = _get_example_data([100, 1])
+
+    keras_ensemble = trieste_keras_ensemble_model(example_data, _ENSEMBLE_SIZE)
+
+    epochs = 2
+    init_lr = 1.0
+
+    fit_args = {
+        "epochs": epochs,
+        "batch_size": 20,
+        "verbose": 0,
+    }
+
+    lr_schedule = tf.keras.optimizers.schedules.ExponentialDecay(
+        initial_learning_rate=0.01, decay_steps=1, decay_rate=0.5
+    )
+    optimizer = KerasOptimizer(tf.optimizers.Adam(lr_schedule), fit_args)
+    model = DeepEnsemble(keras_ensemble, optimizer)
+
+    model.optimize(example_data)
+
+    assert not np.any(np.isnan(model.model.history.history["loss"]))
 
 
 def test_deep_ensemble_ensemble_distributions(ensemble_size: int, dataset_size: int) -> None:

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -229,7 +229,7 @@ def test_deep_ensemble_with_lr_scheduler() -> None:
     }
 
     lr_schedule = tf.keras.optimizers.schedules.ExponentialDecay(
-        initial_learning_rate=0.01, decay_steps=1, decay_rate=0.5
+        initial_learning_rate=init_lr, decay_steps=1, decay_rate=0.5
     )
     optimizer = KerasOptimizer(tf.optimizers.Adam(lr_schedule), fit_args)
     model = DeepEnsemble(keras_ensemble, optimizer)


### PR DESCRIPTION
in keras and gpflux models we can use TF keras optimizers, instead of a callback learning rate schedule can be set as an instance of `tf.keras.optimizers.schedules.LearningRateSchedule` in which case our way of resetting the learning rate is not necessary and would throw an error