### PR TITLE
Local models and datasets

### DIFF
--- a/docs/notebooks/trust_region.pct.py
+++ b/docs/notebooks/trust_region.pct.py
@@ -246,44 +246,6 @@ plot_final_result(dataset)
 plot_history(result)
 
 # %% [markdown]
-# ## TEST
-
-# %%
-num_query_points = 5
-
-init_subspaces = [
-    trieste.acquisition.rule.SingleObjectiveTrustRegionBox(search_space)
-    for _ in range(num_query_points)
-]
-base_rule = trieste.acquisition.rule.EfficientGlobalOptimization(
-    builder=trieste.acquisition.ParallelContinuousThompsonSampling(),
-    num_query_points=1,
-)
-batch_acq_rule = trieste.acquisition.rule.BatchTrustRegionBox(
-    init_subspaces, base_rule
-)
-
-bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
-
-num_steps = 5
-result = bo.optimize(
-    num_steps,
-    {trieste.observer.OBJECTIVE: initial_data},
-    trieste.acquisition.utils.copy_to_local_models(
-        build_model(), num_query_points
-    ),
-    batch_acq_rule,
-    track_state=True,
-)
-dataset = result.try_get_final_dataset()
-
-# %%
-plot_final_result(dataset)
-
-# %%
-plot_history(result)
-
-# %% [markdown]
 # ## Trust region `TurBO` acquisition rule
 #
 # Finally, we show how to run Bayesian optimization with the `TurBO` algorithm. This is a

--- a/docs/notebooks/trust_region.pct.py
+++ b/docs/notebooks/trust_region.pct.py
@@ -242,7 +242,9 @@ dataset = result.try_get_final_dataset()
 # %% [markdown]
 # ### Visualizing batch trust region results
 #
-# We visualize the results as before.
+# We visualize the results as before. However, please note that the initial query points (crosses) are
+# not highlighted in these plots. On each iteration, the batch trust region rule filters out points
+# that are not in the regions anymore; so there isn't an easy way to track the initial points.
 
 # %%
 plot_final_result(dataset, num_init_points=0)

--- a/docs/notebooks/trust_region.pct.py
+++ b/docs/notebooks/trust_region.pct.py
@@ -211,7 +211,7 @@ init_subspaces = [
 ]
 base_rule = trieste.acquisition.rule.EfficientGlobalOptimization(  # type: ignore[var-annotated]
     builder=trieste.acquisition.ParallelContinuousThompsonSampling(),
-    #num_query_points=num_query_points,
+    # num_query_points=num_query_points,
 )
 batch_acq_rule = trieste.acquisition.rule.BatchTrustRegionBox(
     init_subspaces, base_rule
@@ -230,9 +230,9 @@ bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
 
 num_steps = 5
 result = bo.optimize(
-    #num_steps, initial_data, build_model(), batch_acq_rule, track_state=True
+    # num_steps, initial_data, build_model(), batch_acq_rule, track_state=True
     num_steps,
-    initial_data,
+    {trieste.observer.OBJECTIVE: initial_data},
     trieste.acquisition.utils.copy_to_local_models(build_model(), 2),
     batch_acq_rule,
     track_state=True,

--- a/docs/notebooks/trust_region.pct.py
+++ b/docs/notebooks/trust_region.pct.py
@@ -106,9 +106,7 @@ dataset = result.try_get_final_dataset()
 from trieste.experimental.plotting import plot_bo_points, plot_function_2d
 
 
-def plot_final_result(
-    _dataset: trieste.data.Dataset, num_init_points=num_initial_data_points
-) -> None:
+def plot_final_result(_dataset: trieste.data.Dataset) -> None:
     arg_min_idx = tf.squeeze(tf.argmin(_dataset.observations, axis=0))
     query_points = _dataset.query_points.numpy()
     _, ax = plot_function_2d(
@@ -119,7 +117,7 @@ def plot_final_result(
         contour=True,
     )
 
-    plot_bo_points(query_points, ax[0, 0], num_init_points, arg_min_idx)
+    plot_bo_points(query_points, ax[0, 0], num_initial_data_points, arg_min_idx)
 
 
 plot_final_result(dataset)
@@ -146,10 +144,7 @@ from trieste.experimental.plotting import (
 )
 
 
-def plot_history(
-    result: trieste.bayesian_optimizer.OptimizationResult,
-    num_init_points=num_initial_data_points,
-) -> None:
+def plot_history(result: trieste.bayesian_optimizer.OptimizationResult) -> None:
     frames = []
     for step, hist in enumerate(
         result.history + [result.final_result.unwrap()]
@@ -159,7 +154,7 @@ def plot_history(
             search_space.lower,
             search_space.upper,
             hist,
-            num_init=num_init_points,
+            num_init=num_initial_data_points,
         )
 
         if fig is not None:
@@ -242,15 +237,13 @@ dataset = result.try_get_final_dataset()
 # %% [markdown]
 # ### Visualizing batch trust region results
 #
-# We visualize the results as before. However, please note that the initial query points (crosses) are
-# not highlighted in these plots. On each iteration, the batch trust region rule filters out points
-# that are not in the regions anymore; so there isn't an easy way to track the initial points.
+# We visualize the results as before.
 
 # %%
-plot_final_result(dataset, num_init_points=0)
+plot_final_result(dataset)
 
 # %%
-plot_history(result, num_init_points=0)
+plot_history(result)
 
 # %% [markdown]
 # ## TEST
@@ -285,10 +278,10 @@ result = bo.optimize(
 dataset = result.try_get_final_dataset()
 
 # %%
-plot_final_result(dataset, num_init_points=0)
+plot_final_result(dataset)
 
 # %%
-plot_history(result, num_init_points=0)
+plot_history(result)
 
 # %% [markdown]
 # ## Trust region `TurBO` acquisition rule

--- a/docs/notebooks/trust_region.pct.py
+++ b/docs/notebooks/trust_region.pct.py
@@ -199,15 +199,15 @@ plot_history(result)
 # Note: the number of sub-spaces/regions must match the number of batch query points.
 
 # %%
-num_query_points = 5
+num_query_points = 6
 
 init_subspaces = [
-    trieste.acquisition.rule.SingleObjectiveTrustRegionBox(search_space)
-    for _ in range(num_query_points)
+    trieste.acquisition.rule.SingleObjectiveTrustRegionBox(search_space, i)
+    for i in range(num_query_points)
 ]
 base_rule = trieste.acquisition.rule.EfficientGlobalOptimization(  # type: ignore[var-annotated]
     builder=trieste.acquisition.ParallelContinuousThompsonSampling(),
-    num_query_points=num_query_points,
+    #num_query_points=num_query_points,
 )
 batch_acq_rule = trieste.acquisition.rule.BatchTrustRegionBox(
     init_subspaces, base_rule
@@ -226,7 +226,12 @@ bo = trieste.bayesian_optimizer.BayesianOptimizer(observer, search_space)
 
 num_steps = 5
 result = bo.optimize(
-    num_steps, initial_data, build_model(), batch_acq_rule, track_state=True
+    #num_steps, initial_data, build_model(), batch_acq_rule, track_state=True
+    num_steps,
+    initial_data,
+    trieste.acquisition.utils.copy_to_local_models(build_model(), 2),
+    batch_acq_rule,
+    track_state=True,
 )
 dataset = result.try_get_final_dataset()
 

--- a/tests/integration/test_ask_tell_optimization.py
+++ b/tests/integration/test_ask_tell_optimization.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import copy
 import pickle
 import tempfile
-from typing import Callable
+from typing import Callable, Tuple
 
 import numpy.testing as npt
 import pytest
@@ -49,30 +49,27 @@ from trieste.types import State, TensorType
 # We use a copy of these for a quicker test against a simple quadratic function
 # (copying is necessary as some of the acquisition rules are stateful).
 OPTIMIZER_PARAMS = (
-    "num_steps, reload_state, acquisition_rule_fn, num_models",
+    "num_steps, reload_state, acquisition_rule_fn",
     [
         pytest.param(
-            20, False, lambda: EfficientGlobalOptimization(), 1, id="EfficientGlobalOptimization"
+            20, False, lambda: EfficientGlobalOptimization(), id="EfficientGlobalOptimization"
         ),
         pytest.param(
             20,
             True,
             lambda: EfficientGlobalOptimization(),
-            1,
             id="EfficientGlobalOptimization/reload_state",
         ),
         pytest.param(
             15,
             False,
             lambda: BatchTrustRegionBox(TREGOBox(ScaledBranin.search_space)),
-            1,
             id="TREGO",
         ),
         pytest.param(
             16,
             True,
             lambda: BatchTrustRegionBox(TREGOBox(ScaledBranin.search_space)),
-            1,
             id="TREGO/reload_state",
         ),
         pytest.param(
@@ -85,20 +82,21 @@ OPTIMIZER_PARAMS = (
                     num_query_points=3,
                 ),
             ),
-            1,
             id="BatchTrustRegionBox",
         ),
         pytest.param(
             10,
             False,
-            lambda: BatchTrustRegionBox(
-                [SingleObjectiveTrustRegionBox(ScaledBranin.search_space) for _ in range(3)],
-                EfficientGlobalOptimization(
-                    ParallelContinuousThompsonSampling(),
-                    num_query_points=2,
+            (
+                lambda: BatchTrustRegionBox(
+                    [SingleObjectiveTrustRegionBox(ScaledBranin.search_space) for _ in range(3)],
+                    EfficientGlobalOptimization(
+                        ParallelContinuousThompsonSampling(),
+                        num_query_points=2,
+                    ),
                 ),
+                3,
             ),
-            3,
             id="BatchTrustRegionBox/LocalModels",
         ),
         pytest.param(
@@ -110,7 +108,6 @@ OPTIMIZER_PARAMS = (
                 ).using(OBJECTIVE),
                 num_query_points=3,
             ),
-            1,
             id="LocalPenalization",
         ),
         pytest.param(
@@ -121,10 +118,22 @@ OPTIMIZER_PARAMS = (
                     ScaledBranin.search_space,
                 ).using(OBJECTIVE),
             ),
-            1,
             id="LocalPenalization/AsynchronousGreedy",
         ),
     ],
+)
+
+
+AcquisitionRuleFunction = (
+    Callable[[], AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModel]]
+    | Callable[
+        [],
+        AcquisitionRule[
+            State[TensorType, AsynchronousRuleState | BatchTrustRegionBox.State],
+            Box,
+            TrainableProbabilisticModel,
+        ],
+    ]
 )
 
 
@@ -134,22 +143,9 @@ OPTIMIZER_PARAMS = (
 def test_ask_tell_optimizer_finds_minima_of_the_scaled_branin_function(
     num_steps: int,
     reload_state: bool,
-    acquisition_rule_fn: Callable[
-        [], AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModel]
-    ]
-    | Callable[
-        [],
-        AcquisitionRule[
-            State[TensorType, AsynchronousRuleState | BatchTrustRegionBox.State],
-            Box,
-            TrainableProbabilisticModel,
-        ],
-    ],
-    num_models: int,
+    acquisition_rule_fn: AcquisitionRuleFunction | Tuple[AcquisitionRuleFunction, int],
 ) -> None:
-    _test_ask_tell_optimization_finds_minima(
-        True, num_steps, reload_state, acquisition_rule_fn, num_models
-    )
+    _test_ask_tell_optimization_finds_minima(True, num_steps, reload_state, acquisition_rule_fn)
 
 
 @random_seed
@@ -157,23 +153,12 @@ def test_ask_tell_optimizer_finds_minima_of_the_scaled_branin_function(
 def test_ask_tell_optimizer_finds_minima_of_simple_quadratic(
     num_steps: int,
     reload_state: bool,
-    acquisition_rule_fn: Callable[
-        [], AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModel]
-    ]
-    | Callable[
-        [],
-        AcquisitionRule[
-            State[TensorType, AsynchronousRuleState | BatchTrustRegionBox.State],
-            Box,
-            TrainableProbabilisticModel,
-        ],
-    ],
-    num_models: int,
+    acquisition_rule_fn: AcquisitionRuleFunction | Tuple[AcquisitionRuleFunction, int],
 ) -> None:
     # for speed reasons we sometimes test with a simple quadratic defined on the same search space
     # branin; currently assume that every rule should be able to solve this in 5 steps
     _test_ask_tell_optimization_finds_minima(
-        False, min(num_steps, 5), reload_state, acquisition_rule_fn, num_models
+        False, min(num_steps, 5), reload_state, acquisition_rule_fn
     )
 
 
@@ -181,18 +166,7 @@ def _test_ask_tell_optimization_finds_minima(
     optimize_branin: bool,
     num_steps: int,
     reload_state: bool,
-    acquisition_rule_fn: Callable[
-        [], AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModel]
-    ]
-    | Callable[
-        [],
-        AcquisitionRule[
-            State[TensorType, AsynchronousRuleState | BatchTrustRegionBox.State],
-            Box,
-            TrainableProbabilisticModel,
-        ],
-    ],
-    num_models: int,
+    acquisition_rule_fn: AcquisitionRuleFunction | Tuple[AcquisitionRuleFunction, int],
 ) -> None:
     # For the case when optimization state is saved and reload on each iteration
     # we need to use new acquisition function object to imitate real life usage
@@ -203,6 +177,11 @@ def _test_ask_tell_optimization_finds_minima(
     observer = mk_observer(ScaledBranin.objective if optimize_branin else SimpleQuadratic.objective)
     batch_observer = mk_batch_observer(observer)
     initial_data = observer(initial_query_points)
+
+    if isinstance(acquisition_rule_fn, tuple):
+        acquisition_rule_fn, num_models = acquisition_rule_fn
+    else:
+        num_models = 1
 
     model = GaussianProcessRegression(
         build_gpr(initial_data, search_space, likelihood_variance=1e-7)

--- a/tests/integration/test_ask_tell_optimization.py
+++ b/tests/integration/test_ask_tell_optimization.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import copy
 import pickle
 import tempfile
-from typing import Callable, Tuple
+from typing import Callable, Tuple, Union
 
 import numpy.testing as npt
 import pytest
@@ -124,17 +124,17 @@ OPTIMIZER_PARAMS = (
 )
 
 
-AcquisitionRuleFunction = (
-    Callable[[], AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModel]]
-    | Callable[
+AcquisitionRuleFunction = Union[
+    Callable[[], AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModel]],
+    Callable[
         [],
         AcquisitionRule[
-            State[TensorType, AsynchronousRuleState | BatchTrustRegionBox.State],
+            State[TensorType, Union[AsynchronousRuleState, BatchTrustRegionBox.State]],
             Box,
             TrainableProbabilisticModel,
         ],
-    ]
-)
+    ],
+]
 
 
 @random_seed

--- a/tests/integration/test_ask_tell_optimization.py
+++ b/tests/integration/test_ask_tell_optimization.py
@@ -201,7 +201,7 @@ def _test_ask_tell_optimization_finds_minima(
     search_space = ScaledBranin.search_space
     initial_query_points = search_space.sample(5)
     observer = mk_observer(ScaledBranin.objective if optimize_branin else SimpleQuadratic.objective)
-    batch_observer = mk_batch_observer(observer, OBJECTIVE)
+    batch_observer = mk_batch_observer(observer)
     initial_data = observer(initial_query_points)
 
     model = GaussianProcessRegression(

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Trieste Contributors
+# Copyright 2021 The Trieste Contrib_fnutors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -99,13 +99,12 @@ except ImportError:  # pragma: no cover (tested but not by coverage)
 # (regenerating is necessary as some of the acquisition rules are stateful).
 def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
     return (
-        "num_steps, acquisition_rule, num_models",
+        "num_steps, acquisition_rule",
         [
-            pytest.param(20, EfficientGlobalOptimization(), 1, id="EfficientGlobalOptimization"),
+            pytest.param(20, EfficientGlobalOptimization(), id="EfficientGlobalOptimization"),
             pytest.param(
                 30,
                 EfficientGlobalOptimization(AugmentedExpectedImprovement().using(OBJECTIVE)),
-                1,
                 id="AugmentedExpectedImprovement",
             ),
             pytest.param(
@@ -114,7 +113,6 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                     MonteCarloExpectedImprovement(int(1e3)).using(OBJECTIVE),
                     generate_continuous_optimizer(100),
                 ),
-                1,
                 id="MonteCarloExpectedImprovement",
             ),
             pytest.param(
@@ -125,7 +123,6 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                         min_value_sampler=ThompsonSamplerFromTrajectory(sample_min_value=True),
                     ).using(OBJECTIVE)
                 ),
-                1,
                 id="MinValueEntropySearch",
             ),
             pytest.param(
@@ -134,7 +131,6 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                     BatchExpectedImprovement(sample_size=100).using(OBJECTIVE),
                     num_query_points=3,
                 ),
-                1,
                 id="BatchExpectedImprovement",
             ),
             pytest.param(
@@ -143,11 +139,10 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                     BatchMonteCarloExpectedImprovement(sample_size=500).using(OBJECTIVE),
                     num_query_points=3,
                 ),
-                1,
                 id="BatchMonteCarloExpectedImprovement",
             ),
             pytest.param(
-                12, AsynchronousOptimization(num_query_points=3), 1, id="AsynchronousOptimization"
+                12, AsynchronousOptimization(num_query_points=3), id="AsynchronousOptimization"
             ),
             pytest.param(
                 15,
@@ -157,7 +152,6 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                     ).using(OBJECTIVE),
                     num_query_points=3,
                 ),
-                1,
                 id="LocalPenalization",
             ),
             pytest.param(
@@ -168,7 +162,6 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                     ).using(OBJECTIVE),
                     num_query_points=3,
                 ),
