### PR TITLE
Note that Thompson Sampler minimiser ties aren't broken randomly

### DIFF
--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -92,7 +92,7 @@ class ExactThompsonSampler(ThompsonSampler[ProbabilisticModel]):
     ) -> TensorType:
         """
         Return exact samples from either the objective function's minimiser or its minimal value
-        over the candidate set `at`.
+        over the candidate set `at`. Note that minimiser ties aren't broken randomly.
 
         :param model: The model to sample from.
         :param sample_size: The desired number of samples.
@@ -225,7 +225,7 @@ class ThompsonSamplerFromTrajectory(ThompsonSampler[HasTrajectorySampler]):
     ) -> TensorType:
         """
         Return approximate samples from either the objective function's minimser or its minimal
-        value over the candidate set `at`.
+        value over the candidate set `at`. Note that minimiser ties aren't broken randomly.
 
         :param model: The model to sample from.
         :param sample_size: The desired number of samples.


### PR DESCRIPTION
**Related issue(s)/PRs:** https://github.com/secondmind-labs/trieste/issues/464

## Summary

Note that Thompson Sampler minimiser ties aren't broken randomly. Fixing this properly has performance impacts

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [x] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [x] Any new features are well-documented (in docstrings or notebooks)
