### PR TITLE
Make ensure_variable_model_data optional

### DIFF
--- a/tests/unit/models/gpflow/test_interface.py
+++ b/tests/unit/models/gpflow/test_interface.py
@@ -34,9 +34,6 @@ class _QuadraticPredictor(GPflowPredictor):
     def update(self, dataset: Dataset) -> None:
         return
 
-    def _ensure_variable_model_data(self) -> None:
-        pass
-
 
 class _QuadraticGPModel(GPModel):
     def __init__(self) -> None:

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -71,7 +71,6 @@ class GPflowPredictor(
         """
         self._posterior = self.model.posterior(PrecomputeCacheType.VARIABLE)
 
-    @abstractmethod
     def _ensure_variable_model_data(self) -> None:
         """Ensure GPflow data, which is normally stored in Tensors, is instead stored in
         dynamically shaped Variables."""

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -73,7 +73,7 @@ class GPflowPredictor(
 
     def _ensure_variable_model_data(self) -> None:
         """Ensure GPflow data, which is normally stored in Tensors, is instead stored in
-        dynamically shaped Variables."""
+        dynamically shaped Variables. Override this as required."""
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         # when unpickling we may need to regenerate the posterior cache


### PR DESCRIPTION
#741 added a `GaussianProcessRegression` abstract method `_ensure_variable_model_data`. This is an unnecessary breaking change, as some subclasses may not need to implement this (and any that do should know about it by failing garden path tests). This PR makes it optional instead.