### PR TITLE
Make ProbabilisticModel a pure interface

### DIFF
--- a/docs/notebooks/code_overview.pct.py
+++ b/docs/notebooks/code_overview.pct.py
@@ -198,12 +198,13 @@ from trieste.acquisition import (
     AcquisitionFunction,
     SingleModelAcquisitionBuilder,
 )
+from trieste.models.interfaces import SupportsPredictY
 from trieste.data import Dataset
 
 
-class ProbabilityOfValidity(SingleModelAcquisitionBuilder[ProbabilisticModel]):
+class ProbabilityOfValidity(SingleModelAcquisitionBuilder[SupportsPredictY]):
     def prepare_acquisition_function(
-        self, model: ProbabilisticModel, dataset: Optional[Dataset] = None
+        self, model: SupportsPredictY, dataset: Optional[Dataset] = None
     ) -> AcquisitionFunction:
         def acquisition(at: TensorType) -> TensorType:
             mean, _ = model.predict_y(tf.squeeze(at, -2))
@@ -217,9 +218,9 @@ class ProbabilityOfValidity(SingleModelAcquisitionBuilder[ProbabilisticModel]):
 
 
 # %%
-class ProbabilityOfValidity2(SingleModelAcquisitionBuilder[ProbabilisticModel]):
+class ProbabilityOfValidity2(SingleModelAcquisitionBuilder[SupportsPredictY]):
     def prepare_acquisition_function(
-        self, model: ProbabilisticModel, dataset: Optional[Dataset] = None
+        self, model: SupportsPredictY, dataset: Optional[Dataset] = None
     ) -> AcquisitionFunction:
         @tf.function
         def acquisition(at: TensorType) -> TensorType:
@@ -231,7 +232,7 @@ class ProbabilityOfValidity2(SingleModelAcquisitionBuilder[ProbabilisticModel]):
     def update_acquisition_function(
         self,
         function: AcquisitionFunction,
-        model: ProbabilisticModel,
+        model: SupportsPredictY,
         dataset: Optional[Dataset] = None,
     ) -> AcquisitionFunction:
         return function  # no need to update anything

--- a/docs/notebooks/expected_improvement.pct.py
+++ b/docs/notebooks/expected_improvement.pct.py
@@ -299,7 +299,9 @@ saved_result.try_get_final_model().model  # type: ignore
 
 # %%
 # save the model to a given path, exporting just the predict method
