### PR TITLE
Fix slowtests

### DIFF
--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -326,7 +326,7 @@ def test_bayesian_optimizer_with_svgp_finds_minima_of_simple_quadratic() -> None
 
 
 @random_seed
-@pytest.mark.slow
+# @pytest.mark.slow
 def test_bayesian_optimizer_with_sgpr_finds_minima_of_scaled_branin() -> None:
     _test_optimizer_finds_minimum(
         SparseGaussianProcessRegression,
@@ -626,7 +626,9 @@ def _test_optimizer_finds_minimum(
                 acquisition_rule,
                 track_state=True,
                 track_path=Path(tmpdirname) / "history",
-                early_stop_callback=stop_at_minimum(minima, minimizers, minimum_rtol=rtol_level),
+                early_stop_callback=stop_at_minimum(
+                    minima, minimizers, minimum_rtol=rtol_level, minimum_step_number=2
+                ),
                 fit_model=fit_model,
             )
 

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -326,7 +326,7 @@ def test_bayesian_optimizer_with_svgp_finds_minima_of_simple_quadratic() -> None
 
 
 @random_seed
-# @pytest.mark.slow
+@pytest.mark.slow
 def test_bayesian_optimizer_with_sgpr_finds_minima_of_scaled_branin() -> None:
     _test_optimizer_finds_minimum(
         SparseGaussianProcessRegression,

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -624,6 +624,7 @@ def _test_optimizer_finds_minimum(
                 track_state=True,
                 track_path=Path(tmpdirname) / "history",
                 early_stop_callback=stop_at_minimum(
+                    # stop as soon as we find the minimum (but always run at least one step)
                     minima, minimizers, minimum_rtol=rtol_level, minimum_step_number=2
                 ),
                 fit_model=not isinstance(acquisition_rule, TURBO),

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -141,7 +141,7 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                 12, AsynchronousOptimization(num_query_points=3), id="AsynchronousOptimization"
             ),
             pytest.param(
-                10,
+                15,
                 EfficientGlobalOptimization(
                     LocalPenalization(
                         ScaledBranin.search_space,
@@ -151,7 +151,7 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                 id="LocalPenalization",
             ),
             pytest.param(
-                10,
+                15,
                 AsynchronousGreedy(
                     LocalPenalization(
                         ScaledBranin.search_space,
@@ -180,7 +180,7 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                 ),
                 id="MultipleOptimismNegativeLowerConfidenceBound",
             ),
-            pytest.param(15, TrustRegion(), id="TrustRegion"),
+            pytest.param(20, TrustRegion(), id="TrustRegion"),
             pytest.param(
                 15,
                 TrustRegion(

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -616,9 +616,6 @@ def _test_optimizer_finds_minimum(
     with tempfile.TemporaryDirectory() as tmpdirname:
         summary_writer = tf.summary.create_file_writer(tmpdirname)
         with tensorboard_writer(summary_writer):
-            fit_model = (
-                "never" if isinstance(acquisition_rule, TURBO) else "all_but_init"
-            )  # avoid updating global model
             result = BayesianOptimizer(observer, search_space).optimize(
                 num_steps or 2,
                 initial_data,
@@ -629,7 +626,8 @@ def _test_optimizer_finds_minimum(
                 early_stop_callback=stop_at_minimum(
                     minima, minimizers, minimum_rtol=rtol_level, minimum_step_number=2
                 ),
-                fit_model=fit_model,
+                fit_model=not isinstance(acquisition_rule, TURBO),
+                fit_initial_model=False,
             )
 
             # check history saved ok

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -625,7 +625,10 @@ def _test_optimizer_finds_minimum(
                 track_path=Path(tmpdirname) / "history",
                 early_stop_callback=stop_at_minimum(
                     # stop as soon as we find the minimum (but always run at least one step)
-                    minima, minimizers, minimum_rtol=rtol_level, minimum_step_number=2
+                    minima,
+                    minimizers,
+                    minimum_rtol=rtol_level,
+                    minimum_step_number=2,
                 ),
                 fit_model=not isinstance(acquisition_rule, TURBO),
                 fit_initial_model=False,

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -209,23 +209,12 @@ def test_optimization_result_from_path_partial_result() -> None:
         )
 
 
-def test_bayesian_optimizer_optimize_raises_if_invalid_fit_model_arg() -> None:
-    data, models = {OBJECTIVE: empty_dataset([1], [1])}, {OBJECTIVE: _PseudoTrainableQuadratic()}
-    # first check that doesnt raise if correct fit_model given
-    bo = BayesianOptimizer(lambda x: x[:1], Box([-1], [1]))
-    bo.optimize(1, data, models, fit_model="all")
-    bo.optimize(1, data, models, fit_model="all_but_init")
-    bo.optimize(1, data, models, fit_model="never")
-    with pytest.raises(ValueError):  # now check that raises for bad value
-        bo.optimize(1, data, models, fit_model="blah")
-
-
 def test_bayesian_optimizer_optimize_raises_if_invalid_model_training_args() -> None:
     data, models = {NA: empty_dataset([1], [1])}, {NA: _PseudoTrainableQuadratic()}
     bo = BayesianOptimizer(lambda x: x[:1], Box([-1], [1]))
 
     with pytest.raises(ValueError):  # turning off global model training means we do not train
-        bo.optimize(1, data, models, fit_model="never")
+        bo.optimize(1, data, models, fit_model=False)
 
 
 @pytest.mark.parametrize("steps", [0, 1, 2, 5])
@@ -314,7 +303,8 @@ def test_bayesian_optimizer_optimizes_initial_model(fit_model: str) -> None:
             {NA: mk_dataset([[0.0]], [[0.0]])},
             {NA: model},
             rule,
-            fit_model=fit_model,
+            fit_model=(fit_model in ["all", "all_but_init"]),
+            fit_initial_model=(fit_model in ["all"]),
         )
         .astuple()
     )
@@ -421,7 +411,7 @@ def test_bayesian_optimizer_optimize_for_uncopyable_model() -> None:
             {NA: mk_dataset([[0.0]], [[0.0]])},
             {NA: _UncopyableModel()},
             rule,
-            fit_model="all_but_init",
+            fit_initial_model=False,
         )
         .astuple()
     )

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -231,7 +231,12 @@ def test_wallclock_time_logging(
         steps = 3
         rule = _FixedAcquisitionRuleWithWaiting([[0.0]])
         BayesianOptimizer(lambda x: {tag: Dataset(x, x**2)}, Box([-1], [1])).optimize(
-            steps, data, models, rule, fit_model=fit_model
+            steps,
+            data,
+            models,
+            rule,
+            fit_model=fit_model in ["all", "all_but_init"],
+            fit_initial_model=fit_model in ["all"],
         )
 
     other_scalars = 0

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -1071,6 +1071,7 @@ def stop_at_minimum(
     minimizers_atol: float = 0,
     minimizers_rtol: float = 0.05,
     objective_tag: Tag = OBJECTIVE,
+    minimum_step_number: Optional[int] = None,
 ) -> EarlyStopCallback[TrainableProbabilisticModel, object]:
     """
     Generate an early stop function that terminates a BO loop when it gets close enough to the
@@ -1083,6 +1084,7 @@ def stop_at_minimum(
     :param minimizers_atol: Absolute tolerance for minimizer point.
     :param minimizers_rtol: Relative tolerance for minimizer point.
     :param objective_tag: The tag for the objective data.
+    :param minimum_step_number: Minimum step number to stop at.
     :return: An early stop function that terminates if we get close enough to both the minimum
         and any of the minimizer points.
     """
@@ -1092,6 +1094,8 @@ def stop_at_minimum(
         _models: Mapping[Tag, TrainableProbabilisticModel],
         _acquisition_state: object,
     ) -> bool:
+        if minimum_step_number is not None and logging.get_step_number() < minimum_step_number:
+            return False
         dataset = datasets[objective_tag]
         arg_min_idx = tf.squeeze(tf.argmin(dataset.observations, axis=0))
         if minimum is not None:


### PR DESCRIPTION
**Related issue(s)/PRs:** https://github.com/secondmind-labs/trieste/pull/739

## Summary

Fix failures introduced by TURBO PR:

* Always test at least one BO step even if the initial points happen to have found the minimum!
* Increment max number of steps for a few failing tests (these are failing just due to rng changes and the early_stop_callback will prevent unnecessary steps anyway)
* Remove unnecessary breaking API change: keep `fit_initial_model` and make `fit_model` a simpler bool.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [x] The quality checks are all passing
- [x] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
