### PR TITLE
Add continue_optimization method to BO

### DIFF
--- a/docs/notebooks/recovering_from_errors.pct.py
+++ b/docs/notebooks/recovering_from_errors.pct.py
@@ -61,18 +61,14 @@ acquisition_rule = trieste.acquisition.rule.TrustRegion()
 #
 # In this tutorial we'll try to complete fifteen optimization loops, which, with the broken observer, may take more than one attempt. The optimizer returns an `OptimizationResult`, which is simply a container for both:
 #
-#   * the final result, which uses a `Result` type (not to be confused with `OptimizationResult`) to safely encapsulate the final data, models and acquisition state if the process completed successfully, or an error if one occurred
-#   * the history of the successful optimization steps.
-#
-# We can access these with the `astuple` method.
+#   * the `final_result`, which uses a `Result` type (not to be confused with `OptimizationResult`) to safely encapsulate the final data, models and acquisition state if the process completed successfully, or an error if one occurred
+#   * the `history` of the successful optimization steps.
 
 # %%
 bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
 
 num_steps = 15
-result, history = bo.optimize(
-    num_steps, initial_data, model, acquisition_rule, None
-).astuple()
+result = bo.optimize(num_steps, initial_data, model, acquisition_rule, None)
 
 # %% [markdown]
 # We can see from the logs that the optimization loop failed, and this can be sufficient to know what to do next if we're working in a notebook. However, sometimes our setup means we don't have access to the logs. We'll pretend from here that's the case.
