### PR TITLE
Fix README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Trieste (pronounced tree-est) is a Bayesian optimization toolbox built on [Tenso
 
 ## Getting started
 
-Here's a quick overview of the main components of a Bayesian optimization loop. For more details, see our [Documentation](https://secondmind-labs.github.io/trieste) where we have multiple [Tutorials](https://secondmind-labs.github.io/trieste/tutorials.html) covering both the basic functionalities of the toolbox, as well as more advanced usage.
+Here's a quick overview of the main components of a Bayesian optimization loop. For more details, see our <span style="font-variant:small-caps;">[Documentation](https://secondmind-labs.github.io/trieste)</span> where we have multiple <span style="font-variant:small-caps;">[Tutorials](https://secondmind-labs.github.io/trieste/tutorials.html)</span> covering both the basic functionalities of the toolbox, as well as more advanced usage.
 
 Let's set up a synthetic black-box objective function we wish to minimize, for example, a popular Branin optimization function, and generate some initial data
 ```python
@@ -42,7 +42,7 @@ initial_data = observer(initial_query_points)
 
 First step is to create a probabilistic model of the objective function, for example a Gaussian Process model
 ```python
-from trieste.models import build_gpr, GaussianProcessRegression
+from trieste.models.gpflow import build_gpr, GaussianProcessRegression
 
 gpflow_model = build_gpr(initial_data, Branin.search_space)
 model = GaussianProcessRegression(gpflow_model)
@@ -59,7 +59,7 @@ Finally, we optimize the acquisition function using our model for a number of st
 ```python
 from trieste.bayesian_optimizer import BayesianOptimizer
 
-bo = BayesianOptimizer(observer, search_space)
+bo = BayesianOptimizer(observer, Branin.search_space)
 num_steps = 15
 result = bo.optimize(num_steps, initial_data, model)
 query_point, observation, arg_min_idx = result.try_get_optimal_point()

--- a/trieste/acquisition/__init__.py
+++ b/trieste/acquisition/__init__.py
@@ -95,6 +95,17 @@ from .interface import (
     UpdatablePenalizationFunction,
     VectorizedAcquisitionFunctionBuilder,
 )
+from .rule import (
+    TURBO,
+    AcquisitionRule,
+    AsynchronousGreedy,
+    AsynchronousOptimization,
+    BatchHypervolumeSharpeRatioIndicator,
+    DiscreteThompsonSampling,
+    EfficientGlobalOptimization,
+    RandomSampling,
+    TrustRegion,
+)
 from .sampler import (
     ExactThompsonSampler,
     GumbelSampler,

--- a/trieste/objectives/__init__.py
+++ b/trieste/objectives/__init__.py
@@ -44,3 +44,4 @@ from .single_objectives import (
     SingleObjectiveTestProblem,
     Trid10,
 )
+from .utils import mk_multi_observer, mk_observer


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

The code examples in README.md were failing due to imports.

I also investigated using [byexample](https://byexamples.github.io/byexample/languages/python) to automatically run code extracts in README.md but this is a pain due to how it expects both input and output. So instead suggest we rely on semantic versioning to not break these simple examples.

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [x] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