-module = result.try_get_final_model().get_module_with_variables()
+from trieste.models.utils import get_module_with_variables
+
+module = get_module_with_variables(result.try_get_final_model())
 module.predict = tf.function(
     model.predict,
     input_signature=[tf.TensorSpec(shape=[None, 2], dtype=tf.float64)],

--- a/tests/integration/models/multifidelity/test_multifidelity_models.py
+++ b/tests/integration/models/multifidelity/test_multifidelity_models.py
@@ -11,6 +11,7 @@ from trieste.data import (
     check_and_extract_fidelity_query_points,
     split_dataset_by_fidelity,
 )
+from trieste.models import TrainableProbabilisticModel
 from trieste.models.gpflow import GaussianProcessRegression
 from trieste.models.gpflow.builders import (
     build_gpr,
@@ -119,7 +120,7 @@ def test_multifidelity_nonlinear_autoregressive_results_better_than_linear() -> 
     observer = mk_observer(noisy_nonlinear_multifidelity)
     initial_data = observer(initial_sample)
 
-    nonlinear_model = MultifidelityNonlinearAutoregressive(
+    nonlinear_model: TrainableProbabilisticModel = MultifidelityNonlinearAutoregressive(
         build_multifidelity_nonlinear_autoregressive_models(
             initial_data, n_fidelities, input_search_space
         )

--- a/tests/unit/acquisition/function/test_entropy.py
+++ b/tests/unit/acquisition/function/test_entropy.py
@@ -36,6 +36,7 @@ from trieste.acquisition.function.entropy import (
     MinValueEntropySearch,
     MUMBOModelType,
     SupportsCovarianceObservationNoiseTrajectory,
+    SupportsCovarianceWithTopFidelityPredictY,
     gibbon_quality_term,
     gibbon_repulsion_term,
     min_value_entropy_search,
@@ -48,7 +49,6 @@ from trieste.acquisition.sampler import (
     ThompsonSamplerFromTrajectory,
 )
 from trieste.data import Dataset, add_fidelity_column
-from trieste.models import SupportsCovarianceWithTopFidelity
 from trieste.objectives import Branin
 from trieste.space import Box
 from trieste.types import TensorType
@@ -612,7 +612,7 @@ def test_mumbo_raises_when_use_trajectory_sampler_and_model_without_trajectories
 )
 def test_mumbo_builder_builds_min_value_samples(
     mocked_mves: MagicMock,
-    min_value_sampler: ThompsonSampler[SupportsCovarianceWithTopFidelity],
+    min_value_sampler: ThompsonSampler[SupportsCovarianceWithTopFidelityPredictY],
 ) -> None:
     dataset = Dataset(tf.zeros([3, 2], dtype=tf.float64), tf.ones([3, 2], dtype=tf.float64))
     search_space = Box([0, 0], [1, 1])
@@ -638,7 +638,7 @@ def test_mumbo_builder_builds_min_value_samples(
     [ExactThompsonSampler(sample_min_value=True), GumbelSampler(sample_min_value=True)],
 )
 def test_mumbo_builder_updates_acquisition_function(
-    min_value_sampler: ThompsonSampler[SupportsCovarianceWithTopFidelity],
+    min_value_sampler: ThompsonSampler[SupportsCovarianceWithTopFidelityPredictY],
 ) -> None:
     search_space = Box([0.0, 0.0], [1.0, 1.0])
     model = MultiFidelityQuadraticMeanAndRBFKernel(

--- a/tests/unit/models/gpflow/test_interface.py
+++ b/tests/unit/models/gpflow/test_interface.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 import gpflow
 import numpy.testing as npt
@@ -35,6 +35,9 @@ class _QuadraticPredictor(GPflowPredictor):
         self.optimizer.optimize(self.model, dataset)
 
     def update(self, dataset: Dataset) -> None:
+        return
+
+    def log(self, dataset: Optional[Dataset] = None) -> None:
         return
 
 

--- a/tests/unit/models/gpflow/test_models.py
+++ b/tests/unit/models/gpflow/test_models.py
@@ -84,6 +84,7 @@ from trieste.models.gpflow.sampler import (
     RandomFourierFeatureTrajectorySampler,
 )
 from trieste.models.optimizer import BatchOptimizer, DatasetTransformer, Optimizer
+from trieste.models.utils import get_last_optimization_result, optimize_model_and_save_result
 from trieste.space import Box
 from trieste.types import TensorType
 from trieste.utils import DEFAULTS
@@ -150,13 +151,14 @@ def test_gpflow_wrappers_default_optimize(
         args = {}
 
     loss = internal_model.training_loss(**args)
-    model.optimize_and_save_result(Dataset(*data))
+    optimize_model_and_save_result(model, Dataset(*data))
 
     new_loss = internal_model.training_loss(**args)
     assert new_loss < loss
     if not isinstance(internal_model, SVGP):
-        assert model.last_optimization_result is not None
-        npt.assert_allclose(new_loss, model.last_optimization_result.fun)
+        optimization_result = get_last_optimization_result(model)
+        assert optimization_result is not None
+        npt.assert_allclose(new_loss, optimization_result.fun)
 
 
 def test_gpflow_wrappers_ref_optimize(gpflow_interface_factory: ModelFactoryType) -> None:

--- a/tests/unit/models/gpflow/test_utils.py
+++ b/tests/unit/models/gpflow/test_utils.py
@@ -39,6 +39,7 @@ from trieste.models.gpflow import (
 )
 from trieste.models.interfaces import HasTrajectorySampler
 from trieste.models.optimizer import BatchOptimizer, Optimizer
+from trieste.models.utils import get_module_with_variables
 from trieste.types import TensorType
 
 
@@ -92,7 +93,7 @@ def test_gaussian_process_tf_saved_model(gpflow_interface_factory: ModelFactoryT
         trajectory = trajectory_sampler.get_trajectory()
 
         # generate client model with predict and sample methods
-        module = model.get_module_with_variables(trajectory_sampler, trajectory)
+        module = get_module_with_variables(model, trajectory_sampler, trajectory)
         module.predict = tf.function(
             model.predict, input_signature=[tf.TensorSpec(shape=[None, 1], dtype=tf.float64)]
         )

--- a/tests/unit/models/gpflux/test_interface.py
+++ b/tests/unit/models/gpflux/test_interface.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import gpflow
 import numpy.testing as npt
 import pytest
@@ -68,6 +70,9 @@ class _QuadraticPredictor(GPfluxPredictor):
         return samples
 
     def update(self, dataset: Dataset) -> None:
+        return
+
+    def log(self, dataset: Optional[Dataset] = None) -> None:
         return
 
 

--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -50,7 +50,11 @@ from trieste.logging import step_number, tensorboard_writer
 from trieste.models.gpflux import DeepGaussianProcess
 from trieste.models.interfaces import HasTrajectorySampler
 from trieste.models.optimizer import KerasOptimizer
-from trieste.models.utils import get_module_with_variables
+from trieste.models.utils import (
+    get_last_optimization_result,
+    get_module_with_variables,
+    optimize_model_and_save_result,
+)
 from trieste.types import TensorType
 
 
@@ -298,10 +302,11 @@ def test_deep_gaussian_process_with_lr_scheduler(
     optimizer = KerasOptimizer(tf.optimizers.Adam(lr_schedule), fit_args)
     model = DeepGaussianProcess(two_layer_model(x), optimizer)
 
-    model.optimize_and_save_result(Dataset(x, y))
+    optimize_model_and_save_result(model, Dataset(x, y))
 
-    assert model.last_optimization_result is not None
-    assert len(model.last_optimization_result.history["loss"]) == epochs
+    optimization_result = get_last_optimization_result(model)
+    assert optimization_result is not None
+    assert len(optimization_result.history["loss"]) == epochs
 
 
 def test_deep_gaussian_process_default_optimizer_is_correct(

--- a/tests/unit/models/gpflux/test_models.py
+++ b/tests/unit/models/gpflux/test_models.py
@@ -50,6 +50,7 @@ from trieste.logging import step_number, tensorboard_writer
 from trieste.models.gpflux import DeepGaussianProcess
 from trieste.models.interfaces import HasTrajectorySampler
 from trieste.models.optimizer import KerasOptimizer
+from trieste.models.utils import get_module_with_variables
 from trieste.types import TensorType
 
 
@@ -395,7 +396,7 @@ def test_deepgp_tf_saved_model() -> None:
         trajectory = trajectory_sampler.get_trajectory()
 
         # generate client model with predict and sample methods
-        module = model.get_module_with_variables(trajectory_sampler, trajectory)
+        module = get_module_with_variables(model, trajectory_sampler, trajectory)
         module.predict = tf.function(
             model.predict, input_signature=[tf.TensorSpec(shape=[None, 1], dtype=tf.float64)]
         )

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -42,7 +42,11 @@ from trieste.models.keras import (
     sample_with_replacement,
 )
 from trieste.models.optimizer import KerasOptimizer, TrainingData
-from trieste.models.utils import get_module_with_variables
+from trieste.models.utils import (
+    get_last_optimization_result,
+    get_module_with_variables,
+    optimize_model_and_save_result,
+)
 from trieste.types import TensorType
 
 _ENSEMBLE_SIZE = 3
@@ -216,10 +220,11 @@ def test_deep_ensemble_resets_lr_with_lr_schedule() -> None:
 
     npt.assert_allclose(model.model.optimizer.lr.numpy(), init_lr, rtol=1e-6)
 
-    model.optimize_and_save_result(example_data)
+    optimize_model_and_save_result(model, example_data)
 
-    assert model.last_optimization_result is not None
-    npt.assert_allclose(model.last_optimization_result.history["lr"], [0.5, 0.25])
+    optimization_result = get_last_optimization_result(model)
+    assert optimization_result is not None
+    npt.assert_allclose(optimization_result.history["lr"], [0.5, 0.25])
     npt.assert_allclose(model.model.optimizer.lr.numpy(), init_lr, rtol=1e-6)
 
 

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -42,6 +42,7 @@ from trieste.models.keras import (
     sample_with_replacement,
 )
 from trieste.models.optimizer import KerasOptimizer, TrainingData
+from trieste.models.utils import get_module_with_variables
 from trieste.types import TensorType
 
 _ENSEMBLE_SIZE = 3
@@ -568,7 +569,7 @@ def test_deep_ensemble_tf_saved_model() -> None:
         trajectory = trajectory_sampler.get_trajectory()
 
         # generate client model with predict and sample methods
-        module = model.get_module_with_variables(trajectory_sampler, trajectory)
+        module = get_module_with_variables(model, trajectory_sampler, trajectory)
         module.predict = tf.function(
             model.predict, input_signature=[tf.TensorSpec(shape=[None, 3], dtype=tf.float64)]
         )

--- a/tests/unit/models/test_interfaces.py
+++ b/tests/unit/models/test_interfaces.py
@@ -36,6 +36,7 @@ from trieste.data import Dataset
 from trieste.models import TrainableModelStack, TrainableProbabilisticModel
 from trieste.models.interfaces import (
     TrainablePredictJointReparamModelStack,
+    TrainablePredictYModelStack,
     TrainableSupportsPredictJoint,
     TrainableSupportsPredictJointHasReparamSampler,
 )
@@ -114,28 +115,11 @@ def test_model_stack_predict_joint() -> None:
     npt.assert_allclose(cov[..., 3:, :, :], cov3)
 
 
-def test_model_missing_predict_y() -> None:
-    model = _QuadraticModel([-1.0], [0.1])
-    x_predict = tf.constant([[0]], gpflow.default_float())
-    with pytest.raises(NotImplementedError):
-        model.predict_y(x_predict)
-
-
-def test_model_stack_missing_predict_y() -> None:
-    x = tf.constant(np.arange(5).reshape(-1, 1), dtype=gpflow.default_float())
-    model1 = gpr_model(x, fnc_3x_plus_10(x))
-    model2 = _QuadraticModel([1.0], [2.0])
-    stack = TrainableModelStack((model1, 1), (model2, 1))
-    x_predict = tf.constant([[0]], gpflow.default_float())
-    with pytest.raises(NotImplementedError):
-        stack.predict_y(x_predict)
-
-
 def test_model_stack_predict_y() -> None:
     x = tf.constant(np.arange(5).reshape(-1, 1), dtype=gpflow.default_float())
     model1 = gpr_model(x, fnc_3x_plus_10(x))
     model2 = sgpr_model(x, fnc_2sin_x_over_3(x))
-    stack = TrainableModelStack((model1, 1), (model2, 1))
+    stack = TrainablePredictYModelStack((model1, 1), (model2, 1))
     mean, variance = stack.predict_y(x)
     npt.assert_allclose(mean[:, 0:1], model1.predict_y(x)[0])
     npt.assert_allclose(mean[:, 1:2], model2.predict_y(x)[0])

--- a/tests/unit/models/test_interfaces.py
+++ b/tests/unit/models/test_interfaces.py
@@ -40,6 +40,7 @@ from trieste.models.interfaces import (
     TrainableSupportsPredictJoint,
     TrainableSupportsPredictJointHasReparamSampler,
 )
+from trieste.models.utils import get_last_optimization_result, optimize_model_and_save_result
 from trieste.types import TensorType
 
 
@@ -177,8 +178,8 @@ def test_model_stack_training() -> None:
     stack = TrainableModelStack((model01, 2), (model2, 1), (model3, 1))
     data = Dataset(tf.random.uniform([5, 7, 3]), tf.random.uniform([5, 7, 4]))
     stack.update(data)
-    stack.optimize_and_save_result(data)
-    assert stack.last_optimization_result == [None] * 3
+    optimize_model_and_save_result(stack, data)
+    assert get_last_optimization_result(stack) == [None] * 3
 
 
 def test_model_stack_reparam_sampler_raises_for_submodels_without_reparam_sampler() -> None:

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -491,6 +491,9 @@ def test_bayesian_optimizer_optimize_is_noop_for_zero_steps() -> None:
         def optimize(self, dataset: Dataset) -> NoReturn:
             assert False
 
+        def log(self, dataset: Optional[Dataset] = None) -> None:
+            return
+
     class _UnusableRule(AcquisitionRule[NoReturn, Box, ProbabilisticModel]):
         def acquire(
             self,

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -121,6 +121,9 @@ class GaussianProcess(
         ]
         return tf.concat(covs, axis=-3)
 
+    def log(self, dataset: Optional[Dataset] = None) -> None:
+        return
+
 
 class GaussianProcessWithoutNoise(GaussianMarginal, SupportsPredictJoint, HasReparamSampler):
     """A (static) Gaussian process over a vector random variable with independent reparam sampler

--- a/tests/util/models/gpflow/models.py
+++ b/tests/util/models/gpflow/models.py
@@ -164,6 +164,9 @@ class GaussianProcessWithoutNoise(GaussianMarginal, SupportsPredictJoint, HasRep
     ) -> ReparametrizationSampler[GaussianProcessWithoutNoise]:
         return IndependentReparametrizationSampler(num_samples, self)
 
+    def log(self, dataset: Optional[Dataset] = None) -> None:
+        return
+
 
 class GaussianProcessWithSamplers(GaussianProcess, HasReparamSampler):
     """A (static) Gaussian process over a vector random variable with independent reparam sampler"""

--- a/trieste/acquisition/function/entropy.py
+++ b/trieste/acquisition/function/entropy.py
@@ -29,6 +29,7 @@ from ...models.interfaces import (
     HasTrajectorySampler,
     SupportsCovarianceWithTopFidelity,
     SupportsGetObservationNoise,
+    SupportsPredictY,
 )
 from ...space import SearchSpace
 from ...types import TensorType
@@ -623,10 +624,19 @@ class gibbon_repulsion_term(UpdatablePenalizationFunction):
         return repulsion_weight * repulsion
 
 
+@runtime_checkable
+class SupportsCovarianceWithTopFidelityPredictY(
+    SupportsCovarianceWithTopFidelity, SupportsPredictY, Protocol
+):
+    """A model that is both multifidelity and supports predict_y."""
+
+    pass
+
+
 MUMBOModelType = TypeVar(
-    "MUMBOModelType", bound=SupportsCovarianceWithTopFidelity, contravariant=True
+    "MUMBOModelType", bound=SupportsCovarianceWithTopFidelityPredictY, contravariant=True
 )
-""" Type variable bound to :class:`~trieste.models.SupportsCovarianceWithTopFidelity`. """
+""" Type variable bound to :class:`~trieste.models.SupportsCovarianceWithTopFidelityPredictY`. """
 
 
 class MUMBO(MinValueEntropySearch[MUMBOModelType]):
@@ -645,7 +655,7 @@ class MUMBO(MinValueEntropySearch[MUMBOModelType]):
 
     @overload
     def __init__(
-        self: "MUMBO[SupportsCovarianceWithTopFidelity]",
+        self: "MUMBO[SupportsCovarianceWithTopFidelityPredictY]",
         search_space: SearchSpace,
         num_samples: int = 5,
         grid_size: int = 1000,

--- a/trieste/acquisition/sampler.py
+++ b/trieste/acquisition/sampler.py
@@ -26,7 +26,7 @@ import tensorflow_probability as tfp
 from scipy.optimize import bisect
 
 from ..models import ProbabilisticModel
-from ..models.interfaces import HasTrajectorySampler, ProbabilisticModelType
+from ..models.interfaces import HasTrajectorySampler, ProbabilisticModelType, SupportsPredictY
 from ..types import TensorType
 from .utils import select_nth_output
 
@@ -174,9 +174,9 @@ class GumbelSampler(ThompsonSampler[ProbabilisticModel]):
         tf.debugging.assert_positive(sample_size)
         tf.debugging.assert_shapes([(at, ["N", None])])
 
-        try:
+        if isinstance(model, SupportsPredictY):
             fmean, fvar = model.predict_y(at)
-        except NotImplementedError:
+        else:
             fmean, fvar = model.predict(at)
 
         fsd = tf.math.sqrt(fvar)

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Dict, Generic, Mapping, TypeVar, cast, overload
 
+from .models.utils import optimize_model_and_save_result
+
 try:
     import pandas as pd
 except ModuleNotFoundError:
@@ -233,7 +235,7 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
                 for tag, model in self._models.items():
                     dataset = datasets[tag]
                     model.update(dataset)
-                    model.optimize_and_save_result(dataset)
+                    optimize_model_and_save_result(model, dataset)
 
             summary_writer = logging.get_tensorboard_writer()
             if summary_writer:
@@ -434,7 +436,7 @@ class AskTellOptimizer(Generic[SearchSpaceType, TrainableProbabilisticModelType]
             for tag, model in self._models.items():
                 dataset = self._datasets[tag]
                 model.update(dataset)
-                model.optimize_and_save_result(dataset)
+                optimize_model_and_save_result(model, dataset)
 
         summary_writer = logging.get_tensorboard_writer()
         if summary_writer:

--- a/trieste/bayesian_optimizer.py
+++ b/trieste/bayesian_optimizer.py
@@ -45,6 +45,7 @@ import tensorflow as tf
 from scipy.spatial.distance import pdist
 
 from .acquisition.multi_objective import non_dominated
+from .models.utils import optimize_model_and_save_result
 
 try:
     import pandas as pd
@@ -719,7 +720,7 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                         for tag, model in models.items():
                             dataset = datasets[tag]
                             model.update(dataset)
-                            model.optimize_and_save_result(dataset)
+                            optimize_model_and_save_result(model, dataset)
                     if summary_writer:
                         logging.set_step_number(0)
                         with summary_writer.as_default(step=0):
@@ -752,7 +753,7 @@ class BayesianOptimizer(Generic[SearchSpaceType]):
                             for tag, model in models.items():
                                 dataset = datasets[tag]
                                 model.update(dataset)
-                                model.optimize_and_save_result(dataset)
+                                optimize_model_and_save_result(model, dataset)
 
                 if summary_writer:
                     with summary_writer.as_default(step=step):

--- a/trieste/models/gpflow/interface.py
+++ b/trieste/models/gpflow/interface.py
@@ -33,6 +33,7 @@ from ..interfaces import (
     SupportsGetKernel,
     SupportsGetObservationNoise,
     SupportsPredictJoint,
+    SupportsPredictY,
     TrainableProbabilisticModel,
 )
 from ..optimizer import Optimizer
@@ -48,6 +49,7 @@ class GPflowPredictor(
     SupportsPredictJoint,
     SupportsGetKernel,
     SupportsGetObservationNoise,
+    SupportsPredictY,
     HasReparamSampler,
     TrainableProbabilisticModel,
     ABC,

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -1659,6 +1659,9 @@ class MultifidelityAutoregressive(
 
         return f_var
 
+    def log(self, dataset: Optional[Dataset] = None) -> None:
+        return
+
 
 class MultifidelityNonlinearAutoregressive(
     TrainableProbabilisticModel, SupportsPredictY, SupportsCovarianceWithTopFidelity
@@ -2033,3 +2036,6 @@ class MultifidelityNonlinearAutoregressive(
         cov = tfp.stats.covariance(signal_sample, max_fidelity_sample)[:, :, 0]
 
         return cov
+
+    def log(self, dataset: Optional[Dataset] = None) -> None:
+        return

--- a/trieste/models/gpflow/models.py
+++ b/trieste/models/gpflow/models.py
@@ -46,6 +46,7 @@ from ..interfaces import (
     SupportsCovarianceWithTopFidelity,
     SupportsGetInducingVariables,
     SupportsGetInternalData,
+    SupportsPredictY,
     TrainableProbabilisticModel,
     TrajectorySampler,
 )
@@ -1369,7 +1370,9 @@ class VariationalGaussianProcess(
         )
 
 
-class MultifidelityAutoregressive(TrainableProbabilisticModel, SupportsCovarianceWithTopFidelity):
+class MultifidelityAutoregressive(
+    TrainableProbabilisticModel, SupportsPredictY, SupportsCovarianceWithTopFidelity
+):
     r"""
     A :class:`TrainableProbabilisticModel` implementation of the model
     from :cite:`Kennedy2000`. This is a multi-fidelity model that works with an
@@ -1658,7 +1661,7 @@ class MultifidelityAutoregressive(TrainableProbabilisticModel, SupportsCovarianc
 
 
 class MultifidelityNonlinearAutoregressive(
-    TrainableProbabilisticModel, SupportsCovarianceWithTopFidelity
+    TrainableProbabilisticModel, SupportsPredictY, SupportsCovarianceWithTopFidelity
 ):
     r"""
     A :class:`TrainableProbabilisticModel` implementation of the model from

--- a/trieste/models/gpflux/interface.py
+++ b/trieste/models/gpflux/interface.py
@@ -21,11 +21,11 @@ from check_shapes import inherit_check_shapes
 from gpflow.base import Module
 
 from ...types import TensorType
-from ..interfaces import SupportsGetObservationNoise
+from ..interfaces import SupportsGetObservationNoise, SupportsPredictY
 from ..optimizer import KerasOptimizer
 
 
-class GPfluxPredictor(SupportsGetObservationNoise, ABC):
+class GPfluxPredictor(SupportsGetObservationNoise, SupportsPredictY, ABC):
     """
     A trainable wrapper for a GPflux deep Gaussian process model. The code assumes subclasses
     will use the Keras `fit` method for training, and so they should provide access to both a

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -85,28 +85,6 @@ class ProbabilisticModel(Protocol):
         """
         raise NotImplementedError
 
-    @check_shapes(
-        "query_points: [broadcast batch..., D]",
-        "return[0]: [batch..., E...]",
-        "return[1]: [batch..., E...]",
-    )
-    def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
-        """
-        Return the mean and variance of the independent marginal distributions at each point in
-        ``query_points`` for the observations, including noise contributions.
-
-        Note that this is not supported by all models.
-
-        :param query_points: The points at which to make predictions, of shape [..., D].
-        :return: The mean and variance of the independent marginal distributions at each point in
-            ``query_points``. For a predictive distribution with event shape E, the mean and
-            variance will both have shape [...] + E.
-        """
-        pass  # (required so that mypy doesn't think this method is abstract)
-        raise NotImplementedError(
-            f"Model {self!r} does not support predicting observations, just the latent function"
-        )
-
     def log(self, dataset: Optional[Dataset] = None) -> None:
         """
         Log model-specific information at a given optimization step.
@@ -186,6 +164,29 @@ class SupportsPredictJoint(ProbabilisticModel, Protocol):
         :return: The mean and covariance of the joint marginal distribution at each batch of points
             in ``query_points``. For a predictive distribution with event shape E, the mean will
             have shape [..., B] + E, and the covariance shape [...] + E + [B, B].
+        """
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsPredictY(ProbabilisticModel, Protocol):
+    """A probabilistic model that supports predict_y."""
+
+    @abstractmethod
+    @check_shapes(
+        "query_points: [broadcast batch..., D]",
+        "return[0]: [batch..., E...]",
+        "return[1]: [batch..., E...]",
+    )
+    def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        """
+        Return the mean and variance of the independent marginal distributions at each point in
+        ``query_points`` for the observations, including noise contributions.
+
+        :param query_points: The points at which to make predictions, of shape [..., D].
+        :return: The mean and variance of the independent marginal distributions at each point in
+            ``query_points``. For a predictive distribution with event shape E, the mean and
+            variance will both have shape [...] + E.
         """
         raise NotImplementedError
 
@@ -421,18 +422,6 @@ class ModelStack(ProbabilisticModel, Generic[ProbabilisticModelType]):
         samples = [model.sample(query_points, num_samples) for model in self._models]
         return tf.concat(samples, axis=-1)
 
-    def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
-        r"""
-        :param query_points: The points at which to make predictions, of shape [..., D].
-        :return: The predictions from all the wrapped models, concatenated along the event axis in
-            the same order as they appear in :meth:`__init__`. If the wrapped models have predictive
-            distributions with event shapes [:math:`E_i`], the mean and variance will both have
-            shape [..., :math:`\sum_i E_i`].
-        :raise NotImplementedError: If any of the models don't implement predict_y.
-        """
-        means, vars_ = zip(*[model.predict_y(query_points) for model in self._models])
-        return tf.concat(means, axis=-1), tf.concat(vars_, axis=-1)
-
     def log(self, dataset: Optional[Dataset] = None) -> None:
         """
         Log model-specific information at a given optimization step.
@@ -542,6 +531,26 @@ class PredictJointModelStack(ModelStack[SupportsPredictJoint], SupportsPredictJo
         return tf.concat(means, axis=-1), tf.concat(covs, axis=-3)
 
 
+class PredictYModelStack(ModelStack[SupportsPredictY], SupportsPredictY):
+    r"""
+    A :class:`PredictJointModelStack` is a wrapper around a number of
+    :class:`SupportsPredictY`\ s.
+    It delegates :meth:`predict_y` to each model.
+    """
+
+    def predict_y(self, query_points: TensorType) -> tuple[TensorType, TensorType]:
+        r"""
+        :param query_points: The points at which to make predictions, of shape [..., D].
+        :return: The predictions from all the wrapped models, concatenated along the event axis in
+            the same order as they appear in :meth:`__init__`. If the wrapped models have predictive
+            distributions with event shapes [:math:`E_i`], the mean and variance will both have
+            shape [..., :math:`\sum_i E_i`].
+        :raise NotImplementedError: If any of the models don't implement predict_y.
+        """
+        means, vars_ = zip(*[model.predict_y(query_points) for model in self._models])
+        return tf.concat(means, axis=-1), tf.concat(vars_, axis=-1)
+
+
 # It's useful, though a bit ugly, to define the stack constructors for some model type combinations
 class TrainableSupportsPredictJoint(TrainableProbabilisticModel, SupportsPredictJoint, Protocol):
     """A model that is both trainable and supports predict_joint."""
@@ -553,6 +562,34 @@ class TrainablePredictJointModelStack(
     TrainableModelStack, PredictJointModelStack, ModelStack[TrainableSupportsPredictJoint]
 ):
     """A stack of models that are both trainable and support predict_joint."""
+
+    pass
+
+
+class TrainableSupportsPredictY(TrainableProbabilisticModel, SupportsPredictY, Protocol):
+    """A model that is both trainable and supports predict_y."""
+
+    pass
+
+
+class TrainablePredictYModelStack(
+    TrainableModelStack, PredictYModelStack, ModelStack[TrainableSupportsPredictY]
+):
+    """A stack of models that are both trainable and support predict_y."""
+
+    pass
+
+
+class SupportsPredictJointPredictY(SupportsPredictJoint, SupportsPredictY, Protocol):
+    """A model that supports both predict_joint and predict_y."""
+
+    pass
+
+
+class PredictJointPredictYModelStack(
+    PredictJointModelStack, PredictYModelStack, ModelStack[SupportsPredictJointPredictY]
+):
+    """A stack of models that support both predict_joint and predict_y."""
 
     pass
 

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -25,7 +25,6 @@ from typing_extensions import Protocol, runtime_checkable
 from ..data import Dataset
 from ..types import TensorType
 from ..utils import DEFAULTS
-from ..utils.misc import get_variables
 
 ProbabilisticModelType = TypeVar(
     "ProbabilisticModelType", bound="ProbabilisticModel", contravariant=True
@@ -92,19 +91,6 @@ class ProbabilisticModel(Protocol):
         :param dataset: Optional data that can be used to log additional data-based model summaries.
         """
         return
-
-    def get_module_with_variables(self, *dependencies: Any) -> tf.Module:
-        """
-        Return a fresh module with the model's variables attached, which can then be extended
-        with methods and saved using tf.saved_model.
-
-        :param dependencies: Dependent objects whose variables should also be included.
-        """
-        module = tf.Module()
-        module.saved_variables = get_variables(self)
-        for dependency in dependencies:
-            module.saved_variables += get_variables(dependency)
-        return module
 
 
 @runtime_checkable

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -504,7 +504,7 @@ class PredictJointModelStack(ModelStack[SupportsPredictJoint], SupportsPredictJo
 
 class PredictYModelStack(ModelStack[SupportsPredictY], SupportsPredictY):
     r"""
-    A :class:`PredictJointModelStack` is a wrapper around a number of
+    A :class:`PredictYModelStack` is a wrapper around a number of
     :class:`SupportsPredictY`\ s.
     It delegates :meth:`predict_y` to each model.
     """

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -84,13 +84,14 @@ class ProbabilisticModel(Protocol):
         """
         raise NotImplementedError
 
+    @abstractmethod
     def log(self, dataset: Optional[Dataset] = None) -> None:
         """
         Log model-specific information at a given optimization step.
 
         :param dataset: Optional data that can be used to log additional data-based model summaries.
         """
-        return
+        raise NotImplementedError
 
 
 @runtime_checkable

--- a/trieste/models/interfaces.py
+++ b/trieste/models/interfaces.py
@@ -118,22 +118,6 @@ class TrainableProbabilisticModel(ProbabilisticModel, Protocol):
         """
         raise NotImplementedError
 
-    def optimize_and_save_result(self, dataset: Dataset) -> None:
-        """
-        Optimize the model objective and save the optimization result in
-        ``last_optimization_result``.
-
-        :param dataset: The data with which to train the model.
-        """
-        setattr(self, "_last_optimization_result", self.optimize(dataset))
-
-    @property
-    def last_optimization_result(self) -> Optional[Any]:
-        """
-        The last saved (optimizer-specific) optimization result.
-        """
-        return getattr(self, "_last_optimization_result")
-
 
 @runtime_checkable
 class SupportsPredictJoint(ProbabilisticModel, Protocol):

--- a/trieste/models/keras/interface.py
+++ b/trieste/models/keras/interface.py
@@ -22,6 +22,7 @@ import tensorflow_probability as tfp
 from check_shapes import inherit_check_shapes
 from typing_extensions import Protocol, runtime_checkable
 
+from ...data import Dataset
 from ...types import TensorType
 from ..interfaces import ProbabilisticModel
 from ..optimizer import KerasOptimizer
@@ -75,6 +76,9 @@ class KerasPredictor(ProbabilisticModel, ABC):
             such subclasses should overwrite this method.
             """
         )
+
+    def log(self, dataset: Optional[Dataset] = None) -> None:
+        return
 
 
 @runtime_checkable

--- a/trieste/models/utils.py
+++ b/trieste/models/utils.py
@@ -18,7 +18,7 @@ This module contains auxiliary objects and functions that are used by multiple m
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 import gpflow
 import tensorflow as tf
@@ -27,7 +27,7 @@ from gpflow.utilities.traversal import _merge_leaf_components, leaf_components
 from .. import logging
 from ..data import Dataset
 from ..utils.misc import get_variables
-from .interfaces import ProbabilisticModel
+from .interfaces import ProbabilisticModel, TrainableProbabilisticModel
 
 
 def write_summary_data_based_metrics(
@@ -120,3 +120,20 @@ def get_module_with_variables(model: ProbabilisticModel, *dependencies: Any) -> 
     for dependency in dependencies:
         module.saved_variables += get_variables(dependency)
     return module
+
+
+def optimize_model_and_save_result(model: TrainableProbabilisticModel, dataset: Dataset) -> None:
+    """
+    Optimize the model objective and save the (optimizer-specific) optimization result
+    in the model object. To access it, use ``get_last_optimization_result``.
+
+    :param dataset: The data with which to train the model.
+    """
+    setattr(model, "_last_optimization_result", model.optimize(dataset))
+
+
+def get_last_optimization_result(model: TrainableProbabilisticModel) -> Optional[Any]:
+    """
+    The last saved (optimizer-specific) optimization result.
+    """
+    return getattr(model, "_last_optimization_result")


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

Tidy up ProbabilisticModel and TrainableProbabilisticModel so that they are pure interfaces. Includes making `SupportsPredictY` a separate protocol, which improves static type checking.

**Fully backwards compatible:** no

A few breaking changes justified by simplifying the core type hierarchy. Migration is straightforward and will be properly documented.

1. `ProbabilisticModel.log` is now an abstract method and needs to be explicitly specified in any concrete model class implementation
2. `ProbabilisticModel.get_module_with_variables` is now a utility function in `trieste.models.utils`
3. `TrainableProbabilisticModel.optimize_and_save_result` and `TrainableProbabilisticModel.last_optimization_result` are now also utility functions (renamed to `optimize_model_and_save_result` and `get_last_optimization_result`)

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
