### PR TITLE
Allow boxes with zero widths

### DIFF
--- a/trieste/space.py
+++ b/trieste/space.py
@@ -544,7 +544,7 @@ class Box(SearchSpace):
 
             tf.debugging.assert_same_float_dtype([self._lower, self._upper])
 
-        tf.debugging.assert_less(self._lower, self._upper)
+        tf.debugging.assert_less_equal(self._lower, self._upper)
 
         self._dimension = tf.shape(self._upper)[-1]
 

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -527,7 +527,7 @@ class Box(SearchSpace):
 
             - ``lower`` and ``upper`` have invalid shapes.
             - ``lower`` and ``upper`` do not have the same floating point type.
-            - ``upper`` is not greater than ``lower`` across all dimensions.
+            - ``upper`` is not greater or equal to ``lower`` across all dimensions.
         """
 
         tf.debugging.assert_shapes([(lower, ["D"]), (upper, ["D"])])


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

There is no reason to disallow boxes with zero widths (i.e, where the lower and upper bounds are identical in some dimension).

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [x] The quality checks are all passing
- [x] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
