### PR TITLE
Handle unconstrained priors in randomize_hyperparameters

### DIFF
--- a/trieste/models/gpflow/utils.py
+++ b/trieste/models/gpflow/utils.py
@@ -53,7 +53,8 @@ def assert_data_is_compatible(new_data: Dataset, existing_data: Dataset) -> None
 def randomize_hyperparameters(object: gpflow.Module) -> None:
     """
     Sets hyperparameters to random samples from their prior distributions or (for Sigmoid
-    constraints with no priors) their constrained domains.
+    constraints with no priors) their constrained domains. Note that it is up to the caller
+    to ensure that the prior, if defined, is compatible with the transform.
 
     :param object: Any gpflow Module.
     """

--- a/trieste/models/gpflow/utils.py
+++ b/trieste/models/gpflow/utils.py
@@ -14,12 +14,11 @@
 
 from __future__ import annotations
 
-from typing import Tuple, Union, Optional
+from typing import Tuple, Union
 
 import gpflow
 import tensorflow as tf
 import tensorflow_probability as tfp
-from gpflow.base import TensorData
 
 from ...data import Dataset
 from ...types import TensorType


### PR DESCRIPTION
**Related issue(s)/PRs:** #793

## Summary

Fix randomize_hyperparameters to handle unconstrained priors.

Also change the logic for handling Sigmoid constraints: we now prioritise sampling from the prior if there is one, and sample from the constrained domain only if there isn't.

**Fully backwards compatible:** no

New Sigmoid behaviour is more logical and flexible, and old behaviour can be easily obtained by removing any prior.

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
