### PR TITLE
Make get_unique_points_mask more efficient

### DIFF
--- a/tests/unit/acquisition/test_utils.py
+++ b/tests/unit/acquisition/test_utils.py
@@ -189,6 +189,9 @@ def test_with_local_datasets(
             0.3,
             tf.constant([True, True, False, True, True, False, True, False]),
         ),
+        (tf.constant([[1], [2], [3], [4]]), 1, tf.constant([True, False, True, False])),
+        (tf.constant([[1]]), 0, tf.constant([True])),
+        (tf.zeros([0, 2]), 0, tf.constant([])),
     ],
 )
 def test_get_unique_points_mask(


### PR DESCRIPTION
**Related issue(s)/PRs:** #781 

## Summary

Make get_unique_points_mask run in parallel. Since this approach detects connected graph components, it can trip up on examples like [1,2,3,4] with tolerance 1, which should return two points not one, even though all the points are connected. However, we can fix this using what will almost certainly be a small number of iterations.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
