### PR TITLE
Always build features so trajectories can be saved before being used

### DIFF
--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -773,6 +773,15 @@ class ResampleableRandomFourierFeatureFunctions(RandomFourierFeaturesCosine):
 
         super().__init__(model.get_kernel(), n_components, dtype=tf.float64)
 
+        if isinstance(model, SupportsGetInducingVariables):
+            dummy_X = model.get_inducing_variables()[0][0:1, :]
+        else:
+            dummy_X = model.get_internal_data().query_points[0:1, :]
+
+        # Always build the weights and biases. This is important for saving the trajectory (using
+        # tf.saved_model.save) before it has been used.
+        self.build(dummy_X.shape)
+
     def resample(self) -> None:
         """
         Resample weights and biases


### PR DESCRIPTION
Always build feature-functions using a dummy shape. This is important for `tf.saved_model.save` to work, in cases where the user hasn't called the trajectory yet. By calling `build` in `__init__` we ensure all the variables always exist.