### PR TITLE
Make get_unique_points more efficient

### DIFF
--- a/tests/unit/acquisition/test_utils.py
+++ b/tests/unit/acquisition/test_utils.py
@@ -182,12 +182,12 @@ def test_with_local_datasets(
         (
             tf.constant([[1.0], [2.0], [1.0], [3.0], [1.71], [1.699999], [3.29], [3.300001]]),
             0.3,
-            tf.constant([True, True, False, True, False, True, False, True]),
+            tf.constant([True, True, False, True, False, False, False, True]),
         ),
         (
             tf.constant([[1.0], [2.0], [1.0], [3.0], [1.699999], [1.71], [3.300001], [3.29]]),
             0.3,
-            tf.constant([True, True, False, True, True, False, True, False]),
+            tf.constant([True, True, False, True, False, False, True, False]),
         ),
     ],
 )

--- a/tests/unit/acquisition/test_utils.py
+++ b/tests/unit/acquisition/test_utils.py
@@ -180,14 +180,14 @@ def test_with_local_datasets(
             tf.constant([True, True, False]),
         ),
         (
-            tf.constant([[1.0], [2.0], [1.0], [3.0], [1.71], [1.699999], [3.29], [3.300001]]),
+            tf.constant([[1.0], [2.0], [1.0], [3.0], [2.1], [2.10001], [3.29], [3.300001]]),
             0.3,
-            tf.constant([True, True, False, True, False, False, False, True]),
+            tf.constant([True, True, False, True, False, True, False, True]),
         ),
         (
-            tf.constant([[1.0], [2.0], [1.0], [3.0], [1.699999], [1.71], [3.300001], [3.29]]),
+            tf.constant([[1.0], [2.0], [1.0], [3.0], [2.10001], [2.1], [3.300001], [3.29]]),
             0.3,
-            tf.constant([True, True, False, True, False, False, True, False]),
+            tf.constant([True, True, False, True, True, False, True, False]),
         ),
     ],
 )

--- a/trieste/acquisition/utils.py
+++ b/trieste/acquisition/utils.py
@@ -187,7 +187,8 @@ def with_local_datasets(
     "return: [n_points]",
 )
 def get_unique_points_mask(points: TensorType, tolerance: float = 1e-6) -> TensorType:
-    """Find the boolean mask of unique points in a tensor, within a given tolerance.
+    """Find the boolean mask of unique points in a tensor within a given tolerance, using
+    grid rounding.
 
     Users can get the actual points with:
 


### PR DESCRIPTION
**Related issue(s)/PRs:** #781 

## Summary

Make get_unique_points more efficient and document its precise behaviour.

**Fully backwards compatible:** ish

The behaviour changes as we now use rounding to select points rather than a distance based loop. But the old behaviour was never fully documented, and the rounding approach should work fine for BatchTrustRegionBox.get_initialize_subspaces_mask which is the only place we currently use it.

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
