### PR TITLE
Fix param randomization, generating repeating values

### DIFF
--- a/trieste/models/gpflow/utils.py
+++ b/trieste/models/gpflow/utils.py
@@ -68,6 +68,10 @@ def randomize_hyperparameters(object: gpflow.Module) -> None:
             param.assign(sample)
         elif param.prior is not None:
             # handle constant priors for multi-dimensional parameters
+            # Use python conditionals here to avoid creating tensorflow `tf.cond` ops,
+            # i.e. using `len(param.shape)` instead of `tf.rank(param)`.
+            # Otherwise, tensorflow generates repeating random sequences for hyperparameters, see
+            # https://github.com/tensorflow/tensorflow/issues/61912.
             if param.prior.batch_shape == param.prior.event_shape == [] and len(param.shape) == 1:
                 sample = param.prior.sample(tf.shape(param))
             else:

--- a/trieste/models/gpflow/utils.py
+++ b/trieste/models/gpflow/utils.py
@@ -68,7 +68,7 @@ def randomize_hyperparameters(object: gpflow.Module) -> None:
             param.assign(sample)
         elif param.prior is not None:
             # handle constant priors for multi-dimensional parameters
-            if param.prior.batch_shape == param.prior.event_shape == [] and tf.rank(param) == 1:
+            if param.prior.batch_shape == param.prior.event_shape == [] and len(param.shape) == 1:
                 sample = param.prior.sample(tf.shape(param))
             else:
                 sample = param.prior.sample()


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
This PR workarounds an issue where `randomize_hyperparameters` generated same repeating values for model hyperparameters when the global seed was set. The issue only occurred when `tf.function` compilation was enabled.

The issue seems to be related to the following [documented](https://www.tensorflow.org/api_docs/python/tf/random/set_seed#used-in-the-notebooks) behaviour of tensorflow: 

> Note that tf.function acts like a re-run of a program in this case. When the global seed is set but operation seeds are not set, the sequence of random numbers are the same for each tf.function.

When the function being compiled has a dynamic conditional (i.e. `tf.cond`) and the branches contain randomization calls, it seems internally tensorflow acts like "... re-run of a program". This is likely related to the fact that AutoGraph executes both branches during tracing. This could potentially be a tensorflow bug, but requires more investigation.

This PR simply removes the `tf.Tensor` condition expression (which is converted to `tf.cond` via AutoGraph) to a static python expression. Also added a unit test to catch the issue, which fails on previous version of the code.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
