### PR TITLE
Expose optimize results for trainable models

### DIFF
--- a/tests/unit/models/gpflow/test_interface.py
+++ b/tests/unit/models/gpflow/test_interface.py
@@ -31,6 +31,9 @@ class _QuadraticPredictor(GPflowPredictor):
     def model(self) -> GPModel:
         return _QuadraticGPModel()
 
+    def optimize(self, dataset: Dataset) -> None:
+        self.optimizer.optimize(self.model, dataset)
+
     def update(self, dataset: Dataset) -> None:
         return
 

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -155,8 +155,8 @@ def test_gpflow_wrappers_default_optimize(
     new_loss = internal_model.training_loss(**args)
     assert new_loss < loss
     if not isinstance(internal_model, SVGP):
-        assert model.last_result is not None
-        npt.assert_allclose(new_loss, model.last_result.fun)
+        assert model.last_optimization_result is not None
+        npt.assert_allclose(new_loss, model.last_optimization_result.fun)
 
 
 def test_gpflow_wrappers_ref_optimize(gpflow_interface_factory: ModelFactoryType) -> None:

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -150,9 +150,13 @@ def test_gpflow_wrappers_default_optimize(
         args = {}
 
     loss = internal_model.training_loss(**args)
-    model.optimize(Dataset(*data))
+    model.optimize_and_save_result(Dataset(*data))
 
-    assert internal_model.training_loss(**args) < loss
+    new_loss = internal_model.training_loss(**args)
+    assert new_loss < loss
+    if not isinstance(internal_model, SVGP):
+        assert model.last_result is not None
+        npt.assert_allclose(new_loss, model.last_result.fun)
 
 
 def test_gpflow_wrappers_ref_optimize(gpflow_interface_factory: ModelFactoryType) -> None:

--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -297,9 +297,10 @@ def test_deep_gaussian_process_with_lr_scheduler(
     optimizer = KerasOptimizer(tf.optimizers.Adam(lr_schedule), fit_args)
     model = DeepGaussianProcess(two_layer_model(x), optimizer)
 
-    model.optimize(Dataset(x, y))
+    model.optimize_and_save_result(Dataset(x, y))
 
-    assert len(model.model_keras.history.history["loss"]) == epochs
+    assert model.last_result is not None
+    assert len(model.last_result.history["loss"]) == epochs
 
 
 def test_deep_gaussian_process_default_optimizer_is_correct(

--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -299,8 +299,8 @@ def test_deep_gaussian_process_with_lr_scheduler(
 
     model.optimize_and_save_result(Dataset(x, y))
 
-    assert model.last_result is not None
-    assert len(model.last_result.history["loss"]) == epochs
+    assert model.last_optimization_result is not None
+    assert len(model.last_optimization_result.history["loss"]) == epochs
 
 
 def test_deep_gaussian_process_default_optimizer_is_correct(

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -215,9 +215,10 @@ def test_deep_ensemble_resets_lr_with_lr_schedule() -> None:
 
     npt.assert_allclose(model.model.optimizer.lr.numpy(), init_lr, rtol=1e-6)
 
-    model.optimize(example_data)
+    model.optimize_and_save_result(example_data)
 
-    npt.assert_allclose(model.model.history.history["lr"], [0.5, 0.25])
+    assert model.last_result is not None
+    npt.assert_allclose(model.last_result.history["lr"], [0.5, 0.25])
     npt.assert_allclose(model.model.optimizer.lr.numpy(), init_lr, rtol=1e-6)
 
 

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -217,8 +217,8 @@ def test_deep_ensemble_resets_lr_with_lr_schedule() -> None:
 
     model.optimize_and_save_result(example_data)
 
-    assert model.last_result is not None
-    npt.assert_allclose(model.last_result.history["lr"], [0.5, 0.25])
+    assert model.last_optimization_result is not None
+    npt.assert_allclose(model.last_optimization_result.history["lr"], [0.5, 0.25])
     npt.assert_allclose(model.model.optimizer.lr.numpy(), init_lr, rtol=1e-6)
 
 

--- a/tests/unit/models/keras/test_sampler.py
+++ b/tests/unit/models/keras/test_sampler.py
@@ -407,7 +407,7 @@ def test_ensemble_trajectory_sampler_trajectory_on_subsets_same_as_set(diversify
     eval_2 = trajectory(test_data[100:200, :])
     eval_3 = trajectory(test_data[200:300, :])
 
-    npt.assert_allclose(eval_all, tf.concat([eval_1, eval_2, eval_3], axis=0), rtol=5e-6)
+    npt.assert_allclose(eval_all, tf.concat([eval_1, eval_2, eval_3], axis=0), rtol=1e-5)
 
 
 @random_seed

--- a/tests/unit/models/test_interfaces.py
+++ b/tests/unit/models/test_interfaces.py
@@ -193,7 +193,8 @@ def test_model_stack_training() -> None:
     stack = TrainableModelStack((model01, 2), (model2, 1), (model3, 1))
     data = Dataset(tf.random.uniform([5, 7, 3]), tf.random.uniform([5, 7, 4]))
     stack.update(data)
-    stack.optimize(data)
+    stack.optimize_and_save_result(data)
+    assert stack.last_result == [None] * 3
 
 
 def test_model_stack_reparam_sampler_raises_for_submodels_without_reparam_sampler() -> None:

--- a/tests/unit/models/test_interfaces.py
+++ b/tests/unit/models/test_interfaces.py
@@ -194,7 +194,7 @@ def test_model_stack_training() -> None:
     data = Dataset(tf.random.uniform([5, 7, 3]), tf.random.uniform([5, 7, 4]))
     stack.update(data)
     stack.optimize_and_save_result(data)
-    assert stack.last_result == [None] * 3
+    assert stack.last_optimization_result == [None] * 3
 
 
 def test_model_stack_reparam_sampler_raises_for_submodels_without_reparam_sampler() -> None:

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -204,7 +204,7 @@ def mock_data() -> tuple[tf.Tensor, tf.Tensor]:
 
 
 class QuadraticMeanAndRBFKernelWithSamplers(
-    QuadraticMeanAndRBFKernel, HasTrajectorySampler, HasReparamSampler
+    QuadraticMeanAndRBFKernel, HasTrajectorySampler, HasReparamSampler, TrainableProbabilisticModel
 ):
     r"""
     A Gaussian process with scalar quadratic mean, an RBF kernel and

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -233,7 +233,7 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
                 for tag, model in self._models.items():
                     dataset = datasets[tag]
                     model.update(dataset)
-                    model.optimize(dataset)
+                    model.optimize_and_save_result(dataset)
 
             summary_writer = logging.get_tensorboard_writer()
             if summary_writer:
@@ -434,7 +434,7 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
             for tag, model in self._models.items():
                 dataset = self._datasets[tag]
                 model.update(dataset)
-                model.optimize(dataset)
+                model.optimize_and_save_result(dataset)
 
         summary_writer = logging.get_tensorboard_writer()
         if summary_writer:

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -719,7 +719,7 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                         for tag, model in models.items():
                             dataset = datasets[tag]
                             model.update(dataset)
-                            model.optimize(dataset)
+                            model.optimize_and_save_result(dataset)
                     if summary_writer:
                         logging.set_step_number(0)
                         with summary_writer.as_default(step=0):
@@ -752,7 +752,7 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                             for tag, model in models.items():
                                 dataset = datasets[tag]
                                 model.update(dataset)
-                                model.optimize(dataset)
+                                model.optimize_and_save_result(dataset)
 
                 if summary_writer:
                     with summary_writer.as_default(step=step):

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -151,14 +151,6 @@ class GPflowPredictor(
 
         return noise_variance
 
-    # def optimize(self, dataset: Dataset) -> None:
-    #     """
-    #     Optimize the model with the specified `dataset`.
-    #
-    #     :param dataset: The data with which to optimize the `model`.
-    #     """
-    #     self.optimizer.optimize(self.model, dataset)
-
     def log(self, dataset: Optional[Dataset] = None) -> None:
         """
         Log model training information at a given optimization step to the Tensorboard.

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -32,6 +32,7 @@ from ..interfaces import (
     SupportsGetKernel,
     SupportsGetObservationNoise,
     SupportsPredictJoint,
+    TrainableProbabilisticModel,
 )
 from ..optimizer import Optimizer
 from ..utils import (
@@ -43,7 +44,12 @@ from .sampler import BatchReparametrizationSampler
 
 
 class GPflowPredictor(
-    SupportsPredictJoint, SupportsGetKernel, SupportsGetObservationNoise, HasReparamSampler, ABC
+    SupportsPredictJoint,
+    SupportsGetKernel,
+    SupportsGetObservationNoise,
+    HasReparamSampler,
+    TrainableProbabilisticModel,
+    ABC,
 ):
     """A trainable wrapper for a GPflow Gaussian process model."""
 
@@ -145,13 +151,13 @@ class GPflowPredictor(
 
         return noise_variance
 
-    def optimize(self, dataset: Dataset) -> None:
-        """
-        Optimize the model with the specified `dataset`.
-
-        :param dataset: The data with which to optimize the `model`.
-        """
-        self.optimizer.optimize(self.model, dataset)
+    # def optimize(self, dataset: Dataset) -> None:
+    #     """
+    #     Optimize the model with the specified `dataset`.
+    #
+    #     :param dataset: The data with which to optimize the `model`.
+    #     """
+    #     self.optimizer.optimize(self.model, dataset)
 
     def log(self, dataset: Optional[Dataset] = None) -> None:
         """

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -212,6 +212,10 @@ class DeepGaussianProcess(
             finally:
                 self._model_keras.history.model = history_model
 
+        # don't try to serialize any other copies of the history callback
+        if isinstance(state.get("_last_optimization_result"), keras.callbacks.History):
+            state["_last_optimization_result"] = ...
+
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -265,6 +269,8 @@ class DeepGaussianProcess(
                 model = tf.keras.models.model_from_json(model_json)
                 model.set_weights(weights)
                 self._model_keras.history.set_model(model)
+            if state.get("_last_optimization_result") is ...:
+                self._last_optimization_result = self._model_keras.history
 
     def __repr__(self) -> str:
         """"""

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Optional
 
 import dill
 import gpflow
+import keras.callbacks
 import tensorflow as tf
 from gpflow.inducing_variables import InducingPoints
 from gpflux.layers import GPLayer, LatentVariableLayer
@@ -338,7 +339,7 @@ class DeepGaussianProcess(
 
             inputs = layer(inputs)
 
-    def optimize(self, dataset: Dataset) -> None:
+    def optimize(self, dataset: Dataset) -> keras.callbacks.History:
         """
         Optimize the model with the specified `dataset`.
         :param dataset: The data with which to optimize the `model`.
@@ -369,6 +370,8 @@ class DeepGaussianProcess(
             self.optimizer.optimizer.lr, tf.keras.optimizers.schedules.LearningRateSchedule
         ):
             self.optimizer.optimizer.lr.assign(self.original_lr)
+
+        return hist
 
     def log(self, dataset: Optional[Dataset] = None) -> None:
         """

--- a/trieste/models/gpflux/models.py
+++ b/trieste/models/gpflux/models.py
@@ -269,8 +269,10 @@ class DeepGaussianProcess(
                 model = tf.keras.models.model_from_json(model_json)
                 model.set_weights(weights)
                 self._model_keras.history.set_model(model)
-            if state.get("_last_optimization_result") is ...:
-                self._last_optimization_result = self._model_keras.history
+
+        # recover optimization result if necessary (and possible)
+        if state.get("_last_optimization_result") is ...:
+            self._last_optimization_result = getattr(self._model_keras, "history")
 
     def __repr__(self) -> str:
         """"""

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -140,12 +140,12 @@ class TrainableProbabilisticModel(ProbabilisticModel, Protocol):
 
     def optimize_and_save_result(self, dataset: Dataset) -> None:
         """
-        Optimize the model objective and save the optimization result in last_result.
+        Optimize the model objective and save the optimization result in last_optimization_result.
         """
         setattr(self, "_last_optimization_result", self.optimize(dataset))
 
     @property
-    def last_result(self) -> Optional[Any]:
+    def last_optimization_result(self) -> Optional[Any]:
         """
         The last saved (optimizer-specific) optimization result.
         """

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -155,7 +155,10 @@ class TrainableProbabilisticModel(ProbabilisticModel, Protocol):
 
     def optimize_and_save_result(self, dataset: Dataset) -> None:
         """
-        Optimize the model objective and save the optimization result in last_optimization_result.
+        Optimize the model objective and save the optimization result in
+        ``last_optimization_result``.
+
+        :param dataset: The data with which to train the model.
         """
         setattr(self, "_last_optimization_result", self.optimize(dataset))
 

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -22,7 +22,6 @@ from abc import abstractmethod
 from typing import Any, Callable, Sequence
 
 import dill
-import keras.callbacks
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -128,10 +127,6 @@ class KerasEnsemble:
             finally:
                 self._model.history.model = history_model
 
-        # Don't try to serialize any other copies of the history callback
-        if isinstance(state.get("_last_optimization_result"), keras.callbacks.History):
-            state["_last_optimization_result"] = ...
-
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -155,8 +150,6 @@ class KerasEnsemble:
                 )
                 model.set_weights(weights)
                 self._model.history.set_model(model)
-            if state.get("_last_optimization_result") is ...:
-                self._last_optimization_result = self._model.history
 
 
 class KerasEnsembleNetwork:

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -22,6 +22,7 @@ from abc import abstractmethod
 from typing import Any, Callable, Sequence
 
 import dill
+import keras.callbacks
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -127,6 +128,10 @@ class KerasEnsemble:
             finally:
                 self._model.history.model = history_model
 
+        # Don't try to serialize any other copies of the history callback
+        if isinstance(state.get("_last_optimization_result"), keras.callbacks.History):
+            state["_last_optimization_result"] = ...
+
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -150,6 +155,8 @@ class KerasEnsemble:
                 )
                 model.set_weights(weights)
                 self._model.history.set_model(model)
+            if state.get("_last_optimization_result") is ...:
+                self._last_optimization_result = self._model.history
 
 
 class KerasEnsembleNetwork:

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -18,6 +18,7 @@ import re
 from typing import Any, Dict, Optional
 
 import dill
+import keras.callbacks
 import tensorflow as tf
 import tensorflow_probability as tfp
 import tensorflow_probability.python.distributions as tfd
@@ -349,7 +350,7 @@ class DeepEnsemble(
         """
         return
 
-    def optimize(self, dataset: Dataset) -> None:
+    def optimize(self, dataset: Dataset) -> keras.callbacks.History:
         """
         Optimize the underlying Keras ensemble model with the specified ``dataset``.
 
@@ -392,6 +393,8 @@ class DeepEnsemble(
             self.optimizer.optimizer.lr, tf.keras.optimizers.schedules.LearningRateSchedule
         ):
             self.optimizer.optimizer.lr.assign(self.original_lr)
+
+        return history
 
     def log(self, dataset: Optional[Dataset] = None) -> None:
         """

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -494,6 +494,11 @@ class DeepEnsemble(
                     tensorboard_writers,
                 ):
                     callback._writers = writers
+
+        # don't serialize any history optimization result
+        if isinstance(state.get("_last_optimization_result"), keras.callbacks.History):
+            state["_last_optimization_result"] = ...
+
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -520,3 +525,7 @@ class DeepEnsemble(
             loss=[self.optimizer.loss] * self._model.ensemble_size,
             metrics=[self.optimizer.metrics] * self._model.ensemble_size,
         )
+
+        # recover optimization result if necessary (and possible)
+        if state.get("_last_optimization_result") is ...:
+            self._last_optimization_result = getattr(self.model, "history")


### PR DESCRIPTION
**Related issue(s)/PRs:** #617

## Summary

Allow trainable models to return an optimization result and provide a backwards compatible method to make it accessible in the models. This currently includes OptimizeResult for gpflow models using the SciPy optimizer, keras.callback.History for keras models using the keras fit method, and lists of results for model stacks.

Note that exposing this in the model makes more sense than exposing it in the optimizer wrappers, as these are essentially an implementation detail and behave very differently between e.g. gpflow and keras.

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
