### PR TITLE
Use tie breakers in Thompson sampling

### DIFF
--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -28,6 +28,7 @@ from scipy.optimize import bisect
 from ..models import ProbabilisticModel
 from ..models.interfaces import HasTrajectorySampler, ProbabilisticModelType
 from ..types import TensorType
+from ..utils.misc import tf_argmin_with_tie_breaks
 from .utils import select_nth_output
 
 
@@ -115,7 +116,7 @@ class ExactThompsonSampler(ThompsonSampler[ProbabilisticModel]):
             thompson_samples = tf.reduce_min(samples, axis=1)  # [S, 1]
         else:
             samples_2d = tf.squeeze(samples, -1)  # [S, N]
-            indices = tf.math.argmin(samples_2d, axis=1)
+            indices = tf_argmin_with_tie_breaks(samples_2d, axis=1)
             thompson_samples = tf.gather(at, indices)  # [S, D]
 
         return thompson_samples
@@ -262,7 +263,7 @@ class ThompsonSamplerFromTrajectory(ThompsonSampler[HasTrajectorySampler]):
             if self._sample_min_value:
                 sample = tf.reduce_min(evaluated_trajectory, keepdims=True)  # [1, 1]
             else:
-                sample = tf.gather(at, tf.math.argmin(evaluated_trajectory))  # [1, D]
+                sample = tf.gather(at, tf_argmin_with_tie_breaks(evaluated_trajectory))  # [1, D]
 
             thompson_samples = tf.concat([thompson_samples, sample], axis=0)
 

--- a/trieste/utils/misc.py
+++ b/trieste/utils/misc.py
@@ -397,7 +397,7 @@ def _flatten_module(  # type: ignore[no-untyped-def]
 
 
 def tf_argmin_with_tie_breaks(
-    input: TensorType, axis: int, output_type: DType = tf.int64
+    input: TensorType, axis: int = 0, output_type: DType = tf.int64
 ) -> TensorType:
     """
     Returns the index with the smallest value across axes of a tensor.
@@ -413,7 +413,7 @@ def tf_argmin_with_tie_breaks(
 
 
 def tf_argmax_with_tie_breaks(
-    input: TensorType, axis: int, output_type: DType = tf.int64
+    input: TensorType, axis: int = 0, output_type: DType = tf.int64
 ) -> TensorType:
     """
     Returns the index with the largest value across axes of a tensor.
@@ -429,7 +429,7 @@ def tf_argmax_with_tie_breaks(
 
 
 def _tf_argminmax_with_tie_breaks(
-    argmin: bool, input: TensorType, axis: int, output_type: DType = tf.int64
+    argmin: bool, input: TensorType, axis: int, output_type: DType
 ) -> TensorType:
     # transpose axis to end and flatten
     shape = tf.shape(input)


### PR DESCRIPTION
Investigating adding tie breakers to argmin as suggested in https://github.com/secondmind-labs/trieste/issues/464.

While this does work, the solution here has a **significant** performance impact as it requires a complicated transposition and shuffle of the entire array before calling tf.math.argmin. Suggest abandoning as not worthwhile.