### PR TITLE
Parallelise integration test run

### DIFF
--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        part: [ "1", "2", "3" ]
+        part: [ "1", "2", "3", "4" ]
     name: tests (part${{ matrix.part }})
     steps:
     - uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        part: [ "1", "2", "3" ]
+        part: [ "1", "2", "3", "4" ]
     name: tests_old (part${{ matrix.part }})
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ description =
     tests_1: Run tests part 1
     tests_2: Run tests part 2
     tests_3: Run tests part 3
+    tests_4: Run tests part 4
     coverage: Generate code coverage
     docs: Generate documentation
     quickdocs: Generate dummy documentation
@@ -58,10 +59,11 @@ commands =
     types: mypy {posargs}
     # run tests (run with "-- --runslow yes" to run all tests)
     # note that we currently split this into three separate runs due to memory leak issues
-    tests,tests_1,tests_2,tests_3: pip install .[qhsri] -r tests/latest/requirements.txt -c tests/latest/constraints.txt
+    tests,tests_1,tests_2,tests_3,tests_4: pip install .[qhsri] -r tests/latest/requirements.txt -c tests/latest/constraints.txt
     tests,tests_1: pytest --ignore trieste/experimental --qhsri yes {posargs} trieste tests/unit/models/gpflux
     tests,tests_2: pytest --ignore tests/unit/models/gpflux --qhsri yes {posargs} tests/unit
-    tests,tests_3: pytest --qhsri yes {posargs} tests/util tests/integration
+    tests,tests_3: pytest --qhsri yes {posargs} tests/util tests/integration/test_ask_tell_optimization.py tests/integration/test_bayesian_optimization.py
+    tests,tests_4: pytest --qhsri yes --ignore tests/integration/test_ask_tell_optimization.py --ignore tests/integration/test_bayesian_optimization.py {posargs} tests/integration
     # code coverage
     coverage: pip install .[qhsri] -r tests/latest/requirements.txt -c tests/latest/constraints.txt
     coverage: pip install -r common_build/taskipy/requirements.txt -c common_build/taskipy/constraints.txt
@@ -82,7 +84,7 @@ commands =
 
 # additional tests using python 3.7 and older versions of tensorflow
 
-[testenv:{types_old,tests_old,tests_old_1,tests_old_2,tests_old_3}]
+[testenv:{types_old,tests_old,tests_old_1,tests_old_2,tests_old_3,tests_old_4}]
 basepython = python3.7
 description =
     types_old: Check types [Python 3.7]
@@ -90,13 +92,15 @@ description =
     tests_old_1: Run old tests part 1
     tests_old_2: Run old tests part 2
     tests_old_3: Run old tests part 3
+    tests_old_4: Run old tests part 4
 commands =
     types_old: pip install -r common_build/types/requirements.txt -c common_build/types/constraints.txt
     types_old: pip install . -r tests/old/requirements.txt -c tests/old/constraints.txt
     types_old: mypy {posargs}
     # unlike tests this doesn't include the optional qhsri support
     # note that we currently split this into three separate runs due to memory leak issues
-    tests_old,tests_old_1,tests_old_2,tests_old_3: pip install . -r tests/old/requirements.txt -c tests/old/constraints.txt
+    tests_old,tests_old_1,tests_old_2,tests_old_3,tests_old_4: pip install . -r tests/old/requirements.txt -c tests/old/constraints.txt
     tests_old,tests_old_1: pytest --ignore trieste/experimental {posargs} trieste tests/unit/models/gpflux
     tests_old,tests_old_2: pytest --ignore tests/unit/models/gpflux {posargs} tests/unit
-    tests_old,tests_old_3: pytest {posargs} tests/util tests/integration
+    tests_old,tests_old_3: pytest {posargs} tests/util tests/integration/test_ask_tell_optimization.py tests/integration/test_bayesian_optimization.py
+    tests_old,tests_old_4: pytest --ignore tests/integration/test_ask_tell_optimization.py --ignore tests/integration/test_bayesian_optimization.py {posargs} tests/integration


### PR DESCRIPTION
**Related issue(s)/PRs:** #770

## Summary

Adding and enabling shape checks has slowed down the integration test run a bit. This PR splits the run in two so it's no longer the bottleneck.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