@@ -80,35 +76,27 @@ result, history = bo.optimize(
 # %% [markdown]
 # ## Handling success
 #
-# We don't know if the optimization completed successfully or not, so we'll only try to access and plot the data if it was successful. We can find out if this was the case with `result`'s `is_ok` attribute. If it was successful, we know there is data in the `result`, which we can `unwrap` and view.
+# We don't know if the optimization completed successfully or not, so we'll only try to access and plot the data if it was successful. We can find out if this was the case with `result`'s `is_ok` attribute. If it was successful, we know there is data in the `result`, which we can get using `try_get_final_dataset` and view.
 
 # %%
 if result.is_ok:
-    data = result.unwrap().dataset
+    data = result.try_get_final_dataset()
     print("best observation: ", tf.reduce_min(data.observations))
 
 # %% [markdown]
 # ## Handling failure
 #
-# If on the other hand, the optimization didn't complete successfully, we can fix our observer, and try again. We can try again by using the data, model and acquisition state from the last successful step, which is the last element of the `history`. Recall that we only need to account for the acquisition state because we're using the stateful `TrustRegion` rule. For most rules, we don't need to account for this state.
+# If on the other hand, the optimization didn't complete successfully, we can fix our observer, and try again. We can try again by calling the `continue_optimization` method: this is just like `optimize` except it is passed the `OptimizationResult` of a previous run, from which it extracts the last successful data, model and acquisition state. It also automatically calculates the number of remaining optimization steps.
 #
-# Note can view any `Result` by printing it. We'll do that here to see what exception was caught.
+# Note that we can view the `final_result` by printing it. We'll do that here to see what exception was caught.
 
 # %%
 if result.is_err:
-    print("result: ", result)
+    print("result: ", result.final_result)
 
     observer.manual_fix()
 
-    result, new_history = bo.optimize(
-        15 - len(history),
-        history[-1].dataset,
-        history[-1].model,
-        acquisition_rule,
-        history[-1].acquisition_state,
-    ).astuple()
-
-    history.extend(new_history)
+    result = bo.continue_optimization(num_steps, result, acquisition_rule)
 
 # %% [markdown]
 # We can repeat this until we've spent our optimization budget, using a loop if appropriate. But here, we'll just plot the data if it exists, safely by using `result`'s `is_ok` attribute.
@@ -117,7 +105,7 @@ if result.is_err:
 from trieste.experimental.plotting import plot_bo_points, plot_function_2d
 
 if result.is_ok:
-    data = result.unwrap().dataset
+    data = result.try_get_final_dataset()
     arg_min_idx = tf.squeeze(tf.argmin(data.observations, axis=0))
     _, ax = plot_function_2d(
         Branin.objective,
@@ -136,16 +124,16 @@ if result.is_ok:
 # **Note that trieste currently saves models using pickling, which is not portable and not secure. You should only try to load optimization results that you generated yourself on the same system (or a system with the same version libraries).**
 
 # %%
-result, history = bo.optimize(
+result = bo.optimize(
     num_steps, initial_data, model, acquisition_rule, None, track_path="history"
-).astuple()
+)
 
 # %% [markdown]
 # The returned `history` records are now stored in files rather than in memory. Their constituents can be accessed just as before, which loads the content into memory only when required. The `result` is automatically loaded into memory, but is also saved to disk with the rest of the history.
 
 # %%
-print(history[-1])
-print(history[-1].model)
+print(result.history[-1])
+print(result.history[-1].model)
 
 # %% [markdown]
 # It is also possible to reload the `OptimizationResult` in a new Python process:

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -80,6 +80,15 @@ def test_optimization_result_try_get_final_datasets_for_successful_optimization(
     assert result.try_get_final_dataset() is data[FOO]
 
 
+def test_optimization_result_status_for_successful_optimization() -> None:
+    data = {FOO: empty_dataset([1], [1])}
+    result: OptimizationResult[None] = OptimizationResult(
+        Ok(Record(data, {FOO: _PseudoTrainableQuadratic()}, None)), []
+    )
+    assert result.is_ok
+    assert not result.is_err
+
+
 def test_optimization_result_try_get_final_datasets_for_multiple_datasets() -> None:
     data = {FOO: empty_dataset([1], [1]), BAR: empty_dataset([2], [2])}
     models = {FOO: _PseudoTrainableQuadratic(), BAR: _PseudoTrainableQuadratic()}
@@ -93,6 +102,12 @@ def test_optimization_result_try_get_final_datasets_for_failed_optimization() ->
     result: OptimizationResult[object] = OptimizationResult(Err(_Whoops()), [])
     with pytest.raises(_Whoops):
         result.try_get_final_datasets()
+
+
+def test_optimization_result_status_for_failed_optimization() -> None:
+    result: OptimizationResult[object] = OptimizationResult(Err(_Whoops()), [])
+    assert result.is_err
+    assert not result.is_ok
 
 
 def test_optimization_result_try_get_final_models_for_successful_optimization() -> None:

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -296,8 +296,6 @@ def test_bayesian_optimizer_continue_optimization_raises_for_empty_result() -> N
         optimizer.continue_optimization(10, opt_result, rule)
 
 
-@pytest.mark.parametrize("fit_initial_model", [True, False])
-def test_bayesian_optimizer_optimizes_initial_model(fit_initial_model: bool) -> None:
 @pytest.mark.parametrize("fit_model", ["all", "all_but_init", "never"])
 def test_bayesian_optimizer_optimizes_initial_model(fit_model: str) -> None:
     class _CountingOptimizerModel(_PseudoTrainableQuadratic):

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -599,8 +599,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
         :param early_stop_callback: An optional callback that is evaluated with the current
             datasets, models and optimization state before every optimization step. If this
             returns `True` then the optimization loop is terminated early.
-        :param start_step: The step number to start with. This number is removed from the
-            number of optimization steps run and is useful for restarting previous computations.
+        :param start_step: The step number to start with. This number is removed from ``num_steps``
+            and is useful for restarting previous computations.
         :return: An :class:`OptimizationResult`. The :attr:`final_result` element contains either
             the final optimization data, models and acquisition state, or, if an exception was
             raised while executing the optimization loop, it contains the exception raised. In

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -797,8 +797,8 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
             models and acquisition state. If the result was successful then the final result is
             used; otherwise the last record in the history is used. The size of the history
             is used to determine how many more steps are required.
-        :param *args: Any more positional arguments to pass on to optimize.
-        :param **kwargs: Any more keyword arguments to pass on to optimize.
+        :param args: Any more positional arguments to pass on to optimize.
+        :param kwargs: Any more keyword arguments to pass on to optimize.
         :return: An :class:`OptimizationResult`. The history will contain both the history from
             `optimization_result` (including the `final_result` if that was successful) and
             any new records.


### PR DESCRIPTION
Add a `continue_optimization` method to `BayesianOptimizer` to make it simpler to continue a previous optimization, either one which failed or one which passed but that you wish to continue for longer.