### PR TITLE
Start adding some check_shape decorations

### DIFF
--- a/tests/unit/acquisition/function/test_function.py
+++ b/tests/unit/acquisition/function/test_function.py
@@ -22,6 +22,7 @@ import numpy.testing as npt
 import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
+from check_shapes.exceptions import ShapeMismatchError
 
 from tests.util.misc import (
     TF_DEBUGGING_ERROR_TYPES,
@@ -282,7 +283,7 @@ def test_expected_improvement_switches_to_improvement_on_feasible_points() -> No
 def test_expected_improvement_raises_for_invalid_batch_size(at: TensorType) -> None:
     ei = expected_improvement(QuadraticMeanAndRBFKernel(), tf.constant([1.0]))
 
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+    with pytest.raises(ShapeMismatchError):
         ei(at)
 
 
@@ -946,7 +947,7 @@ def test_expected_constrained_improvement_raises_for_invalid_batch_size(at: Tens
 
     eci = builder.prepare_acquisition_function({NA: QuadraticMeanAndRBFKernel()}, datasets=data)
 
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+    with pytest.raises(ShapeMismatchError):
         eci(at)
 
 

--- a/tests/unit/acquisition/function/test_function.py
+++ b/tests/unit/acquisition/function/test_function.py
@@ -22,7 +22,7 @@ import numpy.testing as npt
 import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
-from check_shapes.exceptions import ShapeMismatchError
+from tensorflow.python.autograph.impl.api import StagingError
 
 from tests.util.misc import (
     TF_DEBUGGING_ERROR_TYPES,
@@ -283,7 +283,7 @@ def test_expected_improvement_switches_to_improvement_on_feasible_points() -> No
 def test_expected_improvement_raises_for_invalid_batch_size(at: TensorType) -> None:
     ei = expected_improvement(QuadraticMeanAndRBFKernel(), tf.constant([1.0]))
 
-    with pytest.raises(ShapeMismatchError):
+    with pytest.raises(StagingError):
         ei(at)
 
 
@@ -947,7 +947,7 @@ def test_expected_constrained_improvement_raises_for_invalid_batch_size(at: Tens
 
     eci = builder.prepare_acquisition_function({NA: QuadraticMeanAndRBFKernel()}, datasets=data)
 
-    with pytest.raises(ShapeMismatchError):
+    with pytest.raises(StagingError):
         eci(at)
 
 

--- a/tests/unit/models/gpflow/test_sampler.py
+++ b/tests/unit/models/gpflow/test_sampler.py
@@ -22,6 +22,7 @@ import numpy.testing as npt
 import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
+from check_shapes.exceptions import ShapeMismatchError
 from scipy import stats
 
 from tests.util.misc import TF_DEBUGGING_ERROR_TYPES, ShapeLike, quadratic, random_seed
@@ -140,7 +141,7 @@ def test_independent_reparametrization_sampler_sample_raises_for_invalid_at_shap
 ) -> None:
     sampler = IndependentReparametrizationSampler(1, QuadraticMeanAndRBFKernel(), qmc=qmc)
 
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+    with pytest.raises(ShapeMismatchError):
         sampler.sample(tf.zeros(shape))
 
 

--- a/tests/unit/models/gpflux/test_interface.py
+++ b/tests/unit/models/gpflux/test_interface.py
@@ -18,6 +18,7 @@ import gpflow
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
+from check_shapes import inherit_check_shapes
 from gpflow.conditionals.util import sample_mvn
 from gpflux.helpers import construct_basic_inducing_variables, construct_basic_kernel
 from gpflux.layers import GPLayer
@@ -57,6 +58,7 @@ class _QuadraticPredictor(GPfluxPredictor):
     def optimizer(self) -> tf.keras.optimizers.Optimizer:
         return self._optimizer
 
+    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         # Taken from GPflow implementation of `GPModel.predict_f_samples` in gpflow.models.model
         mean, cov = self._model_gpflux.predict_f(query_points, full_cov=True)

--- a/tests/unit/objectives/test_multi_objectives.py
+++ b/tests/unit/objectives/test_multi_objectives.py
@@ -16,8 +16,8 @@ from typing import Callable
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
+from check_shapes.exceptions import ShapeMismatchError
 
-from tests.util.misc import TF_DEBUGGING_ERROR_TYPES
 from trieste.objectives.multi_objectives import DTLZ1, DTLZ2, VLMOP2, MultiObjectiveTestProblem
 from trieste.types import TensorType
 
@@ -142,7 +142,7 @@ def test_gen_pareto_front_is_equal_to_math_defined(
 def test_func_raises_specified_input_dim_not_align_with_actual_input_dim(
     obj_inst: MultiObjectiveTestProblem, actual_x: TensorType
 ) -> None:
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
+    with pytest.raises(ShapeMismatchError):
         obj_inst.objective(actual_x)
 
 

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -21,6 +21,7 @@ from typing import NoReturn, Optional
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
+from check_shapes import inherit_check_shapes
 
 from tests.util.misc import (
     FixedAcquisitionRule,
@@ -596,6 +597,7 @@ class _DecreasingVarianceModel(QuadraticMeanAndRBFKernel, TrainableProbabilistic
         super().__init__()
         self._data = data
 
+    @inherit_check_shapes
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         mean, var = super().predict(query_points)
         return mean, var / len(self._data)

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -102,6 +102,7 @@ class GaussianProcess(
         mean, cov = self.predict_joint(query_points[..., None, :])
         return tf.squeeze(mean, -2), tf.squeeze(cov, [-2, -1])
 
+    @inherit_check_shapes
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         means = [f(query_points) for f in self._mean_functions]
         covs = [k.tensor(query_points, query_points, 1, 1)[..., None, :, :] for k in self._kernels]
@@ -139,6 +140,7 @@ class GaussianProcessWithoutNoise(GaussianMarginal, HasReparamSampler):
         mean, cov = self.predict_joint(query_points[..., None, :])
         return tf.squeeze(mean, -2), tf.squeeze(cov, [-2, -1])
 
+    @inherit_check_shapes
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         means = [f(query_points) for f in self._mean_functions]
         covs = [k.tensor(query_points, query_points, 1, 1)[..., None, :, :] for k in self._kernels]

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -46,6 +46,7 @@ from trieste.models.interfaces import (
     SupportsCovarianceWithTopFidelity,
     SupportsGetKernel,
     SupportsGetObservationNoise,
+    SupportsPredictJoint,
 )
 from trieste.models.optimizer import Optimizer
 from trieste.types import TensorType
@@ -120,7 +121,7 @@ class GaussianProcess(
         return tf.concat(covs, axis=-3)
 
 
-class GaussianProcessWithoutNoise(GaussianMarginal, HasReparamSampler):
+class GaussianProcessWithoutNoise(GaussianMarginal, SupportsPredictJoint, HasReparamSampler):
     """A (static) Gaussian process over a vector random variable with independent reparam sampler
     but without noise variance."""
 

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -212,11 +212,11 @@ class expected_improvement(AcquisitionFunctionClass):
         """Update the acquisition function with a new eta value."""
         self._eta.assign(eta)
 
+    @tf.function
     @check_shapes(
         "x: [N..., 1, D] # This acquisition function only supports batch sizes of one",
         "return: [N..., L]",
     )
-    @tf.function
     def __call__(self, x: TensorType) -> TensorType:
         mean, variance = self._model.predict(tf.squeeze(x, -2))
         normal = tfp.distributions.Normal(mean, tf.sqrt(variance))

--- a/trieste/acquisition/function/function.py
+++ b/trieste/acquisition/function/function.py
@@ -21,6 +21,7 @@ from typing import Callable, Mapping, Optional, cast
 
 import tensorflow as tf
 import tensorflow_probability as tfp
+from check_shapes import check_shapes
 
 from ...data import Dataset
 from ...models import ProbabilisticModel, ReparametrizationSampler
@@ -211,12 +212,12 @@ class expected_improvement(AcquisitionFunctionClass):
         """Update the acquisition function with a new eta value."""
         self._eta.assign(eta)
 
+    @check_shapes(
+        "x: [N..., 1, D] # This acquisition function only supports batch sizes of one",
+        "return: [N..., L]",
+    )
     @tf.function
     def __call__(self, x: TensorType) -> TensorType:
-        tf.debugging.assert_shapes(
-            [(x, [..., 1, None])],
-            message="This acquisition function only supports batch sizes of one.",
-        )
         mean, variance = self._model.predict(tf.squeeze(x, -2))
         normal = tfp.distributions.Normal(mean, tf.sqrt(variance))
         return (self._eta - mean) * normal.cdf(self._eta) + variance * normal.prob(self._eta)

--- a/trieste/acquisition/function/greedy_batch.py
+++ b/trieste/acquisition/function/greedy_batch.py
@@ -673,6 +673,7 @@ class _fantasized_model(SupportsPredictJoint, SupportsGetKernel, SupportsGetObse
 
         return _broadcast_predict(query_points, fun)
 
+    @inherit_check_shapes
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
         This function wraps conditional_predict_joint. It cannot directly call

--- a/trieste/acquisition/function/greedy_batch.py
+++ b/trieste/acquisition/function/greedy_batch.py
@@ -21,7 +21,7 @@ from typing import Callable, Dict, Mapping, Optional, Union, cast
 import gpflow
 import tensorflow as tf
 import tensorflow_probability as tfp
-from check_shapes import inherit_check_shapes, check_shapes
+from check_shapes import check_shapes
 from typing_extensions import Protocol, runtime_checkable
 
 from ...data import Dataset

--- a/trieste/acquisition/function/greedy_batch.py
+++ b/trieste/acquisition/function/greedy_batch.py
@@ -21,6 +21,7 @@ from typing import Callable, Dict, Mapping, Optional, Union, cast
 import gpflow
 import tensorflow as tf
 import tensorflow_probability as tfp
+from check_shapes import inherit_check_shapes
 from typing_extensions import Protocol, runtime_checkable
 
 from ...data import Dataset
@@ -652,6 +653,7 @@ class _fantasized_model(SupportsPredictJoint, SupportsGetKernel, SupportsGetObse
         self._fantasized_query_points.assign(fantasized_data.query_points)
         self._fantasized_observations.assign(fantasized_data.observations)
 
+    @inherit_check_shapes
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
         This function wraps conditional_predict_f. It cannot directly call
@@ -690,6 +692,7 @@ class _fantasized_model(SupportsPredictJoint, SupportsGetKernel, SupportsGetObse
 
         return _broadcast_predict(query_points, fun)
 
+    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         """
         This function wraps conditional_predict_f_sample. It cannot directly call
@@ -716,6 +719,7 @@ class _fantasized_model(SupportsPredictJoint, SupportsGetKernel, SupportsGetObse
         )  # [B, ..., S, L]
         return _restore_leading_dim(samples, leading_dim)
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
         This function wraps conditional_predict_y. It cannot directly call

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -19,6 +19,7 @@ from typing import Any, Optional
 
 import gpflow
 import tensorflow as tf
+from check_shapes import inherit_check_shapes
 from gpflow.models import GPModel
 from gpflow.posteriors import BasePosterior, PrecomputeCacheType
 from typing_extensions import Protocol
@@ -93,6 +94,7 @@ class GPflowPredictor(
     def model(self) -> GPModel:
         """The underlying GPflow model."""
 
+    @inherit_check_shapes
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         mean, cov = (self._posterior or self.model).predict_f(query_points)
         # posterior predict can return negative variance values [cf GPFlow issue #1813]
@@ -109,9 +111,11 @@ class GPflowPredictor(
             )
         return mean, cov
 
+    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         return self.model.predict_f_samples(query_points, num_samples)
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         return self.model.predict_y(query_points)
 

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -102,6 +102,7 @@ class GPflowPredictor(
             cov = tf.clip_by_value(cov, 1e-12, cov.dtype.max)
         return mean, cov
 
+    @inherit_check_shapes
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         mean, cov = (self._posterior or self.model).predict_f(query_points, full_cov=True)
         # posterior predict can return negative variance values [cf GPFlow issue #1813]

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -19,6 +19,7 @@ from typing import Optional, Sequence, Tuple, Union, cast
 import gpflow
 import tensorflow as tf
 import tensorflow_probability as tfp
+from check_shapes import inherit_check_shapes
 from gpflow.conditionals.util import sample_mvn
 from gpflow.inducing_variables import (
     SeparateIndependentInducingVariables,
@@ -158,6 +159,7 @@ class GaussianProcessRegression(
             ),
         )
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         f_mean, f_var = self.predict(query_points)
         return self.model.likelihood.predict_mean_and_var(query_points, f_mean, f_var)
@@ -607,6 +609,7 @@ class SparseGaussianProcessRegression(
     ) -> Optional[InducingPointSelector[SparseGaussianProcessRegression]]:
         return self._inducing_point_selector
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         f_mean, f_var = self.predict(query_points)
         return self.model.likelihood.predict_mean_and_var(query_points, f_mean, f_var)
@@ -929,6 +932,7 @@ class SparseVariational(
     def inducing_point_selector(self) -> Optional[InducingPointSelector[SparseVariational]]:
         return self._inducing_point_selector
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         f_mean, f_var = self.predict(query_points)
         return self.model.likelihood.predict_mean_and_var(query_points, f_mean, f_var)
@@ -1241,6 +1245,7 @@ class VariationalGaussianProcess(
     def model(self) -> VGP:
         return self._model
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         f_mean, f_var = self.predict(query_points)
         return self.model.likelihood.predict_mean_and_var(query_points, f_mean, f_var)
@@ -1409,6 +1414,7 @@ class MultifidelityAutoregressive(TrainableProbabilisticModel, SupportsCovarianc
     def num_fidelities(self) -> int:
         return self._num_fidelities
 
+    @inherit_check_shapes
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
         Predict the marginal mean and variance at query_points.
@@ -1489,6 +1495,7 @@ class MultifidelityAutoregressive(TrainableProbabilisticModel, SupportsCovarianc
         )
         return residuals
 
+    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         """
         Sample `num_samples` samples from the posterior distribution at `query_points`
@@ -1525,6 +1532,7 @@ class MultifidelityAutoregressive(TrainableProbabilisticModel, SupportsCovarianc
 
         return signal_sample
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
         Predict the marginal mean and variance at `query_points` including observation noise
@@ -1691,6 +1699,7 @@ class MultifidelityNonlinearAutoregressive(
     def num_fidelities(self) -> int:
         return self._num_fidelities
 
+    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         """
         Return ``num_samples`` samples from the independent marginal distributions at
@@ -1734,6 +1743,7 @@ class MultifidelityNonlinearAutoregressive(
 
         return signal_sample
 
+    @inherit_check_shapes
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
         Predict the marginal mean and variance at query_points.
@@ -1754,6 +1764,7 @@ class MultifidelityNonlinearAutoregressive(
         mean = tf.reduce_mean(sample_mean, axis=-1)
         return mean, variance
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
         Predict the marginal mean and variance at `query_points` including observation noise

--- a/trieste/models/gpflux/interface.py
+++ b/trieste/models/gpflux/interface.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 import tensorflow as tf
+from check_shapes import inherit_check_shapes
 from gpflow.base import Module
 
 from ...types import TensorType
@@ -58,6 +59,7 @@ class GPfluxPredictor(SupportsGetObservationNoise, ABC):
         """The optimizer wrapper for training the model."""
         return self._optimizer
 
+    @inherit_check_shapes
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """Note: unless otherwise noted, this returns the mean and variance of the last layer
         conditioned on one sample from the previous layers."""
@@ -67,6 +69,7 @@ class GPfluxPredictor(SupportsGetObservationNoise, ABC):
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         raise NotImplementedError
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """Note: unless otherwise noted, this will return the prediction conditioned on one sample
         from the lower layers."""

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Optional
 import dill
 import gpflow
 import tensorflow as tf
+from check_shapes import inherit_check_shapes
 from gpflow.inducing_variables import InducingPoints
 from gpflux.layers import GPLayer, LatentVariableLayer
 from gpflux.models import DeepGP
@@ -277,6 +278,7 @@ class DeepGaussianProcess(
     def model_keras(self) -> tf.keras.Model:
         return self._model_keras
 
+    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         trajectory = self.trajectory_sampler().get_trajectory()
         expanded_query_points = tf.expand_dims(query_points, -2)  # [N, 1, D]

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -157,6 +157,11 @@ class SupportsPredictJoint(ProbabilisticModel, Protocol):
     """A probabilistic model that supports predict_joint."""
 
     @abstractmethod
+    @check_shapes(
+        "query_points: [batch..., B, D]",
+        "return[0]: [batch..., B, E...]",
+        "return[1]: [batch..., E..., B, B]",
+    )
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
         :param query_points: The points at which to make predictions, of shape [..., B, D].
@@ -503,6 +508,7 @@ class PredictJointModelStack(ModelStack[SupportsPredictJoint], SupportsPredictJo
     It delegates :meth:`predict_joint` to each model.
     """
 
+    @inherit_check_shapes
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         r"""
         :param query_points: The points at which to make predictions, of shape [..., B, D].

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -48,9 +48,9 @@ class ProbabilisticModel(Protocol):
 
     @abstractmethod
     @check_shapes(
-        "query_points: [batch..., N, D]",
-        "return[0]: [batch..., N, E]",
-        "return[1]: [batch..., N, E]",
+        "query_points: [batch..., D]",
+        "return[0]: [batch..., E]",
+        "return[1]: [batch..., E]",
     )
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
@@ -84,8 +84,8 @@ class ProbabilisticModel(Protocol):
         raise NotImplementedError
 
     @check_shapes(
-        "query_points: [batch..., N, D]",
-        "return: [batch..., S, N, E]",
+        "query_points: [broadcast batch..., D]",
+        "return: [batch..., E]",
     )
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Generic, Optional, TypeVar
 
 import gpflow
 import tensorflow as tf
-from check_shapes import check_shapes, inherit_check_shapes
+from check_shapes import check_shapes
 from typing_extensions import Protocol, runtime_checkable
 
 from ..data import Dataset

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -378,7 +378,9 @@ class ModelStack(ProbabilisticModel, Generic[ProbabilisticModelType]):
         """
         self._models, self._event_sizes = zip(*(model_with_event_size,) + models_with_event_sizes)
 
-    @inherit_check_shapes
+    # NB we don't use @inherit_shapes below as some classes break the shape API (👀 fantasizer)
+    # instead we rely on the shape checking inside the submodels
+
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         r"""
         :param query_points: The points at which to make predictions, of shape [..., D].
@@ -390,7 +392,6 @@ class ModelStack(ProbabilisticModel, Generic[ProbabilisticModelType]):
         means, vars_ = zip(*[model.predict(query_points) for model in self._models])
         return tf.concat(means, axis=-1), tf.concat(vars_, axis=-1)
 
-    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         r"""
         :param query_points: The points at which to sample, with shape [..., N, D].
@@ -402,7 +403,6 @@ class ModelStack(ProbabilisticModel, Generic[ProbabilisticModelType]):
         samples = [model.sample(query_points, num_samples) for model in self._models]
         return tf.concat(samples, axis=-1)
 
-    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         r"""
         :param query_points: The points at which to make predictions, of shape [..., D].
@@ -508,7 +508,6 @@ class PredictJointModelStack(ModelStack[SupportsPredictJoint], SupportsPredictJo
     It delegates :meth:`predict_joint` to each model.
     """
 
-    @inherit_check_shapes
     def predict_joint(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         r"""
         :param query_points: The points at which to make predictions, of shape [..., B, D].

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -87,7 +87,8 @@ class ProbabilisticModel(Protocol):
 
     @check_shapes(
         "query_points: [broadcast batch..., D]",
-        "return: [batch..., E...]",
+        "return[0]: [batch..., E...]",
+        "return[1]: [batch..., E...]",
     )
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -49,8 +49,8 @@ class ProbabilisticModel(Protocol):
     @abstractmethod
     @check_shapes(
         "query_points: [batch..., D]",
-        "return[0]: [batch..., E]",
-        "return[1]: [batch..., E]",
+        "return[0]: [batch..., E...]",
+        "return[1]: [batch..., E...]",
     )
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
@@ -61,31 +61,33 @@ class ProbabilisticModel(Protocol):
         dimensions of ``query_points`` are all interpreted as broadcasting dimensions instead of
         batch dimensions, and the covariance is squeezed to remove redundant nesting.
 
-        :param query_points: The points at which to make predictions.
+        :param query_points: The points at which to make predictions, of shape [..., D].
         :return: The mean and variance of the independent marginal distributions at each point in
-            ``query_points``.
+            ``query_points``. For a predictive distribution with event shape E, the mean and
+            variance will both have shape [...] + E.
         """
         raise NotImplementedError
 
     @abstractmethod
     @check_shapes(
         "query_points: [batch..., N, D]",
-        "return: [batch..., S, N, E]",
+        "return: [batch..., S, N, E...]",
     )
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         """
         Return ``num_samples`` samples from the independent marginal distributions at
         ``query_points``.
 
-        :param query_points: The points at which to sample.
+        :param query_points: The points at which to sample, with shape [..., N, D].
         :param num_samples: The number of samples at each point.
-        :return: The samples, where *S* is the number of samples.
+        :return: The samples. For a predictive distribution with event shape E, this has shape
+            [..., S, N] + E, where S is the number of samples.
         """
         raise NotImplementedError
 
     @check_shapes(
         "query_points: [broadcast batch..., D]",
-        "return: [batch..., E]",
+        "return: [batch..., E...]",
     )
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         """
@@ -94,9 +96,10 @@ class ProbabilisticModel(Protocol):
 
         Note that this is not supported by all models.
 
-        :param query_points: The points at which to make predictions.
+        :param query_points: The points at which to make predictions, of shape [..., D].
         :return: The mean and variance of the independent marginal distributions at each point in
-            ``query_points``.
+            ``query_points``. For a predictive distribution with event shape E, the mean and
+            variance will both have shape [...] + E.
         """
         pass  # (required so that mypy doesn't think this method is abstract)
         raise NotImplementedError(

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Generic, Optional, TypeVar
 
 import gpflow
 import tensorflow as tf
-from check_shapes import check_shapes
+from check_shapes import check_shapes, inherit_check_shapes
 from typing_extensions import Protocol, runtime_checkable
 
 from ..data import Dataset
@@ -373,6 +373,7 @@ class ModelStack(ProbabilisticModel, Generic[ProbabilisticModelType]):
         """
         self._models, self._event_sizes = zip(*(model_with_event_size,) + models_with_event_sizes)
 
+    @inherit_check_shapes
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         r"""
         :param query_points: The points at which to make predictions, of shape [..., D].
@@ -384,6 +385,7 @@ class ModelStack(ProbabilisticModel, Generic[ProbabilisticModelType]):
         means, vars_ = zip(*[model.predict(query_points) for model in self._models])
         return tf.concat(means, axis=-1), tf.concat(vars_, axis=-1)
 
+    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         r"""
         :param query_points: The points at which to sample, with shape [..., N, D].
@@ -395,6 +397,7 @@ class ModelStack(ProbabilisticModel, Generic[ProbabilisticModelType]):
         samples = [model.sample(query_points, num_samples) for model in self._models]
         return tf.concat(samples, axis=-1)
 
+    @inherit_check_shapes
     def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         r"""
         :param query_points: The points at which to make predictions, of shape [..., D].

--- a/trieste/models/keras/interface.py
+++ b/trieste/models/keras/interface.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 import tensorflow as tf
 import tensorflow_probability as tfp
+from check_shapes import inherit_check_shapes
 from typing_extensions import Protocol, runtime_checkable
 
 from ...types import TensorType
@@ -60,9 +61,11 @@ class KerasPredictor(ProbabilisticModel, ABC):
         """The optimizer wrapper for training the model."""
         return self._optimizer
 
+    @inherit_check_shapes
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         return self.model.predict(query_points)
 
+    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         raise NotImplementedError(
             """

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -21,6 +21,7 @@ import dill
 import tensorflow as tf
 import tensorflow_probability as tfp
 import tensorflow_probability.python.distributions as tfd
+from check_shapes import inherit_check_shapes
 from tensorflow.python.keras.callbacks import Callback
 
 from ... import logging
@@ -227,6 +228,7 @@ class DeepEnsemble(
         x_transformed: dict[str, TensorType] = self.prepare_query_points(query_points)
         return self._model.model(x_transformed)
 
+    @inherit_check_shapes
     def predict(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
         r"""
         Returns mean and variance at ``query_points`` for the whole ensemble.
@@ -291,6 +293,7 @@ class DeepEnsemble(
 
         return predicted_means, predicted_vars
 
+    @inherit_check_shapes
     def sample(self, query_points: TensorType, num_samples: int) -> TensorType:
         """
         Return ``num_samples`` samples at ``query_points``. We use the mixture approximation in


### PR DESCRIPTION
**Related issue(s)/PRs:** #130

## Summary

Start adding `check_shape` decorations. This has lots of pros over our existing ad hoc use of `tf.debugging.assert_shapes`:

1. better checking  (e.g. can check batch dimensions, input broadcasting, return types, object attributes and more)
2. more consistent checking (e.g. can inherit checks from abstract methods)
3. clearer code documentation (potentially including docstring rewriting, but see below)
4. clearer error messages, e.g.:

```
E             ShapeMismatchError: 
E             Tensor shape mismatch.
E               Function: expected_improvement.__call__
E                 Declared: /home/uri.granta/code/trieste/trieste/acquisition/function/function.py:215
E                 Argument: x
E                   Note:     This acquisition function only supports batch sizes of one
E                   Expected: [N..., 1, D]
E                   Actual:   [1, 2, 1]
```

However, note that:

* sphinx-autoapi (which we use for our docs, probably because it's simple and quick) doesn't support docstring rewriting, which means that the argument shapes won't automatically appear in the online docs (though they will appear in interactive docstrings)
* by default shape checking is disabled for anything wrapped in a tf.function (though we explicitly enable this in the unit tests) so performance impact should be limited; see below for further discussion (including impact on test runtime)

**Fully backwards compatible:** yes

## Performance impact

Looking at integration test runtimes, the additional shape checks added here don't (currently) seem to have a significant perf impact by themselves. However:

* calling `set_enable_check_shapes(ShapeCheckingState.ENABLED)` for all the tests does slow things down somewhat, though this is primarily due to additional the gpflow shape checks which are now enabled rather than the new checks added in this PR. For example, for `test_bayesian_optimizer_with_gpr_finds_minima_of_scaled_branin`
  * `EfficientGlobalOptimization` goes from 20s to 40s
  * `AugmentedExpectedImprovement` goes from 30s to 50s (even though we didn't add any more checks for that function)
  * `Fantasizer` goes from 60s to 80s.
* conversely, explicitly disabling shape checking sometimes speeds things up over before, as it removes all gpflow checks; this doesn't affect  `EfficientGlobalOptimization` or `AugmentedExpectedImprovement`, but for `Fantasizer` it speeds it up from 60s to 30s! we should definitely document and advertise this (though it's more likely to affect research than production, as the latter is more likely to be compiling everything).

Overall, the test runtime for the unit tests doesn't seem to be impacted, but the (non-slow) integration test runtime increases from around 31 minutes to 38 minutes. If this becomes an issue we can easily split the integration tests into two parallel jobs.

## PR checklist
<!-- tick off [X] as applicable -->
- [x] The quality checks are all passing
- [x] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