-                1,
                 id="LocalPenalization/AsynchronousGreedy",
             ),
             pytest.param(
@@ -179,7 +172,6 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                     ).using(OBJECTIVE),
                     num_query_points=2,
                 ),
-                1,
                 id="GIBBON",
             ),
             pytest.param(
@@ -190,13 +182,11 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                     ).using(OBJECTIVE),
                     num_query_points=3,
                 ),
-                1,
                 id="MultipleOptimismNegativeLowerConfidenceBound",
             ),
             pytest.param(
                 20,
                 BatchTrustRegionBox(TREGOBox(ScaledBranin.search_space)),
-                1,
                 id="TREGO",
             ),
             pytest.param(
@@ -209,7 +199,6 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                         ).using(OBJECTIVE)
                     ),
                 ),
-                1,
                 id="TREGO/MinValueEntropySearch",
             ),
             pytest.param(
@@ -221,13 +210,11 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                         num_query_points=3,
                     ),
                 ),
-                1,
                 id="TREGO/ParallelContinuousThompsonSampling",
             ),
             pytest.param(
                 10,
                 TURBO(ScaledBranin.search_space, rule=DiscreteThompsonSampling(500, 3)),
-                1,
                 id="Turbo",
             ),
             pytest.param(
@@ -239,29 +226,32 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                         num_query_points=3,
                     ),
                 ),
-                1,
                 id="BatchTrustRegionBox",
             ),
             pytest.param(
                 10,
-                BatchTrustRegionBox(
-                    [SingleObjectiveTrustRegionBox(ScaledBranin.search_space) for _ in range(3)],
-                    EfficientGlobalOptimization(
-                        ParallelContinuousThompsonSampling(),
-                        num_query_points=2,
+                (
+                    BatchTrustRegionBox(
+                        [
+                            SingleObjectiveTrustRegionBox(ScaledBranin.search_space)
+                            for _ in range(3)
+                        ],
+                        EfficientGlobalOptimization(
+                            ParallelContinuousThompsonSampling(),
+                            num_query_points=2,
+                        ),
                     ),
+                    3,
                 ),
-                3,
                 id="BatchTrustRegionBox/LocalModels",
             ),
-            pytest.param(15, DiscreteThompsonSampling(500, 5), 1, id="DiscreteThompsonSampling"),
+            pytest.param(15, DiscreteThompsonSampling(500, 5), id="DiscreteThompsonSampling"),
             pytest.param(
                 15,
                 EfficientGlobalOptimization(
                     Fantasizer(),
                     num_query_points=3,
                 ),
-                1,
                 id="Fantasizer",
             ),
             pytest.param(
@@ -270,7 +260,6 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                     GreedyContinuousThompsonSampling(),
                     num_query_points=5,
                 ),
-                1,
                 id="GreedyContinuousThompsonSampling",
             ),
             pytest.param(
@@ -279,13 +268,11 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
                     ParallelContinuousThompsonSampling(),
                     num_query_points=5,
                 ),
-                1,
                 id="ParallelContinuousThompsonSampling",
             ),
             pytest.param(
                 15,
                 BatchHypervolumeSharpeRatioIndicator() if pymoo else None,
-                1,
                 id="BatchHypevolumeSharpeRatioIndicator",
                 marks=pytest.mark.qhsri,
             ),
@@ -293,25 +280,29 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
     )
 
 
+AcquisitionRuleType = (
+    AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModelType]
+    | AcquisitionRule[
+        State[TensorType, AsynchronousRuleState | BatchTrustRegion.State],
+        Box,
+        TrainableProbabilisticModelType,
+    ]
+)
+
+
 @random_seed
 @pytest.mark.slow  # to run this, add --runslow yes to the pytest command
 @pytest.mark.parametrize(*GPR_OPTIMIZER_PARAMS())
 def test_bayesian_optimizer_with_gpr_finds_minima_of_scaled_branin(
     num_steps: int,
-    acquisition_rule: AcquisitionRule[TensorType, SearchSpace, GaussianProcessRegression]
-    | AcquisitionRule[
-        State[TensorType, AsynchronousRuleState | BatchTrustRegion.State],
-        Box,
-        GaussianProcessRegression,
-    ],
-    num_models: int,
+    acquisition_rule: AcquisitionRuleType[GaussianProcessRegression]
+    | Tuple[AcquisitionRuleType[GaussianProcessRegression], int],
 ) -> None:
     _test_optimizer_finds_minimum(
         GaussianProcessRegression,
         num_steps,
         acquisition_rule,
         optimize_branin=True,
-        num_models=num_models,
     )
 
 
