### PR TITLE
Fix versions.json links for latest sphinx

### DIFF
--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -73,7 +73,7 @@ def test_versions_is_valid(versions: list[dict[str, Any]]) -> None:
         assert isinstance(v, dict)
         assert set(v.keys()) == {"version", "url"}
         assert all(isinstance(value, str) for value in v.values())
-        assert v["url"] == f"https://secondmind-labs.github.io/trieste/{v['version']}/index.html"
+        assert v["url"] == f"https://secondmind-labs.github.io/trieste/{v['version']}/"
 
 
 def test_version_in_versions(version: str, versions: list[dict[str, Any]]) -> None:

--- a/versions.json
+++ b/versions.json
@@ -1,30 +1,30 @@
 [
   {
     "version": "develop",
-    "url": "https://secondmind-labs.github.io/trieste/develop/index.html"
+    "url": "https://secondmind-labs.github.io/trieste/develop/"
   },
   {
     "version": "1.2.0",
-    "url": "https://secondmind-labs.github.io/trieste/1.2.0/index.html"
+    "url": "https://secondmind-labs.github.io/trieste/1.2.0/"
   },
   {
     "version": "1.1.2",
-    "url": "https://secondmind-labs.github.io/trieste/1.1.2/index.html"
+    "url": "https://secondmind-labs.github.io/trieste/1.1.2/"
   },
   {
     "version": "1.0.0",
-    "url": "https://secondmind-labs.github.io/trieste/1.0.0/index.html"
+    "url": "https://secondmind-labs.github.io/trieste/1.0.0/"
   },
   {
     "version": "0.13.3",
-    "url": "https://secondmind-labs.github.io/trieste/0.13.3/index.html"
+    "url": "https://secondmind-labs.github.io/trieste/0.13.3/"
   },
   {
     "version": "0.12.0",
-    "url": "https://secondmind-labs.github.io/trieste/0.12.0/index.html"
+    "url": "https://secondmind-labs.github.io/trieste/0.12.0/"
   },
   {
     "version": "0.11.3",
-    "url": "https://secondmind-labs.github.io/trieste/0.11.3/index.html"
+    "url": "https://secondmind-labs.github.io/trieste/0.11.3/"
   }
 ]


### PR DESCRIPTION
**Related issue(s)/PRs:** #734

## Summary

Unpinning the version of sphinx theme used to generate the docs seems to have broken the links between versions (using the dropdown menu on the topright). Previously the links were absolute (always going to e.g. https://secondmind-labs.github.io/trieste/1.2.0/index.html), but now they're relative, appending the appropriate document path. This is a good thing, but we need to fix and deploy versions.json to get this to work.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [x] The quality checks are all passing
- [x] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
