### PR TITLE
ScipyOptimizer

### DIFF
--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -41,6 +41,7 @@ from ..utils import (
     write_summary_kernel_parameters,
     write_summary_likelihood_parameters,
 )
+from .optimizer import ScipyOptimizer
 from .sampler import BatchReparametrizationSampler
 
 
@@ -57,10 +58,10 @@ class GPflowPredictor(
     def __init__(self, optimizer: Optimizer | None = None):
         """
         :param optimizer: The optimizer with which to train the model. Defaults to
-            :class:`~trieste.models.optimizer.Optimizer` with :class:`~gpflow.optimizers.Scipy`.
+            :class:`~trieste.models.gpflow.optimizers.ScipyOptimizer`
         """
         if optimizer is None:
-            optimizer = Optimizer(gpflow.optimizers.Scipy(), compile=True)
+            optimizer = ScipyOptimizer(compile=True)
 
         self._optimizer = optimizer
         self._posterior: Optional[BasePosterior] = None


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

Resolves #793 

## Summary

This PR introduces a `ScipyOptimizer` class for GPFlow Modules that automatically extracts parameter bounds and passes them to `gpflow.optimizers.Scipy`. This fixes an issue where `unconstrained_variables` that are actually constrained under the prior cause model fitting to fail. 

Additionally, this PR fixes a bug in `resample_hyperparameters` where `prior_on` was ignored.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** no

<!-- if not, include a short justification -->

There are edge-cases which may cause this code to fail. For example, `Scipy` may choose to filter out parameters that it deems inactive and, in so doing, cause the provided bounds to be misspecified (since it does not filter out the corresponding bounds).

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
