### PR TITLE
Filter-out local datasets when calling base-rule

### DIFF
--- a/tests/integration/test_ask_tell_optimization.py
+++ b/tests/integration/test_ask_tell_optimization.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import copy
 import pickle
 import tempfile
-from typing import Callable, Tuple, Union
+from typing import Callable, Mapping, Tuple, Union
 
 import numpy.testing as npt
 import pytest
@@ -36,6 +36,7 @@ from trieste.acquisition.rule import (
 from trieste.acquisition.utils import copy_to_local_models
 from trieste.ask_tell_optimization import AskTellOptimizer
 from trieste.bayesian_optimizer import OptimizationResult, Record
+from trieste.data import Dataset
 from trieste.logging import set_step_number, tensorboard_writer
 from trieste.models import TrainableProbabilisticModel
 from trieste.models.gpflow import GaussianProcessRegression, build_gpr
@@ -43,7 +44,7 @@ from trieste.objectives import ScaledBranin, SimpleQuadratic
 from trieste.objectives.utils import mk_batch_observer, mk_observer
 from trieste.observer import OBJECTIVE
 from trieste.space import Box, SearchSpace
-from trieste.types import State, TensorType
+from trieste.types import State, Tag, TensorType
 
 # Optimizer parameters for testing against the branin function.
 # We use a copy of these for a quicker test against a simple quadratic function
@@ -212,7 +213,9 @@ def _test_ask_tell_optimization_finds_minima(
 
                 # If query points are rank 3, then use a batched observer.
                 if tf.rank(new_point) == 3:
-                    new_data_point = batch_observer(new_point)
+                    new_data_point: Union[Mapping[Tag, Dataset], Dataset] = batch_observer(
+                        new_point
+                    )
                 else:
                     new_data_point = observer(new_point)
 

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -1816,7 +1816,7 @@ def test_multi_trust_region_box_acquire_filters() -> None:
 
     # Create a BatchTrustRegionBox instance with the mock base_rule.
     subspaces = [SingleObjectiveTrustRegionBox(search_space) for _ in range(2)]
-    rule = BatchTrustRegionBox(subspaces, mock_base_rule)  # type: ignore[var-annotated]
+    rule: BatchTrustRegionBox[ProbabilisticModel] = BatchTrustRegionBox(subspaces, mock_base_rule)
 
     rule.acquire(search_space, models, datasets)(None)
 

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1234,8 +1234,8 @@ class BatchTrustRegion(
         # Otherwise, run the base rule as is (i.e as a batch), once with all models and datasets.
         # Note: this should only trigger on the first call to `acquire`, as after that we will
         # have a list of rules in `self._rules`.
-        if self._rules is None and (
-            _num_local_models > 0 or not isinstance(self._rule, EfficientGlobalOptimization)
+        if self._rules is None and not (
+            _num_local_models == 0 and isinstance(self._rule, EfficientGlobalOptimization)
         ):
             self._rules = [copy.deepcopy(self._rule) for _ in range(num_subspaces)]
 
@@ -1282,8 +1282,8 @@ class BatchTrustRegion(
                     _points.append(rule.acquire(subspace, _models, _datasets))
                 points = tf.stack(_points, axis=1)
             else:
-                # Filter out local datasets as this is the EGO rule with normal acquisition
-                # functions that don't expect local datasets.
+                # Filter out local datasets as this is a rule (currently only EGO) with normal
+                # acquisition functions that don't expect local datasets.
                 # Note: no need to filter out local models, as setups with local models
                 # are handled above (i.e. we run the base rule sequentially for each subspace).
                 if datasets is not None:

--- a/trieste/objectives/utils.py
+++ b/trieste/objectives/utils.py
@@ -65,7 +65,7 @@ def mk_multi_observer(**kwargs: Callable[[TensorType], TensorType]) -> MultiObse
 def mk_batch_observer(
     objective_or_observer: Union[Callable[[TensorType], TensorType], Observer],
     default_key: Tag = OBJECTIVE,
-) -> Observer:
+) -> MultiObserver:
     """
     Create an observer that returns the data from ``objective`` or an existing ``observer``
     separately for each query point in a batch.


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Filter out local datasets when calling the EGO base rule. This will reduce the burden of filtering on most acquisition rules/functions that we currently have. If in the future we have acquisition rules/functions that need to see the local datasets, we can expand the functionality then.

Also took the opportunity to fix a very minor typing issue in `mk_batch_observer`.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
