### PR TITLE
Rename frontpage badges

### DIFF
--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The Trieste Contributors
+# Copyright 2024 The Trieste Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Develop checks
+name: Release checks
 
 on:
   workflow_dispatch:
   push:
-    branches: develop
+    tags: v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
+  types:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - run: pip install tox
+    - run: tox -e types
+
+  types_old:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.7"
+    - run: pip install tox
+    - run: tox -e types_old
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - run: pip install tox
+    - run: tox -e format
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        part: [ "1", "2", "3", "4" ]
+    name: tests (part${{ matrix.part }})
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - run: pip install tox
+    - run: tox -e tests_${{ matrix.part }}
+
+  tests_old:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        part: [ "1", "2", "3", "4" ]
+    name: tests_old (part${{ matrix.part }})
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.7"
+    - run: pip install tox
+    - run: tox -e tests_old_${{ matrix.part }}
+
   slowtests:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![PyPI](https://img.shields.io/pypi/v/trieste.svg)](https://pypi.org/project/trieste)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE)
-[![Release](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/deploy.yaml?logo=github&label=Release%20build)](https://github.com/secondmind-labs/trieste/actions/workflows/deploy.yaml)
-[![Quality checks](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/develop-checks.yaml?logo=github&label=develop%20checks)](https://github.com/secondmind-labs/trieste/actions?query=workflows%3Adevelop-checks)
+[![Release](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/develop-checks.yaml?logo=github&label=Release%20checks&branch=v2.0.0)](https://github.com/secondmind-labs/trieste/actions/runs/7264909157)
+[![Develop](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/develop-checks.yaml?logo=github&label=develop%20checks)](https://github.com/secondmind-labs/trieste/actions?query=workflows%3Adevelop-checks)
 [![Codecov](https://img.shields.io/codecov/c/github/secondmind-labs/trieste/coverage.svg?branch=develop)](https://app.codecov.io/github/secondmind-labs/trieste/tree/develop)
 [![Slack Status](https://img.shields.io/badge/slack-trieste-green.svg?logo=Slack)](https://join.slack.com/t/secondmind-labs/shared_invite/zt-ph07nuie-gMlkle__tjvXBay4FNSLkw)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/trieste.svg)](https://pypi.org/project/trieste)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE)
-[![Release](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/release-checks.yaml?logo=github&label=release%20checks)](https://github.com/secondmind-labs/trieste/actions?query=workflows%3Arelease-checks)
+[![Release](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/develop-checks.yaml?logo=github&label=Release%20checks&branch=v2.0.0)](https://github.com/secondmind-labs/trieste/actions/runs/7264909157)
 [![Develop](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/develop-checks.yaml?logo=github&label=develop%20checks)](https://github.com/secondmind-labs/trieste/actions?query=workflows%3Adevelop-checks)
 [![Codecov](https://img.shields.io/codecov/c/github/secondmind-labs/trieste/coverage.svg?branch=develop)](https://app.codecov.io/github/secondmind-labs/trieste/tree/develop)
 [![Slack Status](https://img.shields.io/badge/slack-trieste-green.svg?logo=Slack)](https://join.slack.com/t/secondmind-labs/shared_invite/zt-ph07nuie-gMlkle__tjvXBay4FNSLkw)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/trieste.svg)](https://pypi.org/project/trieste)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE)
-[![Deploy](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/deploy.yaml?logo=github&label=Release%20build)](https://github.com/secondmind-labs/trieste/actions/workflows/deploy.yaml)
+[![Release](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/deploy.yaml?logo=github&label=Release%20build)](https://github.com/secondmind-labs/trieste/actions/workflows/deploy.yaml)
 [![Quality checks](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/develop-checks.yaml?logo=github&label=develop%20checks)](https://github.com/secondmind-labs/trieste/actions?query=workflows%3Adevelop-checks)
 [![Codecov](https://img.shields.io/codecov/c/github/secondmind-labs/trieste/coverage.svg?branch=develop)](https://app.codecov.io/github/secondmind-labs/trieste/tree/develop)
 [![Slack Status](https://img.shields.io/badge/slack-trieste-green.svg?logo=Slack)](https://join.slack.com/t/secondmind-labs/shared_invite/zt-ph07nuie-gMlkle__tjvXBay4FNSLkw)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/trieste.svg)](https://pypi.org/project/trieste)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE)
-[![Release](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/develop-checks.yaml?logo=github&label=Release%20checks&branch=v2.0.0)](https://github.com/secondmind-labs/trieste/actions/runs/7264909157)
+[![Release](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/release-checks.yaml?logo=github&label=release%20checks)](https://github.com/secondmind-labs/trieste/actions?query=workflows%3Arelease-checks)
 [![Develop](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/develop-checks.yaml?logo=github&label=develop%20checks)](https://github.com/secondmind-labs/trieste/actions?query=workflows%3Adevelop-checks)
 [![Codecov](https://img.shields.io/codecov/c/github/secondmind-labs/trieste/coverage.svg?branch=develop)](https://app.codecov.io/github/secondmind-labs/trieste/tree/develop)
 [![Slack Status](https://img.shields.io/badge/slack-trieste-green.svg?logo=Slack)](https://join.slack.com/t/secondmind-labs/shared_invite/zt-ph07nuie-gMlkle__tjvXBay4FNSLkw)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![PyPI](https://img.shields.io/pypi/v/trieste.svg)](https://pypi.org/project/trieste)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE)
-[![Quality checks](https://github.com/secondmind-labs/trieste/actions/workflows/develop-checks.yaml/badge.svg)](https://github.com/secondmind-labs/trieste/actions?query=workflows%3Adevelop-checks)
-[![Docs](https://github.com/secondmind-labs/trieste/actions/workflows/deploy.yaml/badge.svg)](https://github.com/secondmind-labs/trieste/actions/workflows/deploy.yaml)
+[![Deploy](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/deploy.yaml?logo=github&label=Release%20build)](https://github.com/secondmind-labs/trieste/actions/workflows/deploy.yaml)
+[![Quality checks](https://img.shields.io/github/actions/workflow/status/secondmind-labs/trieste/develop-checks.yaml?logo=github&label=develop%20checks)](https://github.com/secondmind-labs/trieste/actions?query=workflows%3Adevelop-checks)
 [![Codecov](https://img.shields.io/codecov/c/github/secondmind-labs/trieste/coverage.svg?branch=develop)](https://app.codecov.io/github/secondmind-labs/trieste/tree/develop)
 [![Slack Status](https://img.shields.io/badge/slack-trieste-green.svg?logo=Slack)](https://join.slack.com/t/secondmind-labs/shared_invite/zt-ph07nuie-gMlkle__tjvXBay4FNSLkw)
 


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

Relable and reorder the release deploy and develop check frontpage badges, so it's less scary when the develop checks happen to be failing.

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