@@ -319,19 +310,12 @@ def test_bayesian_optimizer_with_gpr_finds_minima_of_scaled_branin(
 @pytest.mark.parametrize(*GPR_OPTIMIZER_PARAMS())
 def test_bayesian_optimizer_with_gpr_finds_minima_of_simple_quadratic(
     num_steps: int,
-    acquisition_rule: AcquisitionRule[TensorType, SearchSpace, GaussianProcessRegression]
-    | AcquisitionRule[
-        State[TensorType, AsynchronousRuleState | BatchTrustRegion.State],
-        Box,
-        GaussianProcessRegression,
-    ],
-    num_models: int,
+    acquisition_rule: AcquisitionRuleType[GaussianProcessRegression]
+    | Tuple[AcquisitionRuleType[GaussianProcessRegression], int],
 ) -> None:
     # for speed reasons we sometimes test with a simple quadratic defined on the same search space
     # branin; currently assume that every rule should be able to solve this in 6 steps
-    _test_optimizer_finds_minimum(
-        GaussianProcessRegression, min(num_steps, 6), acquisition_rule, num_models=num_models
-    )
+    _test_optimizer_finds_minimum(GaussianProcessRegression, min(num_steps, 6), acquisition_rule)
 
 
 @random_seed
@@ -595,16 +579,11 @@ def test_bayesian_optimizer_with_PCTS_and_deep_ensemble_finds_minima_of_simple_q
 def _test_optimizer_finds_minimum(
     model_type: Type[TrainableProbabilisticModelType],
     num_steps: Optional[int],
-    acquisition_rule: AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModelType]
-    | AcquisitionRule[
-        State[TensorType, AsynchronousRuleState | BatchTrustRegion.State],
-        Box,
-        TrainableProbabilisticModelType,
-    ],
+    acquisition_rule: AcquisitionRuleType[TrainableProbabilisticModelType]
+    | Tuple[AcquisitionRuleType[TrainableProbabilisticModelType], int],
     optimize_branin: bool = False,
     model_args: Optional[Mapping[str, Any]] = None,
     check_regret: bool = False,
-    num_models: int = 1,
 ) -> None:
     model_args = model_args or {}
 
@@ -629,6 +608,11 @@ def _test_optimizer_finds_minimum(
     initial_query_points = search_space.sample(num_initial_query_points)
     observer = mk_observer(ScaledBranin.objective if optimize_branin else SimpleQuadratic.objective)
     initial_data = observer(initial_query_points)
+
+    if isinstance(acquisition_rule, tuple):
+        acquisition_rule, num_models = acquisition_rule
+    else:
+        num_models = 1
 
     model: TrainableProbabilisticModel  # (really TPMType, but that's too complicated for mypy)
 

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import tempfile
 from functools import partial
 from pathlib import Path
-from typing import Any, List, Mapping, Optional, Tuple, Type, cast
+from typing import Any, List, Mapping, Optional, Tuple, Type, Union, cast
 
 import dill
 import gpflow
@@ -280,14 +280,14 @@ def GPR_OPTIMIZER_PARAMS() -> Tuple[str, List[ParameterSet]]:
     )
 
 
-AcquisitionRuleType = (
-    AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModelType]
-    | AcquisitionRule[
-        State[TensorType, AsynchronousRuleState | BatchTrustRegion.State],
+AcquisitionRuleType = Union[
+    AcquisitionRule[TensorType, SearchSpace, TrainableProbabilisticModelType],
+    AcquisitionRule[
+        State[TensorType, Union[AsynchronousRuleState, BatchTrustRegion.State]],
         Box,
         TrainableProbabilisticModelType,
-    ]
-)
+    ],
+]
 
 
 @random_seed

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -26,7 +26,6 @@ import tensorflow as tf
 from _pytest.mark import ParameterSet
 
 from tests.util.misc import random_seed
