### PR TITLE
Use int64 when calculating data size in split_acquisition_function

### DIFF
--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -192,6 +192,9 @@ def generate_continuous_optimizer(
     If all `num_optimization_runs` optimizations fail to converge then we run
     `num_recovery_runs` additional runs starting from random locations (also ran in parallel).
 
+    **Note:** using a large number of `num_initial_samples` and `num_optimization_runs` with a
+    high-dimensional search space can consume a large amount of CPU memory (RAM).
+
     :param num_initial_samples: The size of the random sample used to find the starting point(s) of
         the optimization.
     :param num_optimization_runs: The number of separate optimizations to run.

--- a/trieste/acquisition/utils.py
+++ b/trieste/acquisition/utils.py
@@ -48,7 +48,7 @@ def split_acquisition_function(
         if length == 0:
             return fn(x)
 
-        elements_per_block = tf.size(x) / length
+        elements_per_block = tf.size(x, out_type=tf.int64) / length
         blocks_per_batch = tf.cast(tf.math.ceil(split_size / elements_per_block), tf.int32)
 
         num_batches = tf.cast(tf.math.ceil(length / blocks_per_batch) - 1, tf.int32)

--- a/trieste/acquisition/utils.py
+++ b/trieste/acquisition/utils.py
@@ -48,6 +48,7 @@ def split_acquisition_function(
         if length == 0:
             return fn(x)
 
+        # Use int64 to calculate the input tensor size, otherwise we can overflow for large tensors.
         elements_per_block = tf.size(x, out_type=tf.int64) / length
         blocks_per_batch = tf.cast(tf.math.ceil(split_size / elements_per_block), tf.int32)
 


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Use `int64` to calculate the input tensor size when splitting acquisition functions. Otherwise, we overflow for large tensors, e.g. of shape ` [30000, 1000, 100]`.

It is tricky to add a unit test to cover the limit, as we run into memory issues. Using mocking or sparse-tensors gets a bit messy, so skipping unit testing for this simple change.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
