### PR TITLE
Search spaces should be deepcopied

### DIFF
--- a/trieste/space.py
+++ b/trieste/space.py
@@ -478,9 +478,6 @@ class DiscreteSearchSpace(SearchSpace):
             return NotImplemented
         return bool(tf.reduce_all(tf.sort(self.points, 0) == tf.sort(other.points, 0)))
 
-    def __deepcopy__(self, memo: dict[int, object]) -> DiscreteSearchSpace:
-        return self
-
 
 class Box(SearchSpace):
     r"""
@@ -843,9 +840,6 @@ class Box(SearchSpace):
             and self._constraints == other._constraints
         )
 
-    def __deepcopy__(self, memo: dict[int, object]) -> Box:
-        return self
-
     def constraints_residuals(self, points: TensorType) -> TensorType:
         """
         Return residuals for all the constraints in this :class:`SearchSpace`.
@@ -1074,6 +1068,3 @@ class TaggedProductSearchSpace(SearchSpace):
         if not isinstance(other, TaggedProductSearchSpace):
             return NotImplemented
         return self._tags == other._tags and self._spaces == other._spaces
-
-    def __deepcopy__(self, memo: dict[int, object]) -> TaggedProductSearchSpace:
-        return self


### PR DESCRIPTION
**Related issue(s)/PRs:** #104 

## Summary

Search spaces are currently not deepcopied for speed reasons (see #104). However, since there's nothing in the search space API that says spaces must be immutable this can result in bugs. It's also not clear how significant the speed saving is (saving state is not usually a bottleneck).

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