-from trieste.data import Dataset
 from trieste.acquisition import (
     GIBBON,
     AcquisitionFunctionClass,
@@ -87,7 +86,7 @@ from trieste.objectives import ScaledBranin, SimpleQuadratic
 from trieste.objectives.utils import mk_observer
 from trieste.observer import OBJECTIVE
 from trieste.space import Box, SearchSpace
-from trieste.types import State, Tag, TensorType
+from trieste.types import State, TensorType
 
 try:
     import pymoo
@@ -690,7 +689,7 @@ def _test_optimizer_finds_minimum(
 
     model = cast(TrainableProbabilisticModelType, model)
     models = copy_to_local_models(model, num_models) if num_models > 1 else {OBJECTIVE: model}
-    dataset: Mapping[Tag, Dataset] = {OBJECTIVE: initial_data}
+    dataset = {OBJECTIVE: initial_data}
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         summary_writer = tf.summary.create_file_writer(tmpdirname)

--- a/tests/integration/test_bayesian_optimization.py
+++ b/tests/integration/test_bayesian_optimization.py
@@ -26,6 +26,7 @@ import tensorflow as tf
 from _pytest.mark import ParameterSet
 
 from tests.util.misc import random_seed
+from trieste.data import Dataset
 from trieste.acquisition import (
     GIBBON,
     AcquisitionFunctionClass,
@@ -86,7 +87,7 @@ from trieste.objectives import ScaledBranin, SimpleQuadratic
 from trieste.objectives.utils import mk_observer
 from trieste.observer import OBJECTIVE
 from trieste.space import Box, SearchSpace
-from trieste.types import State, TensorType
+from trieste.types import State, Tag, TensorType
 
 try:
     import pymoo
@@ -687,18 +688,16 @@ def _test_optimizer_finds_minimum(
     else:
         raise ValueError(f"Unsupported model_type '{model_type}'")
 
-    models = cast(TrainableProbabilisticModelType, model)
-
-    if num_models > 1:
-        initial_data = {OBJECTIVE: initial_data}
-        models = copy_to_local_models(models, num_models)
+    model = cast(TrainableProbabilisticModelType, model)
+    models = copy_to_local_models(model, num_models) if num_models > 1 else {OBJECTIVE: model}
+    dataset: Mapping[Tag, Dataset] = {OBJECTIVE: initial_data}
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         summary_writer = tf.summary.create_file_writer(tmpdirname)
         with tensorboard_writer(summary_writer):
             result = BayesianOptimizer(observer, search_space).optimize(
                 num_steps or 2,
-                initial_data,
+                dataset,
                 models,
                 acquisition_rule,
                 track_state=True,

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -1218,6 +1218,20 @@ def test_trust_region_box_get_dataset_min() -> None:
     npt.assert_array_equal(y_min, tf.constant([0.2], dtype=tf.float64))
 
 
+# get_dataset_min returns first x value and inf y value when points in dataset are outside the
+# search space.
+def test_trust_region_box_get_dataset_min_outside_search_space() -> None:
+    search_space = Box([0.0, 0.0], [1.0, 1.0])
+    dataset = Dataset(
+        tf.constant([[1.2, 1.3], [-0.4, -0.5]], dtype=tf.float64),
+        tf.constant([[0.7], [0.9]], dtype=tf.float64),
+    )
+    trb = SingleObjectiveTrustRegionBox(search_space)
+    x_min, y_min = trb.get_dataset_min(dataset)
+    npt.assert_array_equal(x_min, tf.constant([1.2, 1.3], dtype=tf.float64))
+    npt.assert_array_equal(y_min, tf.constant([np.inf], dtype=tf.float64))
+
+
 # Initialize sets the box to a random location, and sets the eps and y_min values.
 def test_trust_region_box_initialize() -> None:
     search_space = Box([0.0, 0.0], [1.0, 1.0])

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -1213,7 +1213,7 @@ def test_trust_region_box_get_dataset_min() -> None:
     trb = SingleObjectiveTrustRegionBox(search_space)
     trb._lower = tf.constant([0.2, 0.2], dtype=tf.float64)
     trb._upper = tf.constant([0.7, 0.7], dtype=tf.float64)
-    x_min, y_min = trb.get_dataset_min(dataset)
+    x_min, y_min = trb.get_dataset_min({"foo": dataset})
     npt.assert_array_equal(x_min, tf.constant([0.3, 0.4], dtype=tf.float64))
     npt.assert_array_equal(y_min, tf.constant([0.2], dtype=tf.float64))
 
@@ -1227,7 +1227,7 @@ def test_trust_region_box_get_dataset_min_outside_search_space() -> None:
         tf.constant([[0.7], [0.9]], dtype=tf.float64),
     )
     trb = SingleObjectiveTrustRegionBox(search_space)
-    x_min, y_min = trb.get_dataset_min(dataset)
+    x_min, y_min = trb.get_dataset_min({"foo": dataset})
     npt.assert_array_equal(x_min, tf.constant([1.2, 1.3], dtype=tf.float64))
     npt.assert_array_equal(y_min, tf.constant([np.inf], dtype=tf.float64))
 

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -1699,7 +1699,7 @@ def test_multi_trust_region_box_updated_datasets_are_in_regions(
     )
     rule = BatchTrustRegionBox(subspaces, base_rule)
     _, points = rule.acquire(search_space, models, datasets)(None)
-    observer = mk_batch_observer(quadratic, OBJECTIVE)
+    observer = mk_batch_observer(quadratic)
     new_data = observer(points)
     assert not isinstance(new_data, Dataset)
     datasets = rule.update_datasets(datasets, new_data)

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -1681,10 +1681,10 @@ def test_multi_trust_region_box_updated_datasets_are_in_regions(
     # Check local datasets.
     for i, subspace in enumerate(subspaces):
         assert (
-            datasets[f"OBJECTIVE__{i}"].query_points.shape[0]
+            datasets[LocalTag(OBJECTIVE, i)].query_points.shape[0]
             == exp_num_init_points + num_query_points_per_region
         )
-        assert np.all(subspace.contains(datasets[f"OBJECTIVE__{i}"].query_points))
+        assert np.all(subspace.contains(datasets[LocalTag(OBJECTIVE, i)].query_points))
 
     # Check global dataset.
     assert datasets[OBJECTIVE].query_points.shape[0] == num_local_models * (
@@ -1695,7 +1695,7 @@ def test_multi_trust_region_box_updated_datasets_are_in_regions(
         assert any(subspace.contains(point) for subspace in subspaces)
     # Global dataset should be the concatenation of all local datasets.
     exp_query_points = tf.concat(
-        [datasets[f"OBJECTIVE__{i}"].query_points for i in range(num_local_models)], axis=0
+        [datasets[LocalTag(OBJECTIVE, i)].query_points for i in range(num_local_models)], axis=0
     )
     npt.assert_array_almost_equal(datasets[OBJECTIVE].query_points, exp_query_points)
 

--- a/tests/unit/objectives/test_utils.py
+++ b/tests/unit/objectives/test_utils.py
@@ -86,11 +86,15 @@ def test_mk_batch_observer(
     else:
         assert isinstance(ys, dict)
         if batch_size == 1:
-            assert ys.keys() == {key}
-            npt.assert_array_equal(ys[key].query_points, x_[:, 0])
-            npt.assert_array_equal(ys[key].observations, x_[:, 0])
+            exp_keys = {key}
         else:
-            assert ys.keys() == {f"{key}__{i}" for i in range(batch_size)}
+            exp_keys = {f"{key}__{i}" for i in range(batch_size)}
+            exp_keys.add(key)
+
+        assert ys.keys() == exp_keys
+        npt.assert_array_equal(ys[key].query_points, tf.reshape(x_, [-1, 1]))
+        npt.assert_array_equal(ys[key].observations, tf.reshape(x_, [-1, 1]))
+        if batch_size > 1:
             for i in range(batch_size):
                 npt.assert_array_equal(ys[f"{key}__{i}"].query_points, x_[:, i])
                 npt.assert_array_equal(ys[f"{key}__{i}"].observations, x_[:, i])

--- a/tests/unit/objectives/test_utils.py
+++ b/tests/unit/objectives/test_utils.py
@@ -11,10 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Callable, Union
+
 import numpy.testing as npt
+import pytest
 import tensorflow as tf
 
-from trieste.objectives.utils import mk_multi_observer, mk_observer
+from trieste.data import Dataset
+from trieste.objectives.utils import mk_batch_observer, mk_multi_observer, mk_observer
+from trieste.observer import SingleObserver
+from trieste.types import Tag, TensorType
 
 
 def test_mk_observer() -> None:
@@ -49,3 +55,42 @@ def test_mk_multi_observer() -> None:
     npt.assert_array_equal(ys["foo"].observations, x_ + 1)
     npt.assert_array_equal(ys["bar"].query_points, x_)
     npt.assert_array_equal(ys["bar"].observations, x_ - 1)
+
+
+def test_mk_batch_observer_raises_on_multi_observer() -> None:
+    observer = mk_batch_observer(mk_multi_observer(foo=lambda x: x + 1, bar=lambda x: x - 1))
+    with pytest.raises(ValueError, match="mk_batch_observer does not support multi-observers"):
+        observer(tf.constant([[[3.0]]]))
+
+
+@pytest.mark.parametrize("input_objective", [lambda x: x, lambda x: Dataset(x, x)])
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+@pytest.mark.parametrize("num_query_points_per_batch", [1, 2])
+@pytest.mark.parametrize("key", [None, "bar"])
+def test_mk_batch_observer(
+    input_objective: Union[Callable[[TensorType], TensorType], SingleObserver],
+    batch_size: int,
+    num_query_points_per_batch: int,
+    key: Tag,
+) -> None:
+    x_ = tf.reshape(
+        tf.constant(range(batch_size * num_query_points_per_batch), tf.float64),
+        (num_query_points_per_batch, batch_size, 1),
+    )
+    ys = mk_batch_observer(input_objective, key)(x_)
+
+    if key is None:
+        assert isinstance(ys, Dataset)
+        npt.assert_array_equal(ys.query_points, tf.reshape(x_, [-1, 1]))
+        npt.assert_array_equal(ys.observations, tf.reshape(x_, [-1, 1]))
+    else:
+        assert isinstance(ys, dict)
+        if batch_size == 1:
+            assert ys.keys() == {key}
+            npt.assert_array_equal(ys[key].query_points, x_[:, 0])
+            npt.assert_array_equal(ys[key].observations, x_[:, 0])
+        else:
+            assert ys.keys() == {f"{key}__{i}" for i in range(batch_size)}
+            for i in range(batch_size):
+                npt.assert_array_equal(ys[f"{key}__{i}"].query_points, x_[:, i])
+                npt.assert_array_equal(ys[f"{key}__{i}"].observations, x_[:, i])

--- a/tests/unit/objectives/test_utils.py
+++ b/tests/unit/objectives/test_utils.py
@@ -85,16 +85,12 @@ def test_mk_batch_observer(
         npt.assert_array_equal(ys.observations, tf.reshape(x_, [-1, 1]))
     else:
         assert isinstance(ys, dict)
-        if batch_size == 1:
-            exp_keys = {key}
-        else:
-            exp_keys = {f"{key}__{i}" for i in range(batch_size)}
-            exp_keys.add(key)
+        exp_keys = {f"{key}__{i}" for i in range(batch_size)}
+        exp_keys.add(str(key))
 
         assert ys.keys() == exp_keys
         npt.assert_array_equal(ys[key].query_points, tf.reshape(x_, [-1, 1]))
         npt.assert_array_equal(ys[key].observations, tf.reshape(x_, [-1, 1]))
-        if batch_size > 1:
-            for i in range(batch_size):
-                npt.assert_array_equal(ys[f"{key}__{i}"].query_points, x_[:, i])
-                npt.assert_array_equal(ys[f"{key}__{i}"].observations, x_[:, i])
+        for i in range(batch_size):
+            npt.assert_array_equal(ys[f"{key}__{i}"].query_points, x_[:, i])
+            npt.assert_array_equal(ys[f"{key}__{i}"].observations, x_[:, i])

--- a/tests/unit/objectives/test_utils.py
+++ b/tests/unit/objectives/test_utils.py
@@ -21,6 +21,7 @@ from trieste.data import Dataset
 from trieste.objectives.utils import mk_batch_observer, mk_multi_observer, mk_observer
 from trieste.observer import SingleObserver
 from trieste.types import Tag, TensorType
+from trieste.utils.misc import LocalTag
 
 
 def test_mk_observer() -> None:
@@ -85,12 +86,12 @@ def test_mk_batch_observer(
         npt.assert_array_equal(ys.observations, tf.reshape(x_, [-1, 1]))
     else:
         assert isinstance(ys, dict)
-        exp_keys = {f"{key}__{i}" for i in range(batch_size)}
-        exp_keys.add(str(key))
+        exp_keys = {LocalTag(key, i).tag for i in range(batch_size)}
+        exp_keys.add(key)
 
         assert ys.keys() == exp_keys
         npt.assert_array_equal(ys[key].query_points, tf.reshape(x_, [-1, 1]))
         npt.assert_array_equal(ys[key].observations, tf.reshape(x_, [-1, 1]))
         for i in range(batch_size):
-            npt.assert_array_equal(ys[f"{key}__{i}"].query_points, x_[:, i])
-            npt.assert_array_equal(ys[f"{key}__{i}"].observations, x_[:, i])
+            npt.assert_array_equal(ys[LocalTag(key, i)].query_points, x_[:, i])
+            npt.assert_array_equal(ys[LocalTag(key, i)].observations, x_[:, i])

--- a/tests/unit/objectives/test_utils.py
+++ b/tests/unit/objectives/test_utils.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, Sequence, Union
+from typing import Callable, Sequence, Set, Union
 
 import numpy.testing as npt
 import pytest
@@ -21,7 +21,7 @@ from trieste.data import Dataset
 from trieste.objectives.utils import mk_batch_observer, mk_multi_observer, mk_observer
 from trieste.observer import Observer
 from trieste.types import Tag, TensorType
-from trieste.utils.misc import LocalTag
+from trieste.utils.misc import LocalizedTag
 
 
 def test_mk_observer() -> None:
@@ -83,9 +83,9 @@ def test_mk_batch_observer(
     assert isinstance(ys, dict)
 
     # Check keys.
-    exp_keys = set()
+    exp_keys: Set[Union[Tag, LocalizedTag]] = set()
     for key in keys:
-        exp_keys.update({LocalTag(key, i).tag for i in range(batch_size)})
+        exp_keys.update({LocalizedTag(key, i) for i in range(batch_size)})
         exp_keys.add(key)
     assert ys.keys() == exp_keys
 
@@ -102,5 +102,5 @@ def test_mk_batch_observer(
         npt.assert_array_equal(ys[key].query_points, tf.reshape(x_, [-1, 1]))
         npt.assert_array_equal(ys[key].observations, tf.reshape(exp_o, [-1, 1]))
         for i in range(batch_size):
-            npt.assert_array_equal(ys[LocalTag(key, i)].query_points, x_[:, i])
-            npt.assert_array_equal(ys[LocalTag(key, i)].observations, exp_o[:, i])
+            npt.assert_array_equal(ys[LocalizedTag(key, i)].query_points, x_[:, i])
+            npt.assert_array_equal(ys[LocalizedTag(key, i)].observations, exp_o[:, i])

--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -36,7 +36,7 @@ from trieste.objectives.utils import mk_batch_observer
 from trieste.observer import OBJECTIVE
 from trieste.space import Box
 from trieste.types import State, Tag, TensorType
-from trieste.utils.misc import LocalTag
+from trieste.utils.misc import LocalizedTag
 
 # tags
 TAG1: Tag = "1"
@@ -451,7 +451,7 @@ def test_ask_tell_optimizer_creates_correct_datasets_for_rank3_points(
         init_data = {OBJECTIVE: mk_dataset([[0.5], [1.5]], [[0.25], [0.35]])}
     else:
         init_data = {
-            LocalTag(OBJECTIVE, i): mk_dataset([[0.5 + i], [1.5 + i]], [[0.25], [0.35]])
+            LocalizedTag(OBJECTIVE, i): mk_dataset([[0.5 + i], [1.5 + i]], [[0.25], [0.35]])
             for i in range(batch_size)
         }
         init_data[OBJECTIVE] = mk_dataset([[0.5], [1.5]], [[0.25], [0.35]])
@@ -484,7 +484,7 @@ def test_ask_tell_optimizer_creates_correct_datasets_for_rank3_points(
                 if use_global_model:
                     exp_qps = tf.concat([exp_init_qps, tf.reshape(query_points, [-1, 1])], 0)
                 else:
-                    index = LocalTag.from_tag(self._tag).local_index
+                    index = LocalizedTag.from_tag(self._tag).local_index
                     exp_qps = tf.concat([exp_init_qps, query_points[:, index]], 0)
 
             npt.assert_array_equal(exp_qps, dataset.query_points)

--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -438,6 +438,8 @@ def test_ask_tell_optimizer_for_uncopyable_model(
     assert ask_tell.to_result(copy=False).final_result.is_ok
 
 
+# Check that the correct dataset is routed to the model.
+# Note: this test is almost identical to the one in test_bayesian_optimizer.py.
 @pytest.mark.parametrize("use_global_model", [True, False])
 @pytest.mark.parametrize("use_global_init_dataset", [True, False])
 @pytest.mark.parametrize("num_query_points_per_batch", [1, 2])

--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -180,7 +180,7 @@ def test_ask_tell_optimizer_copies_state(
     ask_tell.tell(new_data)
     state_end: Record[None] = ask_tell.to_record(copy=copy)
 
-    assert_datasets_allclose(state_start.dataset, init_dataset if copy else init_dataset + new_data)
+    assert_datasets_allclose(state_start.dataset, init_dataset)
     assert_datasets_allclose(state_end.dataset, init_dataset + new_data)
     assert state_start.model is not model if copy else state_start.model is model
 

--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -500,7 +500,7 @@ def test_ask_tell_optimizer_creates_correct_datasets_for_rank3_points(
     for tag, model in models.items():
         model._tag = tag
 
-    observer = mk_batch_observer(lambda x: Dataset(x, x), OBJECTIVE)
+    observer = mk_batch_observer(lambda x: Dataset(x, x))
     rule = FixedAcquisitionRule(query_points)
     ask_tell = AskTellOptimizer(search_space, init_data, models, rule)
 

--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import copy
 from typing import Mapping, Optional
 
 import numpy.testing as npt
@@ -503,7 +502,7 @@ def test_ask_tell_optimizer_creates_correct_datasets_for_rank3_points(
 
     observer = mk_batch_observer(lambda x: Dataset(x, x))
     rule = FixedAcquisitionRule(query_points)
-    ask_tell = AskTellOptimizer(search_space, copy.deepcopy(init_data), models, rule)
+    ask_tell = AskTellOptimizer(search_space, init_data, models, rule)
 
     points = ask_tell.ask()
     new_data = observer(points)

--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import copy
 from typing import Mapping, Optional
 
 import numpy.testing as npt
@@ -180,7 +181,7 @@ def test_ask_tell_optimizer_copies_state(
     ask_tell.tell(new_data)
     state_end: Record[None] = ask_tell.to_record(copy=copy)
 
-    assert_datasets_allclose(state_start.dataset, init_dataset)
+    assert_datasets_allclose(state_start.dataset, init_dataset if copy else init_dataset + new_data)
     assert_datasets_allclose(state_end.dataset, init_dataset + new_data)
     assert state_start.model is not model if copy else state_start.model is model
 
@@ -502,7 +503,7 @@ def test_ask_tell_optimizer_creates_correct_datasets_for_rank3_points(
 
     observer = mk_batch_observer(lambda x: Dataset(x, x))
     rule = FixedAcquisitionRule(query_points)
-    ask_tell = AskTellOptimizer(search_space, init_data, models, rule)
+    ask_tell = AskTellOptimizer(search_space, copy.deepcopy(init_data), models, rule)
 
     points = ask_tell.ask()
     new_data = observer(points)

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -46,7 +46,7 @@ from trieste.observer import OBJECTIVE, Observer
 from trieste.space import Box, SearchSpace
 from trieste.types import State, Tag, TensorType
 from trieste.utils import Err, Ok
-from trieste.utils.misc import LocalTag
+from trieste.utils.misc import LocalizedTag
 
 # tags
 FOO: Tag = "foo"
@@ -251,7 +251,7 @@ def test_bayesian_optimizer_creates_correct_datasets_for_rank3_points(
         init_data = {OBJECTIVE: mk_dataset([[0.5], [1.5]], [[0.25], [0.35]])}
     else:
         init_data = {
-            LocalTag(OBJECTIVE, i): mk_dataset([[0.5 + i], [1.5 + i]], [[0.25], [0.35]])
+            LocalizedTag(OBJECTIVE, i): mk_dataset([[0.5 + i], [1.5 + i]], [[0.25], [0.35]])
             for i in range(batch_size)
         }
         init_data[OBJECTIVE] = mk_dataset([[0.5], [1.5]], [[0.25], [0.35]])
@@ -284,7 +284,7 @@ def test_bayesian_optimizer_creates_correct_datasets_for_rank3_points(
                 if use_global_model:
                     exp_qps = tf.concat([exp_init_qps, tf.reshape(query_points, [-1, 1])], 0)
                 else:
-                    index = LocalTag.from_tag(self._tag).local_index
+                    index = LocalizedTag.from_tag(self._tag).local_index
                     exp_qps = tf.concat([exp_init_qps, query_points[:, index]], 0)
 
             npt.assert_array_equal(exp_qps, dataset.query_points)

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -259,7 +259,7 @@ def test_bayesian_optimizer_creates_correct_datasets_for_rank3_points(
         (num_query_points_per_batch, batch_size, 1),
     )
 
-    class DatasetChecker(_PseudoTrainableQuadratic):
+    class DatasetChecker(QuadraticMeanAndRBFKernel, PseudoTrainableProbModel):
         def __init__(self) -> None:
             super().__init__()
             self.update_count = 0

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import copy
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
@@ -302,7 +303,7 @@ def test_bayesian_optimizer_creates_correct_datasets_for_rank3_points(
 
     optimizer = BayesianOptimizer(lambda x: Dataset(x, x), search_space)
     rule = FixedAcquisitionRule(query_points)
-    optimizer.optimize(1, init_data, models, rule).final_result.unwrap()
+    optimizer.optimize(1, copy.deepcopy(init_data), models, rule).final_result.unwrap()
 
 
 @pytest.mark.parametrize("mode", ["early", "fail", "full"])

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -238,6 +238,8 @@ def test_bayesian_optimizer_calls_observer_once_per_iteration(steps: int) -> Non
     assert observer.call_count == steps
 
 
+# Check that the correct dataset is routed to the model.
+# Note: this test is almost identical to the one in test_ask_tell_optimization.py.
 @pytest.mark.parametrize("use_global_model", [True, False])
 @pytest.mark.parametrize("use_global_init_dataset", [True, False])
 @pytest.mark.parametrize("num_query_points_per_batch", [1, 2])

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import copy
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
@@ -303,7 +302,7 @@ def test_bayesian_optimizer_creates_correct_datasets_for_rank3_points(
 
     optimizer = BayesianOptimizer(lambda x: Dataset(x, x), search_space)
     rule = FixedAcquisitionRule(query_points)
-    optimizer.optimize(1, copy.deepcopy(init_data), models, rule).final_result.unwrap()
+    optimizer.optimize(1, init_data, models, rule).final_result.unwrap()
 
 
 @pytest.mark.parametrize("mode", ["early", "fail", "full"])

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from time import sleep
-from typing import Any
+from typing import Any, Optional, Union
 
 import numpy as np
 import numpy.testing as npt
@@ -23,9 +23,10 @@ import tensorflow as tf
 
 from tests.util.misc import TF_DEBUGGING_ERROR_TYPES, ShapeLike, various_shapes
 from trieste.observer import OBJECTIVE
-from trieste.types import TensorType
+from trieste.types import Tag, TensorType
 from trieste.utils.misc import (
     Err,
+    LocalTag,
     Ok,
     Timer,
     flatten_leading_dims,
@@ -101,7 +102,7 @@ def test_get_value_for_tag_returns_none_if_mapping_is_none() -> None:
 
 
 def test_get_value_for_tag_raises_if_tag_not_in_mapping() -> None:
-    with pytest.raises(ValueError, match="none of the tags '\['baz'\]' found in mapping"):
+    with pytest.raises(ValueError, match="none of the tags '.'baz'.' found in mapping"):
         get_value_for_tag({"foo": "bar"}, "baz")
 
 
@@ -117,6 +118,38 @@ def test_get_value_for_tag_returns_first_matching_tag() -> None:
     assert get_value_for_tag(
         {"foo": "bar", OBJECTIVE: "baz", "qux": "quux", "bar": "baz"}, ["far", "qux", "foo"]
     ) == ("qux", "quux")
+
+
+@pytest.mark.parametrize("tag_name", ["test_tag_1", "test_tag_2"])
+@pytest.mark.parametrize("tag_index", [0, 2, None])
+def test_local_tag_creation(tag_name: str, tag_index: Optional[int]) -> None:
+    tag = LocalTag(tag_name, tag_index)
+    is_local = True if tag_index is not None else False
+    exp_tag = f"{tag_name}__{tag_index}" if is_local else tag_name
+
+    assert tag.is_local == is_local
+    assert tag.global_tag == tag_name
+    assert tag.local_index == tag_index
+    assert tag == exp_tag
+    assert tag.tag == exp_tag
+    assert str(tag) == exp_tag
+    assert repr(tag) == f"LocalTag({tag_name}, {tag_index})"
+    assert hash(tag) == hash(exp_tag)
+
+
+@pytest.mark.parametrize(
+    "tag, exp_tag",
+    [
+        ("test_tag_1", LocalTag("test_tag_1", None)),
+        ("test_tag__2", LocalTag("test_tag", 2)),
+        (LocalTag("test_tag_1", 3), LocalTag("test_tag_1", 3)),
+        (LocalTag("test_tag", None), LocalTag("test_tag", None)),
+    ],
+)
+def test_local_tag_from_tag(tag: Union[Tag, LocalTag], exp_tag: LocalTag) -> None:
+    ltag = LocalTag.from_tag(tag)
+    assert ltag.global_tag == exp_tag.global_tag
+    assert ltag.local_index == exp_tag.local_index
 
 
 def test_Timer() -> None:

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -97,20 +97,26 @@ def test_err() -> None:
 
 
 def test_get_value_for_tag_returns_none_if_mapping_is_none() -> None:
-    assert get_value_for_tag(None) is None
+    assert get_value_for_tag(None) == (None, None)
 
 
 def test_get_value_for_tag_raises_if_tag_not_in_mapping() -> None:
-    with pytest.raises(ValueError, match="tag 'baz' not found in mapping"):
+    with pytest.raises(ValueError, match="none of the tags '\['baz'\]' found in mapping"):
         get_value_for_tag({"foo": "bar"}, "baz")
 
 
 def test_get_value_for_tag_returns_value_for_default_tag() -> None:
-    assert get_value_for_tag({"foo": "bar", OBJECTIVE: "baz"}) == "baz"
+    assert get_value_for_tag({"foo": "bar", OBJECTIVE: "baz"}) == (OBJECTIVE, "baz")
 
 
 def test_get_value_for_tag_returns_value_for_specified_tag() -> None:
-    assert get_value_for_tag({"foo": "bar", OBJECTIVE: "baz"}, "foo") == "bar"
+    assert get_value_for_tag({"foo": "bar", OBJECTIVE: "baz"}, "foo") == ("foo", "bar")
+
+
+def test_get_value_for_tag_returns_first_matching_tag() -> None:
+    assert get_value_for_tag(
+        {"foo": "bar", OBJECTIVE: "baz", "qux": "quux", "bar": "baz"}, ["far", "qux", "foo"]
+    ) == ("qux", "quux")
 
 
 def test_Timer() -> None:

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1010,8 +1010,8 @@ class UpdatableTrustRegion(SearchSpace):
     def _get_tags(self, tags: Set[Tag]) -> Tuple[Set[Tag], Set[Tag]]:
         # Separate tags into local (matching index) and global tags (without matching
         # local tag).
-        local_gtags = set()
-        global_tags = set()
+        local_gtags = set()  # Set of global part of all local tags.
+        global_tags = set()  # Set of all global tags.
         for tag in tags:
             ltag = LocalizedTag.from_tag(tag)
             if not ltag.is_local:

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -158,13 +158,19 @@ class AcquisitionRule(ABC, Generic[ResultType, SearchSpaceType, ProbabilisticMod
         :param new_datasets: The new datasets.
         :return: The updated datasets.
         """
-        # Account for the case where there may be an initial dataset that is not tagged
-        # per region. In this case, only the global dataset will exist in datasets. We
-        # want to copy this initial dataset to all the regions.
-        #
+        # In order to support local datasets, account for the case where there may be an initial
+        # dataset that is not tagged per region. In this case, only the global dataset will exist
+        # in datasets. We want to copy this initial dataset to all the regions.
         # If a tag from tagged_output does not exist in datasets, then add it to
-        # datasets by copying the dataset from datasets with the same tag-prefix.
-        # Otherwise keep the existing dataset from datasets.
+        # datasets by copying the data from datasets with the same global tag. Otherwise keep the
+        # existing data from datasets.
+        #
+        # Note: this replication of initial data can potentially cause an issue when a global model
+        # is being used with local datasets, as the points may be repeated. This will only be an
+        # issue if two regions overlap and both contain that initial data-point -- as filtering
+        # (in BatchTrustRegion) would otherwise remove duplicates. The main way to avoid the issue
+        # in this scenario is to provide local initial datasets, instead of a global initial
+        # dataset.
         updated_datasets = {}
         for tag in new_datasets:
             _, dataset = get_value_for_tag(datasets, [tag, LocalTag.from_tag(tag).global_tag])

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1072,7 +1072,7 @@ class UpdatableTrustRegion(SearchSpace):
         if datasets is None:
             return None
         else:
-            # Only keep points that are in the box.
+            # Only keep points that are in the region.
             return {
                 tag: self.contains(dataset.query_points)
                 for tag, dataset in datasets.items()

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -64,7 +64,7 @@ from ..models.interfaces import (
 from ..observer import OBJECTIVE
 from ..space import Box, SearchSpace, TaggedMultiSearchSpace
 from ..types import State, Tag, TensorType
-from ..utils.misc import LocalTag
+from ..utils.misc import LocalizedTag
 from .function import (
     BatchMonteCarloExpectedImprovement,
     ExpectedImprovement,
@@ -1010,7 +1010,7 @@ class UpdatableTrustRegion(SearchSpace):
         local_gtags = set()
         global_tags = set()
         for tag in tags:
-            ltag = LocalTag.from_tag(tag)
+            ltag = LocalizedTag.from_tag(tag)
             if not ltag.is_local:
                 global_tags.add(tag)
             elif ltag.local_index == self.region_index:
@@ -1035,7 +1035,9 @@ class UpdatableTrustRegion(SearchSpace):
         elif self.region_index is None:
             # If no index, then return the global models.
             _models = {
-                tag: model for tag, model in models.items() if not LocalTag.from_tag(tag).is_local
+                tag: model
+                for tag, model in models.items()
+                if not LocalizedTag.from_tag(tag).is_local
             }
         else:
             # Prefer matching local model for each tag, otherwise select the global model.
@@ -1043,7 +1045,7 @@ class UpdatableTrustRegion(SearchSpace):
 
             _models = {}
             for tag in local_gtags:
-                ltag = LocalTag(tag, self.region_index)
+                ltag = LocalizedTag(tag, self.region_index)
                 _models[ltag] = models[ltag]
             for tag in global_tags:
                 _models[tag] = models[tag]
@@ -1066,7 +1068,7 @@ class UpdatableTrustRegion(SearchSpace):
             _datasets = {
                 tag: dataset
                 for tag, dataset in datasets.items()
-                if not LocalTag.from_tag(tag).is_local
+                if not LocalizedTag.from_tag(tag).is_local
             }
         else:
             # Prefer matching local dataset for each tag, otherwise select the global dataset.
@@ -1074,7 +1076,7 @@ class UpdatableTrustRegion(SearchSpace):
 
             _datasets = {}
             for tag in local_gtags:
-                ltag = LocalTag(tag, self.region_index)
+                ltag = LocalizedTag(tag, self.region_index)
                 _datasets[ltag] = datasets[ltag]
             for tag in global_tags:
                 _datasets[tag] = datasets[tag]
@@ -1104,7 +1106,7 @@ class UpdatableTrustRegion(SearchSpace):
             return {
                 tag: self.contains(dataset.query_points)
                 for tag, dataset in datasets.items()
-                if LocalTag.from_tag(tag).local_index == self.region_index
+                if LocalizedTag.from_tag(tag).local_index == self.region_index
             }
 
 
@@ -1201,7 +1203,7 @@ class BatchTrustRegion(
 
         num_local_models: Dict[Tag, int] = defaultdict(int)
         for tag in models:
-            ltag = LocalTag.from_tag(tag)
+            ltag = LocalizedTag.from_tag(tag)
             if ltag.is_local:
                 num_local_models[ltag.global_tag] += 1
         num_local_models_vals = set(num_local_models.values())
@@ -1272,11 +1274,12 @@ class BatchTrustRegion(
                     # Remap all local tags to global ones. One reason is that single model
                     # acquisition builders expect OBJECTIVE to exist.
                     _models = {
-                        LocalTag.from_tag(tag).global_tag: model for tag, model in _models.items()
+                        LocalizedTag.from_tag(tag).global_tag: model
+                        for tag, model in _models.items()
                     }
                     if _datasets is not None:
                         _datasets = {
-                            LocalTag.from_tag(tag).global_tag: dataset
+                            LocalizedTag.from_tag(tag).global_tag: dataset
                             for tag, dataset in _datasets.items()
                         }
                     _points.append(rule.acquire(subspace, _models, _datasets))
@@ -1339,11 +1342,11 @@ class BatchTrustRegion(
         used_masks = {
             tag: tf.zeros(dataset.query_points.shape[:-1], dtype=tf.bool)
             for tag, dataset in datasets.items()
-            if LocalTag.from_tag(tag).is_local
+            if LocalizedTag.from_tag(tag).is_local
         }
 
         # Global datasets to re-generate.
-        global_tags = {LocalTag.from_tag(tag).global_tag for tag in used_masks}
+        global_tags = {LocalizedTag.from_tag(tag).global_tag for tag in used_masks}
 
         # Using init_subspaces here relies on the users not creating new subspaces after
         # initialization. This is a reasonable assumption for now.
@@ -1352,7 +1355,7 @@ class BatchTrustRegion(
             in_region_masks = subspace.get_datasets_filter_mask(datasets)
             if in_region_masks is not None:
                 for tag, in_region in in_region_masks.items():
-                    ltag = LocalTag.from_tag(tag)
+                    ltag = LocalizedTag.from_tag(tag)
                     assert ltag.is_local, f"can only filter local tags, got {tag}"
                     used_masks[tag] = tf.logical_or(used_masks[tag], in_region)
 
@@ -1370,7 +1373,7 @@ class BatchTrustRegion(
             local_datasets = [
                 value
                 for tag, value in filtered_datasets.items()
-                if LocalTag.from_tag(tag).global_tag == gtag
+                if LocalizedTag.from_tag(tag).global_tag == gtag
             ]
             # Note there is no ordering assumption for the local datasets. They are simply
             # concatenated and information about which local dataset they came from is lost.
@@ -1491,7 +1494,7 @@ class SingleObjectiveTrustRegionBox(Box, UpdatableTrustRegion):
         if (
             datasets is None
             or len(datasets) != 1
-            or LocalTag.from_tag(next(iter(datasets))).global_tag != OBJECTIVE
+            or LocalizedTag.from_tag(next(iter(datasets))).global_tag != OBJECTIVE
         ):
             raise ValueError("""a single OBJECTIVE dataset must be provided""")
         dataset = next(iter(datasets.values()))
@@ -1648,7 +1651,7 @@ class TREGOBox(SingleObjectiveTrustRegionBox):
             return {
                 tag: tf.ones(tf.shape(dataset.query_points)[:-1], dtype=tf.bool)
                 for tag, dataset in datasets.items()
-                if LocalTag.from_tag(tag).local_index == self.region_index
+                if LocalizedTag.from_tag(tag).local_index == self.region_index
             }
 
     @inherit_check_shapes
@@ -1659,7 +1662,7 @@ class TREGOBox(SingleObjectiveTrustRegionBox):
         if (
             datasets is None
             or len(datasets) != 1
-            or LocalTag.from_tag(next(iter(datasets))).global_tag != OBJECTIVE
+            or LocalizedTag.from_tag(next(iter(datasets))).global_tag != OBJECTIVE
         ):
             raise ValueError("""a single OBJECTIVE dataset must be provided""")
         dataset = next(iter(datasets.values()))

--- a/trieste/acquisition/utils.py
+++ b/trieste/acquisition/utils.py
@@ -19,10 +19,11 @@ import tensorflow as tf
 from check_shapes import check_shapes
 
 from ..data import Dataset
-from ..models.interfaces import ProbabilisticModel
+from ..models import ProbabilisticModelType
 from ..observer import OBJECTIVE
 from ..space import SearchSpaceType
 from ..types import Tag, TensorType
+from ..utils.misc import LocalTag
 from .interface import AcquisitionFunction
 from .optimizer import AcquisitionOptimizer
 
@@ -142,10 +143,10 @@ def get_local_dataset(local_space: SearchSpaceType, dataset: Dataset) -> Dataset
 
 
 def copy_to_local_models(
-    global_model: ProbabilisticModel,
+    global_model: ProbabilisticModelType,
     num_local_models: int,
     key: Tag = OBJECTIVE,
-) -> Mapping[Tag, ProbabilisticModel]:
+) -> Mapping[Tag, ProbabilisticModelType]:
     """
     Helper method to copy a global model to local models.
 
@@ -154,7 +155,7 @@ def copy_to_local_models(
     :param key: The tag prefix for the local models.
     :return: A mapping of the local models.
     """
-    return {f"{key}__{i}": copy.deepcopy(global_model) for i in range(num_local_models)}
+    return {LocalTag(key, i).tag: copy.deepcopy(global_model) for i in range(num_local_models)}
 
 
 @check_shapes(

--- a/trieste/acquisition/utils.py
+++ b/trieste/acquisition/utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import copy
 import functools
-from typing import Mapping, Sequence, Tuple, Union
+from typing import Mapping, Tuple, Union
 
 import tensorflow as tf
 from check_shapes import check_shapes
@@ -155,25 +155,6 @@ def copy_to_local_models(
     :return: A mapping of the local models.
     """
     return {f"{key}__{i}": copy.deepcopy(global_model) for i in range(num_local_models)}
-
-
-def stack_datasets(datasets: Sequence[Dataset]) -> Dataset:
-    """
-    Stack a sequence of datasets along a new second batch axis.
-
-    :param datasets: A sequence of datasets.
-    :return: A dataset whose query points and observations are the stack of the query points
-        and observations in ``datasets`` along the second axis.
-    :raise ValueError: If ``datasets`` is empty.
-    :raise InvalidArgumentError: If the shapes of the query points in ``datasets`` differ in any
-        but the first dimension. The same applies for observations.
-    """
-    if not datasets:
-        raise ValueError("datasets must be non-empty")
-
-    qps = tf.stack([dataset.query_points for dataset in datasets], axis=1)
-    obs = tf.stack([dataset.observations for dataset in datasets], axis=1)
-    return Dataset(tf.reshape(qps, [-1, qps.shape[-1]]), tf.reshape(obs, [-1, obs.shape[-1]]))
 
 
 @check_shapes(

--- a/trieste/acquisition/utils.py
+++ b/trieste/acquisition/utils.py
@@ -11,15 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import functools
-from typing import Tuple, Union
+from typing import Mapping, Tuple, Union
 
 import tensorflow as tf
 from check_shapes import check_shapes
 
 from ..data import Dataset
+from ..models.interfaces import ProbabilisticModel
+from ..observer import OBJECTIVE
 from ..space import SearchSpaceType
-from ..types import TensorType
+from ..types import Tag, TensorType
 from .interface import AcquisitionFunction
 from .optimizer import AcquisitionOptimizer
 
@@ -136,6 +139,22 @@ def get_local_dataset(local_space: SearchSpaceType, dataset: Dataset) -> Dataset
         observations=tf.boolean_mask(dataset.observations, is_in_region_mask),
     )
     return local_dataset
+
+
+def copy_to_local_models(
+    global_model: ProbabilisticModel,
+    num_local_models: int,
+    key: Tag = OBJECTIVE,
+) -> Mapping[Tag, ProbabilisticModel]:
+    """
+    Helper method to copy a global model to local models.
+
+    :param global_model: The global model.
+    :param num_local_models: The number of local models to create.
+    :param key: The tag prefix for the local models.
+    :return: A mapping of the local models.
+    """
+    return {f"{key}__{i}": copy.deepcopy(global_model) for i in range(num_local_models)}
 
 
 @check_shapes(

--- a/trieste/acquisition/utils.py
+++ b/trieste/acquisition/utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import copy
 import functools
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Sequence, Tuple, Union
 
 import tensorflow as tf
 from check_shapes import check_shapes
@@ -155,6 +155,25 @@ def copy_to_local_models(
     :return: A mapping of the local models.
     """
     return {f"{key}__{i}": copy.deepcopy(global_model) for i in range(num_local_models)}
+
+
+def stack_datasets(datasets: Sequence[Dataset]) -> Dataset:
+    """
+    Stack a sequence of datasets along a new second batch axis.
+
+    :param datasets: A sequence of datasets.
+    :return: A dataset whose query points and observations are the stack of the query points
+        and observations in ``datasets`` along the second axis.
+    :raise ValueError: If ``datasets`` is empty.
+    :raise InvalidArgumentError: If the shapes of the query points in ``datasets`` differ in any
+        but the first dimension. The same applies for observations.
+    """
+    if not datasets:
+        raise ValueError("datasets must be non-empty")
+
+    qps = tf.stack([dataset.query_points for dataset in datasets], axis=1)
+    obs = tf.stack([dataset.observations for dataset in datasets], axis=1)
+    return Dataset(tf.reshape(qps, [-1, qps.shape[-1]]), tf.reshape(obs, [-1, obs.shape[-1]]))
 
 
 @check_shapes(

--- a/trieste/acquisition/utils.py
+++ b/trieste/acquisition/utils.py
@@ -23,7 +23,7 @@ from ..models import ProbabilisticModelType
 from ..observer import OBJECTIVE
 from ..space import SearchSpaceType
 from ..types import Tag, TensorType
-from ..utils.misc import LocalTag
+from ..utils.misc import LocalizedTag
 from .interface import AcquisitionFunction
 from .optimizer import AcquisitionOptimizer
 
@@ -155,7 +155,7 @@ def copy_to_local_models(
     :param key: The tag prefix for the local models.
     :return: A mapping of the local models.
     """
-    return {LocalTag(key, i).tag: copy.deepcopy(global_model) for i in range(num_local_models)}
+    return {LocalizedTag(key, i): copy.deepcopy(global_model) for i in range(num_local_models)}
 
 
 @check_shapes(

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -187,6 +187,9 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
         if not datasets or not models:
             raise ValueError("dicts of datasets and models must be populated.")
 
+        # Copy the dataset so we don't change the one provided by the user.
+        datasets = deepcopy(datasets)
+
         if isinstance(datasets, Dataset):
             datasets = {OBJECTIVE: datasets}
         if not isinstance(models, Mapping):

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -446,10 +446,9 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
 
         with Timer() as model_fitting_timer:
             for tag, model in self._models.items():
-                # Prefer local dataset if available.
-                tags = [tag, LocalTag.from_tag(tag).global_tag]
-                _, dataset = get_value_for_tag(self._datasets, tags)
-                assert dataset is not None
+                # Always use the matching dataset to the model. If the model is
+                # local, then the dataset should be too by this stage.
+                dataset = self._datasets[tag]
                 model.update(dataset)
                 model.optimize_and_save_result(dataset)
 

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -192,7 +192,10 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
         if not isinstance(models, Mapping):
             models = {OBJECTIVE: models}
 
+        self._filtered_datasets = datasets
+
         # reassure the type checker that everything is tagged
+        datasets = cast(Dict[Tag, Dataset], datasets)
         models = cast(Dict[Tag, TrainableProbabilisticModelType], models)
 
         # Get set of dataset and model keys, ignoring any local tag index. That is, only the
@@ -206,7 +209,6 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
             )
 
         self._datasets = datasets
-        self._filtered_datasets = datasets
         self._models = models
 
         self._query_plot_dfs: dict[int, pd.DataFrame] = {}

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -436,7 +436,11 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
         if isinstance(new_data, Dataset):
             new_data = {OBJECTIVE: new_data}
 
-        if self._datasets.keys() != new_data.keys():
+        # The datasets must have the same keys as the existing datasets. Only exception is if
+        # the existing datasets are all global, in which case the dataset will be appropriately
+        # updated below for the next iteration.
+        datasets_indices = {LocalTag.from_tag(tag).local_index for tag in self._datasets.keys()}
+        if self._datasets.keys() != new_data.keys() and datasets_indices != {None}:
             raise ValueError(
                 f"new_data keys {new_data.keys()} doesn't "
                 f"match dataset keys {self._datasets.keys()}"

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -635,6 +635,9 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
             - ``datasets`` or ``models`` are empty
             - the default `acquisition_rule` is used and the tags are not `OBJECTIVE`.
         """
+        # Copy the dataset so we don't change the one provided by the user.
+        datasets = copy.deepcopy(datasets)
+
         if isinstance(datasets, Dataset):
             datasets = {OBJECTIVE: datasets}
         if not isinstance(models, Mapping):

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -757,8 +757,9 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                     # If query_points are rank 3, then use a batched observer.
                     if tf.rank(query_points) == 3:
                         num_objective_models = len(
-                            [tag for tag in models if tag.split("__")[0] == OBJECTIVE]
+                            [tag for tag in models if "__" in tag and tag.split("__")[0] == OBJECTIVE]
                         )
+                        num_objective_models = max(num_objective_models, 1)
                         observer = mk_batch_observer(observer, num_objective_models, OBJECTIVE)
                     observer_output = observer(query_points)
 

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -911,7 +911,11 @@ def write_summary_initial_model_fit(
     """Write TensorBoard summary for the model fitting to the initial data."""
     for tag, model in models.items():
         with tf.name_scope(f"{tag}.model"):
-            model.log(datasets[tag])
+            # Prefer local dataset if available.
+            tags = [tag, LocalTag.from_tag(tag).global_tag]
+            _, dataset = get_value_for_tag(datasets, tags)
+            assert dataset is not None
+            model.log(dataset)
     logging.scalar(
         "wallclock/model_fitting",
         model_fitting_timer.time,

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -764,7 +764,7 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                     observer = self._observer
                     # If query_points are rank 3, then use a batched observer.
                     if tf.rank(query_points) == 3:
-                        observer = mk_batch_observer(observer, OBJECTIVE)
+                        observer = mk_batch_observer(observer)
                     observer_output = observer(query_points)
 
                     tagged_output = (

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -778,10 +778,9 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                     with Timer() as model_fitting_timer:
                         if fit_model:
                             for tag, model in models.items():
-                                # Prefer local dataset if available.
-                                tags = [tag, LocalTag.from_tag(tag).global_tag]
-                                _, dataset = get_value_for_tag(datasets, tags)
-                                assert dataset is not None
+                                # Always use the matching dataset to the model. If the model is
+                                # local, then the dataset should be too by this stage.
+                                dataset = datasets[tag]
                                 model.update(dataset)
                                 model.optimize_and_save_result(dataset)
 
@@ -959,7 +958,7 @@ def write_summary_observations(
     observation_plot_dfs: MutableMapping[Tag, pd.DataFrame],
 ) -> None:
     """Write TensorBoard summary for the current step observations."""
-    for tag in datasets:
+    for tag in models:
         with tf.name_scope(f"{tag}.model"):
             models[tag].log(datasets[tag])
 

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -769,17 +769,7 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                         else {OBJECTIVE: observer_output}
                     )
 
-                    # Account for the case where there may be an initial dataset that is not tagged
-                    # per region. In this case, only the global dataset will exist in datasets. We
-                    # want to copy this initial dataset to all the regions.
-                    #
-                    # If a tag from tagged_output does not exist in datasets, then add it to
-                    # datasets by copying the dataset from datasets with the same tag-prefix.
-                    # Otherwise keep the existing dataset from datasets.
-                    datasets = {
-                        tag: get_value_for_tag(datasets, [tag, tag.split("__")[0]]) + tagged_output[tag]
-                        for tag in tagged_output
-                    }
+                    datasets = acquisition_rule.update_datasets(datasets, tagged_output)
 
                     with Timer() as model_fitting_timer:
                         if fit_model:

--- a/trieste/experimental/plotting/plotting.py
+++ b/trieste/experimental/plotting/plotting.py
@@ -37,7 +37,7 @@ from trieste.observer import OBJECTIVE
 from trieste.space import TaggedMultiSearchSpace
 from trieste.types import TensorType
 from trieste.utils import to_numpy
-from trieste.utils.misc import LocalTag
+from trieste.utils.misc import LocalizedTag
 
 
 def create_grid(
@@ -597,7 +597,7 @@ def plot_trust_region_history_2d(
     # Otherwise, use the global dataset and assume the last `num_query_points` points are new.
     if len(history.datasets) > 1:
         # Expect there to be an objective dataset for each subspace.
-        datasets = [history.datasets[LocalTag(OBJECTIVE, i)] for i in range(len(spaces))]
+        datasets = [history.datasets[LocalizedTag(OBJECTIVE, i)] for i in range(len(spaces))]
 
         _new_points_mask = [
             np.zeros(dataset.query_points.shape[0], dtype=bool) for dataset in datasets

--- a/trieste/experimental/plotting/plotting.py
+++ b/trieste/experimental/plotting/plotting.py
@@ -236,7 +236,7 @@ def plot_acq_function_2d(
 
 def format_point_markers(
     num_pts: int,
-    num_init: Optional[int] = None,
+    num_init: Optional[Union[int, TensorType]] = None,
     idx_best: Optional[TensorType] = None,
     mask_fail: Optional[TensorType] = None,
     m_init: str = "x",
@@ -249,7 +249,7 @@ def format_point_markers(
     Prepares point marker styles according to some BO factors.
 
     :param num_pts: total number of BO points
-    :param num_init: initial number of BO points
+    :param num_init: initial number of BO points; can also be a mask
     :param idx_best: index of the best BO point(s)
     :param mask_fail: Bool vector, True if the corresponding observation violates the constraint(s)
     :param m_init: marker for the initial BO points
@@ -264,7 +264,10 @@ def format_point_markers(
     col_pts = np.repeat(c_pass, num_pts)
     col_pts = col_pts.astype("<U15")
     mark_pts = np.repeat(m_init, num_pts)
-    mark_pts[num_init:] = m_add
+    if isinstance(num_init, int):
+        mark_pts[num_init:] = m_add
+    else:
+        mark_pts[np.where(~num_init)] = m_add
     if mask_fail is not None:
         col_pts[np.where(mask_fail)] = c_fail
     if idx_best is not None:
@@ -276,7 +279,7 @@ def format_point_markers(
 def plot_bo_points(
     pts: TensorType,
     ax: Axes,
-    num_init: Optional[int] = None,
+    num_init: Optional[Union[int, TensorType]] = None,
     idx_best: Optional[int] = None,
     mask_fail: Optional[TensorType] = None,
     obs_values: Optional[TensorType] = None,
@@ -292,7 +295,7 @@ def plot_bo_points(
 
     :param pts: [N, 2] x inputs
     :param ax: a plt axes object
-    :param num_init: initial number of BO points
+    :param num_init: initial number of BO points; can also be a mask
     :param idx_best: index of the best BO point
     :param mask_fail: Bool vector, True if the corresponding observation violates the constraint(s)
     :param obs_values: optional [N] outputs (for 3d plots)
@@ -590,13 +593,12 @@ def plot_trust_region_history_2d(
     if num_query_points is None:
         num_query_points = len(spaces)
 
-    query_points = history.dataset.query_points  # All query points.
-
     # If there are local datasets, use them to generate the colors for the query points.
     # Otherwise, use the global dataset and assume the last `num_query_points` points are new.
     if len(history.datasets) > 1:
         # Expect there to be an objective dataset for each subspace.
         datasets = [history.datasets[LocalTag(OBJECTIVE, i)] for i in range(len(spaces))]
+
         _new_points_mask = [
             np.zeros(dataset.query_points.shape[0], dtype=bool) for dataset in datasets
         ]
@@ -605,7 +607,21 @@ def plot_trust_region_history_2d(
             mask[-1] = True
         # Concatenate the masks.
         new_points_mask = np.concatenate(_new_points_mask)
+
+        if num_init is not None:
+            _num_init_mask = [
+                np.zeros(dataset.query_points.shape[0], dtype=bool) for dataset in datasets
+            ]
+            # First num_init points in each dataset are the init points.
+            for mask in _num_init_mask:
+                mask[:num_init] = True
+            # Concatenate the masks.
+            num_init = np.concatenate(_num_init_mask)
+
+        # Get the overall query points.
+        query_points = np.concatenate([dataset.query_points for dataset in datasets])
     else:
+        query_points = history.dataset.query_points  # All query points.
         new_points_mask = np.zeros(query_points.shape[0], dtype=bool)
         new_points_mask[-num_query_points:] = True
 

--- a/trieste/objectives/utils.py
+++ b/trieste/objectives/utils.py
@@ -106,12 +106,13 @@ def mk_batch_observer(
                 # If batch size is 1, just return the dataset as is, i.e. use the global dataset.
                 return {key: obs_or_dataset}
             else:
-                # Include per batch dataset.
+                # Include overall dataset and per batch dataset.
                 obs = obs_or_dataset.observations
                 qps = tf.reshape(qps, [-1, batch_size, qps.shape[-1]])
                 obs = tf.reshape(obs, [-1, batch_size, obs.shape[-1]])
                 datasets: Mapping[Tag, Dataset] = {
-                    **{LocalTag(key, i): Dataset(qps[:, i], obs[:, i]) for i in range(batch_size)}
+                    key: obs_or_dataset,
+                    **{LocalTag(key, i): Dataset(qps[:, i], obs[:, i]) for i in range(batch_size)},
                 }
                 return datasets
 

--- a/trieste/objectives/utils.py
+++ b/trieste/objectives/utils.py
@@ -79,9 +79,6 @@ def mk_batch_observer(
     """
 
     @check_shapes("qps: [n_points, batch_size, n_dims]")
-    # Note that the return type is not correct, but that is what mypy is happy with. It should be
-    # Mapping[Tag, Dataset] if key is not None, otherwise Dataset.
-    # One solution is to create two separate functions, but that will result in some duplicate code.
     def _observer(qps: TensorType) -> Mapping[Tag, Dataset]:
         # Call objective with rank 2 query points by flattening batch dimension.
         # Some objectives might only expect rank 2 query points, so this is safer.

--- a/trieste/objectives/utils.py
+++ b/trieste/objectives/utils.py
@@ -77,7 +77,6 @@ def mk_batch_observer(
     :return: A multi-observer across the batch dimension of query points, returning the data from
         ``objective``. If ``key`` is provided, the observer will be a mapping. Otherwise, it will
         return a single dataset.
-    :raise ValueError (or tf.errors.InvalidArgumentError): If the query points are not rank 3.
     :raise ValueError (or tf.errors.InvalidArgumentError): If ``objective_or_observer`` is a
         multi-observer.
     """

--- a/trieste/objectives/utils.py
+++ b/trieste/objectives/utils.py
@@ -102,18 +102,14 @@ def mk_batch_observer(
             # Always use rank 2 shape as models (e.g. GPR) expect this, so return as is.
             return obs_or_dataset
         else:
-            if batch_size == 1:
-                # If batch size is 1, just return the dataset as is, i.e. use the global dataset.
-                return {key: obs_or_dataset}
-            else:
-                # Include overall dataset and per batch dataset.
-                obs = obs_or_dataset.observations
-                qps = tf.reshape(qps, [-1, batch_size, qps.shape[-1]])
-                obs = tf.reshape(obs, [-1, batch_size, obs.shape[-1]])
-                datasets: Mapping[Tag, Dataset] = {
-                    key: obs_or_dataset,
-                    **{LocalTag(key, i): Dataset(qps[:, i], obs[:, i]) for i in range(batch_size)},
-                }
-                return datasets
+            # Include overall dataset and per batch dataset.
+            obs = obs_or_dataset.observations
+            qps = tf.reshape(qps, [-1, batch_size, qps.shape[-1]])
+            obs = tf.reshape(obs, [-1, batch_size, obs.shape[-1]])
+            datasets: Mapping[Tag, Dataset] = {
+                key: obs_or_dataset,
+                **{LocalTag(key, i): Dataset(qps[:, i], obs[:, i]) for i in range(batch_size)},
+            }
+            return datasets
 
     return _observer

--- a/trieste/utils/misc.py
+++ b/trieste/utils/misc.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from time import perf_counter
 from types import TracebackType
-from typing import Any, Callable, Generic, Mapping, NoReturn, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, Generic, Mapping, NoReturn, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 import numpy as np
 import tensorflow as tf
@@ -220,21 +220,26 @@ T = TypeVar("T")
 """ An unbound type variable. """
 
 
-def get_value_for_tag(mapping: Optional[Mapping[Tag, T]], tag: Tag = OBJECTIVE) -> Optional[T]:
-    """Return the value of a tag in a mapping.
+def get_value_for_tag(
+    mapping: Optional[Mapping[Tag, T]], tags: Union[Tag, Sequence[Tag]] = OBJECTIVE
+) -> Optional[T]:
+    """Return the value from a mapping for the first tag found from a sequence of tags.
 
     :param mapping: A mapping from tags to values.
-    :param tag: A tag.
+    :param tags: A tag or a sequence of tags. Sequence is searched in order.
     :return: The value of the tag in the mapping, or None if the mapping is None.
-    :raises ValueError: If the tag is not in the mapping and the mapping is not None.
+    :raises ValueError: If none of the tags are in the mapping and the mapping is not None.
     """
+
+    if isinstance(tags, Tag):
+        tags = [tags]
 
     if mapping is None:
         return None
-    elif tag in mapping.keys():
-        return mapping[tag]
+    elif matched_tags := sorted(set(tags) & set(mapping.keys()), key = tags.index):
+        return mapping[matched_tags[0]]
     else:
-        raise ValueError(f"tag '{tag}' not found in mapping")
+        raise ValueError(f"none of the tags '{tags}' found in mapping")
 
 
 class Timer:

--- a/trieste/utils/misc.py
+++ b/trieste/utils/misc.py
@@ -266,8 +266,8 @@ class LocalTag:
     local_index: Optional[int]
 
     def __post_init__(self) -> None:
-        if self.is_local and (self.local_index is None or self.local_index < 0):
-            raise ValueError("local index must be non-negative")
+        if self.local_index is not None and self.local_index < 0:
+            raise ValueError(f"local index must be non-negative, got {self.local_index}")
 
     @property
     def is_local(self) -> bool:

--- a/trieste/utils/misc.py
+++ b/trieste/utils/misc.py
@@ -227,7 +227,8 @@ def get_value_for_tag(
     """Return the value from a mapping for the first tag found from a sequence of tags.
 
     :param mapping: A mapping from tags to values.
-    :param tags: A tag or a sequence of tags. Sequence is searched in order.
+    :param tags: A tag or a sequence of tags. Sequence is searched in order. If no tags are
+        provided, the default tag OBJECTIVE is used.
     :return: The chosen tag and value of the tag in the mapping, or None for each if the mapping is
         None.
     :raises ValueError: If none of the tags are in the mapping and the mapping is not None.
@@ -271,6 +272,16 @@ class LocalizedTag:
             return tag
         else:
             return LocalizedTag(tag, None)
+
+
+def ignoring_local_tags(mapping: Mapping[Tag, T]) -> Mapping[Tag, T]:
+    """
+    Filter out local tags from a mapping, returning a new mapping with only global tags.
+
+    :param mapping: A mapping from tags to values.
+    :return: A new mapping with only global tags.
+    """
+    return {k: v for k, v in mapping.items() if not LocalizedTag.from_tag(k).is_local}
 
 
 class Timer:

--- a/trieste/utils/misc.py
+++ b/trieste/utils/misc.py
@@ -250,10 +250,12 @@ def get_value_for_tag(
 
     if mapping is None:
         return None, None
-    elif matched_tags := sorted(set(tags) & set(mapping.keys()), key=tags.index):
-        return matched_tags[0], mapping[matched_tags[0]]
     else:
-        raise ValueError(f"none of the tags '{tags}' found in mapping")
+        matched_tags = sorted(set(tags) & set(mapping.keys()), key=tags.index)
+        if matched_tags:
+            return matched_tags[0], mapping[matched_tags[0]]
+        else:
+            raise ValueError(f"none of the tags '{tags}' found in mapping")
 
 
 @dataclass(frozen=True)

--- a/trieste/utils/misc.py
+++ b/trieste/utils/misc.py
@@ -21,7 +21,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    List,
     Mapping,
     NoReturn,
     Optional,
@@ -281,42 +280,35 @@ class LocalTag:
         else:
             return self.global_tag
 
+    def __repr__(self) -> str:
+        """Return the local tag."""
+        return f"LocalTag({self.global_tag}, {self.local_index})"
+
     def __str__(self) -> str:
         """Return the local tag."""
         return str(self.tag)
 
     def __hash__(self) -> int:
-        """Return the hash of the local tag."""
+        """Return the hash of the overall tag."""
         return hash(self.tag)
 
     def __eq__(self, other: object) -> bool:
         """Return True if the local tag is equal to the other object."""
-        return isinstance(other, LocalTag) and self.tag == other.tag
+        return hash(self) == hash(other)
 
     @staticmethod
-    def from_tag(tag: Tag) -> LocalTag:
+    def from_tag(tag: Union[Tag, LocalTag]) -> LocalTag:
         """Return a LocalTag from a given tag."""
-        tag = str(tag)
-        if "__" in tag:
-            global_tag, _local_index = tag.split("__")
-            local_index = int(_local_index)
+        if isinstance(tag, LocalTag):
+            return tag
         else:
-            global_tag, local_index = tag, None
-        return LocalTag(global_tag, local_index)
-
-
-def get_values_for_tag_prefix(mapping: Mapping[Tag, T], tag_prefix: Tag = OBJECTIVE) -> List[T]:
-    """
-    Return a mapping from tags to values for all tags in ``mapping`` that start with ``tag_prefix``.
-
-    :param mapping: A mapping from tags to values.
-    :param tag_prefix: A tag prefix.
-    :return: A list of values from ``mapping`` for all tags in ``mapping`` that start with
-        ``tag_prefix``.
-    """
-    return [
-        value for tag, value in mapping.items() if LocalTag.from_tag(tag).global_tag == tag_prefix
-    ]
+            tag = str(tag)
+            if "__" in tag:
+                global_tag, _local_index = tag.split("__")
+                local_index = int(_local_index)
+            else:
+                global_tag, local_index = tag, None
+            return LocalTag(global_tag, local_index)
 
 
 class Timer:


### PR DESCRIPTION
**Related issue(s)/PRs:** #782 <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
This PR adds support for local models and datasets. The following scenarios are supported:
- global model and global dataset -- as previously
- local models and local datasets -- one-to-one mapping
- global model and local datasets -- many-to-one mapping

The initial dataset can be a global dataset sampled from the whole search space. This data will be replicated to each of the regions on the first iteration and subsequently each region will have an associated local dataset. For batch-TR algorithm, the dataset for each region are filtered after each iteration to only contain the points in the region (but `TREGO` doesn't do this).

Note: this replication of initial data can potentially cause an issue when a global model is being used, as the points may be repeated. This will only be an issue if regions overlap and both contain that initial data-point (as filtering would otherwise remove duplicates). The main way to avoid this issue is to provide local initial datasets, instead of a global initial dataset.

~~The `trust_region` notebook contains a new temporary `TEST` section, just to show how local models can be used in the notebook. It is worth noting in the `gif` that the query-points are filtered to be only inside the boxes for each iteration. This section is only for demonstration and will be removed before merging this PR. A follow-on PR will update the `TURBO` section to use local models and demonstrate this functionality.~~

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** no

<!-- if not, include a short justification -->
The `BatchTrustRegion` rule acquisition returns rank 3 points, instead of rank 2 as for other rules (and previous trust-region rules). This means the users should use the new batched observer with this rule. That is already taken care of in `BayesianOptimizer`. However, with `AskTellOptimizer` the users should use the batched observer as follows:

``` python
from trieste.objectives.utils import mk_batch_observer

observer = ...
batch_observer = mk_batch_observer(observer)

new_points = ask_tell.ask()
new_data = batch_observer(new_points)
ask_tell.tell(new_data)
```

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [X] Any new features are well-documented (in docstrings or notebooks)
