### PR TITLE
Make IndependentReparametrizationSampler create variables at init

### DIFF
--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -100,7 +100,9 @@ class IndependentReparametrizationSampler(ReparametrizationSampler[Probabilistic
         :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
         """
         super().__init__(sample_size, model)
-        self._eps: Optional[tf.Variable] = None
+        self._eps = tf.Variable(
+            tf.zeros(shape=(sample_size, 0), dtype=tf.float64), shape=(sample_size, None), dtype=tf.float64
+        )
         self._qmc = qmc
         self._qmc_skip = qmc_skip
 
@@ -140,9 +142,6 @@ class IndependentReparametrizationSampler(ReparametrizationSampler[Probabilistic
                     [self._sample_size, tf.shape(mean)[-1]], dtype=tf.float64
                 )
             return normal_samples  # [S, L]
-
-        if self._eps is None:
-            self._eps = tf.Variable(sample_eps())
 
         tf.cond(
             self._initialized,

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -101,7 +101,9 @@ class IndependentReparametrizationSampler(ReparametrizationSampler[Probabilistic
         """
         super().__init__(sample_size, model)
         self._eps = tf.Variable(
-            tf.zeros(shape=(sample_size, 0), dtype=tf.float64), shape=(sample_size, None), dtype=tf.float64
+            tf.zeros(shape=(sample_size, 0), dtype=tf.float64),
+            shape=(sample_size, None),
+            dtype=tf.float64,
         )
         self._qmc = qmc
         self._qmc_skip = qmc_skip


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Make `IndependentReparametrizationSampler` create variables at init. Without this you cannot always save the sampler with dynamic shape (i.e. before sample has been called).
...

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes / no

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
