### PR TITLE
Support optimization of multiple points in batch spaces

### DIFF
--- a/docs/notebooks/trust_region.pct.py
+++ b/docs/notebooks/trust_region.pct.py
@@ -196,7 +196,11 @@ plot_history(result)
 # `EfficientGlobalOptimization` coupled with the `ParallelContinuousThompsonSampling` acquisition
 # function.
 #
-# Note: the number of sub-spaces/regions must match the number of batch query points.
+# Note: in this example the number of sub-spaces/regions is equal to the number of batch query
+# points in the base-rule. This results in each region contributing one query point to the overall
+# batch. However, it is possible to generate multiple query points from each region by setting
+# `num_query_points` to be a multiple `Q` of the number of regions. In this case, each region will
+# contribute `Q` query points to the overall batch.
 
 # %%
 num_query_points = 5

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -215,7 +215,7 @@ def test_optimize_continuous_raises_with_mismatch_multi_search_space() -> None:
         generate_continuous_optimizer()(multi_space, acq_fn)
 
 
-@pytest.mark.parametrize("points_per_box", [1, 2, 3, 5])
+@pytest.mark.parametrize("points_per_box", [1, 3])
 def test_optimize_continuous_finds_points_in_multi_search_space_boxes(points_per_box: int) -> None:
     # Test with non-overlapping grid of 2D boxes. Optimize them as a batch and check that each
     # point is only in the corresponding box (with potentially multiple points per box).

--- a/tests/unit/acquisition/test_optimizer.py
+++ b/tests/unit/acquisition/test_optimizer.py
@@ -209,16 +209,19 @@ def test_optimize_continuous_raises_with_mismatch_multi_search_space() -> None:
     space_B = Box([3], [4])
     multi_space = TaggedMultiSearchSpace(spaces=[space_A, space_B])
     acq_fn = _quadratic_sum([1.0])
-    with pytest.raises(TF_DEBUGGING_ERROR_TYPES, match="The batch shape of initial samples 2 must"):
+    with pytest.raises(
+        TF_DEBUGGING_ERROR_TYPES, match="The vectorization of the target function 1 must be "
+    ):
         generate_continuous_optimizer()(multi_space, acq_fn)
 
 
-def test_optimize_continuous_finds_points_in_multi_search_space_boxes() -> None:
+@pytest.mark.parametrize("points_per_box", [1, 2, 3, 5])
+def test_optimize_continuous_finds_points_in_multi_search_space_boxes(points_per_box: int) -> None:
     # Test with non-overlapping grid of 2D boxes. Optimize them as a batch and check that each
-    # point is only in the corresponding box.
+    # point is only in the corresponding box (with potentially multiple points per box).
     boxes = [Box([x, y], [x + 0.7, y + 0.7]) for x in range(-2, 2) for y in range(-2, 2)]
     multi_space = TaggedMultiSearchSpace(spaces=boxes)
-    batch_size = len(boxes)
+    batch_size = len(boxes) * points_per_box
 
     def target_function(x: TensorType) -> TensorType:  # [N, V, D] -> [N, V]
         individual_func = [_quadratic_sum([1.0])(x[:, i : i + 1, :]) for i in range(batch_size)]
@@ -232,7 +235,7 @@ def test_optimize_continuous_finds_points_in_multi_search_space_boxes() -> None:
     # corresponding box.
     for i, point in enumerate(max_points):
         for j, box in enumerate(boxes):
-            if i == j:
+            if i % len(boxes) == j:
                 assert point in box
             else:
                 assert point not in box


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Add support for batch optimization of multiple points per region/subspace in a `TaggedMultiSearchSpace` collection.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [X] Any new features are well-documented (in docstrings or notebooks)
