### PR TITLE
Avoid use of python bool in qmc_normal_samples

### DIFF
--- a/tests/unit/models/gpflow/test_sampler.py
+++ b/tests/unit/models/gpflow/test_sampler.py
@@ -942,7 +942,7 @@ def test_qmc_samples_shapes(num_samples: int, n_sample_dim: int) -> None:
 
 
 def test_qmc_samples__save_as_tf_function(tmp_path: Path) -> None:
-    def get_samples():
+    def get_samples() -> tf.Tensor:
         return qmc_normal_samples(
             num_samples=tf.constant(5),
             n_sample_dim=tf.constant(2),

--- a/tests/unit/models/gpflow/test_sampler.py
+++ b/tests/unit/models/gpflow/test_sampler.py
@@ -941,12 +941,16 @@ def test_qmc_samples_shapes(num_samples: int, n_sample_dim: int) -> None:
     assert samples.shape == expected_samples_shape
 
 
-def test_qmc_samples__save_as_tf_function(tmp_path: Path) -> None:
+@pytest.mark.parametrize("decorate_with_tf_function", [True, False])
+def test_qmc_samples__save_as_tf_function(tmp_path: Path, decorate_with_tf_function: bool) -> None:
     def get_samples() -> tf.Tensor:
         return qmc_normal_samples(
             num_samples=tf.constant(5),
             n_sample_dim=tf.constant(2),
         )
+
+    if decorate_with_tf_function:
+        get_samples = tf.function(get_samples)
 
     module = tf.Module()
     module.get_samples = tf.function(


### PR DESCRIPTION
Avoid use of python `if` statement in `qmc_normal_samples` which prevents it, or any code which calls it, from being saved as a `tf.module`.

## Summary

`qmc_normal_samples` contains a precondition check to handle the edge cases where the number of samples is zero, or the sample dim is zero. This was implemented using a python `if` statement, but this means that the function can't be saved as a `tf.function`. 

The error raised if you try this is:

```
tensorflow.python.framework.errors_impl.OperatorNotAllowedInGraphError: Using a symbolic `tf.Tensor` as a Python `bool` is not allowed: AutoGraph is disabled in this function. Try decorating it directly with @tf.function.
``` 

As the error message suggests, this can be worked around by ensuring that any usages of `qmc_normal_samples` are wrapped in `tf.function`, but this seems like an unnecessary burden to place on calling code when we can just replace the problematic `if` statement with `tf.cond` instead.

...

**Fully backwards compatible:** yes 

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [x] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
