### PR TITLE
Trust region with mixed search spaces

### DIFF
--- a/docs/notebooks/mixed_search_spaces.pct.py
+++ b/docs/notebooks/mixed_search_spaces.pct.py
@@ -67,6 +67,8 @@ fig.show()
 # We create our mixed search space by instantiating this class with a list containing the discrete
 # and continuous spaces, without any explicit tags (hence using default tags).
 # This can be easily extended to more than two search spaces by adding more elements to the list.
+#
+# Note: the dtype of all the component search spaces must be the same.
 
 # %%
 from trieste.space import Box, DiscreteSearchSpace, TaggedProductSearchSpace

--- a/docs/notebooks/mixed_search_spaces.pct.py
+++ b/docs/notebooks/mixed_search_spaces.pct.py
@@ -238,8 +238,15 @@ model = GaussianProcessRegression(gpflow_model)
 # acquisition rule as the base rule. The trust region acquisition rule is initialized with a set of
 # trust regions; 5 in this example. Each trust regions is defined as a product of a discrete and a
 # continuous trust sub-region. The base rule is then used to optimize the acquisition function
-# within each trust region. This setup is analogous to the one used in the "Batch trust region rule"
+# within each trust region. This setup is similar to the one used in the "Batch trust region rule"
 # section of the [trust region Bayesian optimization notebook](trust_region.ipynb).
+#
+# Analogous to a `TaggedProductSearchSpace`, each trust region is a product of a discrete and a
+# continuous trust (sub-)region. The discrete sub-region is defined by
+# `FixedPointTrustRegionDiscrete` that selects a random point from the discrete space, which is then
+# fixed for the duration of the optimization. The continuous sub-region is defined by
+# `SingleObjectiveTrustRegionBox`, just as in the trust region notebook, where the region is updated
+# at each step of the optimization.
 
 # %%
 from trieste.acquisition import ParallelContinuousThompsonSampling

--- a/docs/notebooks/mixed_search_spaces.pct.py
+++ b/docs/notebooks/mixed_search_spaces.pct.py
@@ -218,6 +218,161 @@ for point in points:
     )
 
 # %% [markdown]
+# ## Trust region with mixed search spaces
+#
+# In this section, we demonstrate the use of trust region acquisition rules with mixed search
+# spaces. We use the same mixed search space and observer as before, and the same initial data.
+# See [trust region Bayesian optimization notebook](trust_region.ipynb) for an introduction to
+# trust region acquisition rules.
+#
+# First we build a Gaussian process model of the objective function using the initial data.
+
+# %%
+gpflow_model = build_gpr(
+    initial_data, mixed_search_space, likelihood_variance=1e-7
+)
+model = GaussianProcessRegression(gpflow_model)
+
+# %% [markdown]
+# We create a trust region acquisition rule that uses the efficient global optimization (EGO)
+# acquisition rule as the base rule. The trust region acquisition rule is initialized with a set of
+# trust regions; 5 in this example. Each trust regions is defined as a product of a discrete and a
+# continuous trust sub-region. The base rule is then used to optimize the acquisition function
+# within each trust region. This setup is analogous to the one used in the "Batch trust region rule"
+# section of the [trust region Bayesian optimization notebook](trust_region.ipynb).
+
+# %%
+from trieste.acquisition import ParallelContinuousThompsonSampling
+from trieste.acquisition.rule import (
+    BatchTrustRegionProduct,
+    EfficientGlobalOptimization,
+    FixedPointTrustRegionDiscrete,
+    SingleObjectiveTrustRegionBox,
+    UpdatableTrustRegionProduct,
+)
+
+num_query_points = 5
+init_regions = [
+    UpdatableTrustRegionProduct(
+        [
+            FixedPointTrustRegionDiscrete(discrete_space),
+            SingleObjectiveTrustRegionBox(continuous_space),
+        ]
+    )
+    for _ in range(num_query_points)
+]
+base_rule = EfficientGlobalOptimization(  # type: ignore[var-annotated]
+    builder=ParallelContinuousThompsonSampling(),
+    num_query_points=num_query_points,
+)
+tr_acq_rule = BatchTrustRegionProduct(init_regions, base_rule)
+
+# %% [markdown]
+# We run the optimization loop for 15 steps using the trust region acquisition rule.
+
+# %%
+bo = BayesianOptimizer(observer, mixed_search_space)
+
+num_steps = 15
+tr_result = bo.optimize(
+    num_steps, initial_data, model, tr_acq_rule, track_state=True
+)
+dataset = tr_result.try_get_final_dataset()
+
+# %% [markdown]
+# The best point found by the optimizer is obtained as before.
+
+# %%
+query_point, observation, arg_min_idx = tr_result.try_get_optimal_point()
+
+print(f"query point: {query_point}")
+print(f"observation: {observation}")
+
+# %% [markdown]
+# Plot of the optimization loop over the mixed search space, similar to the previous plot.
+
+# %%
+query_points = dataset.query_points.numpy()
+observations = dataset.observations.numpy()
+
+_, ax = plot_function_2d(
+    scaled_branin,
+    ScaledBranin.search_space.lower,
+    ScaledBranin.search_space.upper,
+    contour=True,
+)
+plot_bo_points(query_points, ax[0, 0], num_initial_points, arg_min_idx)
+ax[0, 0].set_xlabel(r"$x_1$")
+ax[0, 0].set_ylabel(r"$x_2$")
+
+for point in points:
+    ax[0, 0].vlines(
+        point,
+        mixed_search_space.lower[1],
+        mixed_search_space.upper[1],
+        colors="b",
+        linestyles="dashed",
+        alpha=0.6,
+    )
+
+# %% [markdown]
+# Finally, we visualize the optimization progress by plotting the 5 (product) trust regions at each
+# step. The trust regions are shown as translucent boxes, with each box in a different color. The
+# new query point for earch region is plotted in matching color.
+#
+# Note that since the discrete dimension is on the x-axis, the trust regions appear as vertical
+# lines with zero width.
+
+# %%
+import base64
+from typing import Optional
+
+import IPython
+import matplotlib.pyplot as plt
+
+from trieste.bayesian_optimizer import OptimizationResult
+from trieste.experimental.plotting import (
+    convert_figure_to_frame,
+    convert_frames_to_gif,
+    plot_trust_region_history_2d,
+)
+
+
+def plot_history(
+    result: OptimizationResult,
+    num_query_points: Optional[int] = None,
+) -> None:
+    frames = []
+    for step, hist in enumerate(
+        result.history + [result.final_result.unwrap()]
+    ):
+        fig, _ = plot_trust_region_history_2d(
+            scaled_branin,
+            ScaledBranin.search_space.lower,
+            ScaledBranin.search_space.upper,
+            hist,
+            num_query_points=num_query_points,
+            num_init=num_initial_points,
+            alpha=1.0,
+        )
+
+        if fig is not None:
+            fig.suptitle(f"step number {step}")
+            frames.append(convert_figure_to_frame(fig))
+            plt.close(fig)
+
+    gif_file = convert_frames_to_gif(frames)
+    gif = IPython.display.HTML(
+        '<img src="data:image/gif;base64,{0}"/>'.format(
+            base64.b64encode(gif_file.getvalue()).decode()
+        )
+    )
+    IPython.display.display(gif)
+
+
+plot_history(tr_result)
+
+# %% [markdown]
 # ## LICENSE
 #
 # [Apache License 2.0](https://github.com/secondmind-labs/trieste/blob/develop/LICENSE)

--- a/tests/integration/test_mixed_space_bayesian_optimization.py
+++ b/tests/integration/test_mixed_space_bayesian_optimization.py
@@ -32,6 +32,7 @@ from trieste.acquisition.rule import (
     EfficientGlobalOptimization,
     FixedPointTrustRegionDiscrete,
     SingleObjectiveTrustRegionBox,
+    TURBOBox,
     UpdatableTrustRegionProduct,
 )
 from trieste.bayesian_optimizer import BayesianOptimizer
@@ -99,7 +100,32 @@ mixed_search_space = TaggedProductSearchSpace(
                     num_query_points=10,
                 ),
             ),
-            id="BatchTrustRegionProduct",
+            id="TrustRegionSingleObjectiveFixed",
+        ),
+        pytest.param(
+            10,
+            BatchTrustRegionProduct(
+                [
+                    UpdatableTrustRegionProduct(
+                        [
+                            TURBOBox(mixed_search_space.get_subspace("continuous")),
+                            FixedPointTrustRegionDiscrete(
+                                cast(
+                                    DiscreteSearchSpace, mixed_search_space.get_subspace("discrete")
+                                )
+                            ),
+                        ],
+                        tags=mixed_search_space.subspace_tags,
+                    )
+                    for _ in range(10)
+                ],
+                EfficientGlobalOptimization(
+                    ParallelContinuousThompsonSampling(),
+                    # See comment above.
+                    num_query_points=10,
+                ),
+            ),
+            id="TrustRegionTurboFixed",
         ),
     ],
 )

--- a/tests/integration/test_mixed_space_bayesian_optimization.py
+++ b/tests/integration/test_mixed_space_bayesian_optimization.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+from typing import cast
+
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
@@ -80,7 +82,9 @@ mixed_search_space = TaggedProductSearchSpace(
                                 mixed_search_space.get_subspace("continuous")
                             ),
                             FixedPointTrustRegionDiscrete(
-                                mixed_search_space.get_subspace("discrete")
+                                cast(
+                                    DiscreteSearchSpace, mixed_search_space.get_subspace("discrete")
+                                )
                             ),
                         ],
                         tags=mixed_search_space.subspace_tags,

--- a/tests/integration/test_mixed_space_bayesian_optimization.py
+++ b/tests/integration/test_mixed_space_bayesian_optimization.py
@@ -32,7 +32,6 @@ from trieste.acquisition.rule import (
     EfficientGlobalOptimization,
     FixedPointTrustRegionDiscrete,
     SingleObjectiveTrustRegionBox,
-    TURBOBox,
     UpdatableTrustRegionProduct,
 )
 from trieste.bayesian_optimizer import BayesianOptimizer
@@ -101,31 +100,6 @@ mixed_search_space = TaggedProductSearchSpace(
                 ),
             ),
             id="TrustRegionSingleObjectiveFixed",
-        ),
-        pytest.param(
-            10,
-            BatchTrustRegionProduct(
-                [
-                    UpdatableTrustRegionProduct(
-                        [
-                            TURBOBox(mixed_search_space.get_subspace("continuous")),
-                            FixedPointTrustRegionDiscrete(
-                                cast(
-                                    DiscreteSearchSpace, mixed_search_space.get_subspace("discrete")
-                                )
-                            ),
-                        ],
-                        tags=mixed_search_space.subspace_tags,
-                    )
-                    for _ in range(10)
-                ],
-                EfficientGlobalOptimization(
-                    ParallelContinuousThompsonSampling(),
-                    # See comment above.
-                    num_query_points=10,
-                ),
-            ),
-            id="TrustRegionTurboFixed",
         ),
     ],
 )

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -51,10 +51,12 @@ from trieste.acquisition.rule import (
     BatchTrustRegionBox,
     DiscreteThompsonSampling,
     EfficientGlobalOptimization,
+    FixedPointTrustRegionDiscrete,
     RandomSampling,
     SingleObjectiveTrustRegionBox,
     TREGOBox,
     TURBOBox,
+    UpdatableTrustRegionProduct,
 )
 from trieste.acquisition.sampler import (
     ExactThompsonSampler,
@@ -68,7 +70,7 @@ from trieste.models import ProbabilisticModel
 from trieste.models.interfaces import TrainableSupportsGetKernel
 from trieste.objectives.utils import mk_batch_observer
 from trieste.observer import OBJECTIVE
-from trieste.space import Box, SearchSpace, TaggedMultiSearchSpace
+from trieste.space import Box, DiscreteSearchSpace, SearchSpace, TaggedMultiSearchSpace
 from trieste.types import State, Tag, TensorType
 from trieste.utils.misc import LocalizedTag, get_value_for_tag
 
@@ -1407,6 +1409,172 @@ def test_trust_region_box_update_size(success: bool) -> None:
     # Check the new box bounds.
     npt.assert_allclose(trb.lower, np.maximum(trb.location - trb.eps, search_space.lower))
     npt.assert_allclose(trb.upper, np.minimum(trb.location + trb.eps, search_space.upper))
+
+
+@pytest.fixture
+def discrete_search_space() -> DiscreteSearchSpace:
+    return DiscreteSearchSpace(np.arange(10)[:, None])
+
+
+@pytest.fixture
+def continuous_search_space() -> Box:
+    return Box([0.0], [1.0])
+
+
+@pytest.mark.parametrize("with_initialize", [True, False])
+def test_fixed_trust_region_discrete_initialize(
+    discrete_search_space: DiscreteSearchSpace, with_initialize: bool
+) -> None:
+    # Check that FixedTrustRegionDiscrete inits correctly by picking a single point from the global
+    # search space.
+    tr = FixedPointTrustRegionDiscrete(discrete_search_space)
+    if with_initialize:
+        tr.initialize()
+    assert tr.location.shape == (1,)
+    assert tr.location in discrete_search_space
+
+
+def test_fixed_trust_region_discrete_update(
+    discrete_search_space: DiscreteSearchSpace,
+) -> None:
+    # Update call should not change the location of the region.
+    tr = FixedPointTrustRegionDiscrete(discrete_search_space)
+    tr.initialize()
+    orig_location = tr.location.numpy()
+    tr.update()
+    npt.assert_equal(orig_location, tr.location)
+
+
+def test_updatable_tr_product_raises_on_no_regions() -> None:
+    with pytest.raises(AssertionError, match="at least one region should be provided"):
+        UpdatableTrustRegionProduct([])
+
+
+def test_updatable_tr_product_raises_on_missing_index(
+    discrete_search_space: DiscreteSearchSpace, continuous_search_space: Box
+) -> None:
+    region1 = FixedPointTrustRegionDiscrete(discrete_search_space, region_index=0)
+    region2 = SingleObjectiveTrustRegionBox(continuous_search_space, region_index=1)
+    with pytest.raises(AssertionError, match="regions can only have a region_index"):
+        UpdatableTrustRegionProduct([region1, region2])
+
+
+def test_updatable_tr_product_raises_on_mimatch_index(
+    discrete_search_space: DiscreteSearchSpace, continuous_search_space: Box
+) -> None:
+    region1 = FixedPointTrustRegionDiscrete(discrete_search_space, region_index=0)
+    region2 = SingleObjectiveTrustRegionBox(continuous_search_space, region_index=1)
+    with pytest.raises(AssertionError, match="all regions should have the same index"):
+        UpdatableTrustRegionProduct([region1, region2], region_index=0)
+
+
+def test_updatable_tr_product_sets_all_region_indices(
+    discrete_search_space: DiscreteSearchSpace, continuous_search_space: Box
+) -> None:
+    region1 = FixedPointTrustRegionDiscrete(discrete_search_space, region_index=None)
+    region2 = SingleObjectiveTrustRegionBox(continuous_search_space, region_index=1)
+    tr = UpdatableTrustRegionProduct([region1, region2], region_index=1)
+
+    assert tuple(tr.regions.keys()) == tr.subspace_tags
+    assert list(tr.regions.values()) == [region1, region2]
+
+    assert next(iter(tr.regions.values())).region_index == 1
+    assert len(set([region.region_index for region in tr.regions.values()])) == 1
+    tr.region_index = 10
+    assert next(iter(tr.regions.values())).region_index == 10
+    assert len(set([region.region_index for region in tr.regions.values()])) == 1
+
+
+@pytest.mark.parametrize("disc_dtype", [tf.int32, tf.int64, tf.float32, tf.float64])
+def test_updatable_tr_product_location(
+    disc_dtype: tf.DType, discrete_search_space: DiscreteSearchSpace, continuous_search_space: Box
+) -> None:
+    # Check that we can combine locations of different and same dtypes. continuous_search_space
+    # is of dtype float64, and discrete_search_space is of dtype int64. We cast the
+    # discrete_search_space to different dtype to check that the UpdatableTrustRegionProduct can
+    # handle different dtypes.
+    casted_discrete_search_space = DiscreteSearchSpace(
+        tf.cast(discrete_search_space.points, disc_dtype)
+    )
+    region1 = FixedPointTrustRegionDiscrete(casted_discrete_search_space)
+    region2 = SingleObjectiveTrustRegionBox(continuous_search_space)
+    tr = UpdatableTrustRegionProduct([region1, region2])
+
+    assert tr.location.dtype == tf.float64
+    npt.assert_array_equal(
+        tr.location, np.concatenate([region1.location, region2.location], axis=-1)
+    )
+
+
+@pytest.mark.parametrize("initialize_n_update", [True, False])
+def test_updatable_tr_product_initialize_update_calls_subregions(initialize_n_update: bool) -> None:
+    # Calling initialize/update should call the initialize/update method of all subregions.
+    region1 = MagicMock(spec=FixedPointTrustRegionDiscrete, region_index=None, dimension=1)
+    region2 = MagicMock(spec=SingleObjectiveTrustRegionBox, region_index=None, dimension=1)
+    tr = UpdatableTrustRegionProduct([region1, region2])
+
+    models = {OBJECTIVE: QuadraticMeanAndRBFKernel()}
+    datasets = {
+        OBJECTIVE: Dataset(
+            tf.constant([[3.0, 0.5], [1.0, 0.0], [2.0, 1.0]], dtype=tf.float64),
+            tf.constant([[0.5], [0.0], [1.0]], dtype=tf.float64),
+        )
+    }
+
+    if initialize_n_update:
+        tr.initialize(models, datasets, "dummy_arg", dummy_kwarg="dummy_kwarg_value")
+    else:
+        tr.update(models, datasets, "dummy_arg", dummy_kwarg="dummy_kwarg_value")
+
+    for region, exp_qps in zip(
+        [region1, region2],
+        [
+            tf.constant([[3.0], [1.0], [2.0]], dtype=tf.float64),
+            tf.constant([[0.5], [0.0], [1.0]], dtype=tf.float64),
+        ],
+    ):
+        # Can't use region1.*.assert_called_once_with() directly as bool comparison
+        # doesn't work with datasets. So we check the call_args instead.
+        mock = region.initialize if initialize_n_update else region.update
+        mock.assert_called_once()
+        assert mock.call_args.kwargs == {"dummy_kwarg": "dummy_kwarg_value"}
+        assert mock.call_args.args[0] == models
+        call_dataset = mock.call_args.args[1]
+        assert call_dataset.keys() == {OBJECTIVE}
+        npt.assert_array_equal(
+            exp_qps,
+            call_dataset[OBJECTIVE].query_points,
+        )
+        npt.assert_array_equal(
+            tf.constant([[0.5], [0.0], [1.0]], dtype=tf.float64),
+            call_dataset[OBJECTIVE].observations,
+        )
+        assert mock.call_args.args[2] == "dummy_arg"
+
+
+def test_updatable_tr_product_datasets_filter_mask() -> None:
+    # Calling get_datasets_filter_mask on the product region returns a boolean AND of the masks
+    # returned by the subregions.
+    region1 = MagicMock(spec=FixedPointTrustRegionDiscrete, region_index=None, dimension=1)
+    region1.get_datasets_filter_mask.return_value = {
+        "tag1": tf.constant([True, False, True], dtype=tf.bool),
+        "tag2": tf.constant([True, True, False], dtype=tf.bool),
+    }
+    region2 = MagicMock(spec=SingleObjectiveTrustRegionBox, region_index=None, dimension=1)
+    region2.get_datasets_filter_mask.return_value = {
+        "tag1": tf.constant([True, False, False], dtype=tf.bool),
+        "tag2": tf.constant([True, True, True], dtype=tf.bool),
+    }
+    tr = UpdatableTrustRegionProduct([region1, region2], region_index=3)
+
+    datasets = {OBJECTIVE: empty_dataset([2], [1])}
+    mask = tr.get_datasets_filter_mask(datasets)
+    assert mask is not None
+    assert mask.keys() == {"tag1", "tag2"}
+    npt.assert_array_equal(mask["tag1"], [True, False, False])
+    npt.assert_array_equal(mask["tag2"], [True, True, False])
+    # region1.get_datasets_filter_mask.assert_called_once_with({OBJECTIVE: empty_dataset([1], [1])})
+    # region2.get_datasets_filter_mask.assert_called_once_with({OBJECTIVE: empty_dataset([1], [1])})
 
 
 # Check multi trust region works when no subspace is provided.

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -1872,7 +1872,7 @@ def test_multi_trust_region_box_state_deepcopy() -> None:
 
 @pytest.fixture
 def discrete_search_space() -> DiscreteSearchSpace:
-    return DiscreteSearchSpace(np.arange(10)[:, None])
+    return DiscreteSearchSpace(np.arange(10, dtype=np.float64)[:, None])
 
 
 @pytest.fixture
@@ -1944,18 +1944,11 @@ def test_updatable_tr_product_sets_all_region_indices(
     assert len(set([region.region_index for region in tr.regions.values()])) == 1
 
 
-@pytest.mark.parametrize("disc_dtype", [tf.int32, tf.int64, tf.float32, tf.float64])
 def test_updatable_tr_product_location(
-    disc_dtype: tf.DType, discrete_search_space: DiscreteSearchSpace, continuous_search_space: Box
+    discrete_search_space: DiscreteSearchSpace, continuous_search_space: Box
 ) -> None:
-    # Check that we can combine locations of different and same dtypes. continuous_search_space
-    # is of dtype float64, and discrete_search_space is of dtype int64. We cast the
-    # discrete_search_space to different dtype to check that the UpdatableTrustRegionProduct can
-    # handle different dtypes.
-    casted_discrete_search_space = DiscreteSearchSpace(
-        tf.cast(discrete_search_space.points, disc_dtype)
-    )
-    region1 = FixedPointTrustRegionDiscrete(casted_discrete_search_space)
+    # Check the combined locations of the subregions.
+    region1 = FixedPointTrustRegionDiscrete(discrete_search_space)
     region2 = SingleObjectiveTrustRegionBox(continuous_search_space)
     tr = UpdatableTrustRegionProduct([region1, region2])
 

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -2012,7 +2012,7 @@ def test_updatable_tr_product_method_calls_subregions(
     in_datasets: Optional[Mapping[Tag, Dataset]],
     exp_datasets: List[Optional[Mapping[Tag, Dataset]]],
 ) -> None:
-    # Calling initialize/update should call the initialize/update method of all subregions.
+    # Calling initialize/update/* should call the initialize/update/* method of all subregions.
     region1 = MagicMock(spec=FixedPointTrustRegionDiscrete, region_index=None, dimension=1)
     region2 = MagicMock(spec=SingleObjectiveTrustRegionBox, region_index=None, dimension=1)
     tr = UpdatableTrustRegionProduct([region1, region2], region_index=2)

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -1918,7 +1918,7 @@ def test_updatable_tr_product_raises_on_missing_index(
         UpdatableTrustRegionProduct([region1, region2])
 
 
-def test_updatable_tr_product_raises_on_mimatch_index(
+def test_updatable_tr_product_raises_on_mismatch_index(
     discrete_search_space: DiscreteSearchSpace, continuous_search_space: Box
 ) -> None:
     region1 = FixedPointTrustRegionDiscrete(discrete_search_space, region_index=0)
@@ -2012,7 +2012,8 @@ def test_updatable_tr_product_method_calls_subregions(
     in_datasets: Optional[Mapping[Tag, Dataset]],
     exp_datasets: List[Optional[Mapping[Tag, Dataset]]],
 ) -> None:
-    # Calling initialize/update/* should call the initialize/update/* method of all subregions.
+    # Check that calling initialize/update/* should call the initialize/update/* method of all
+    # subregions with the correct arguments.
     region1 = MagicMock(spec=FixedPointTrustRegionDiscrete, region_index=None, dimension=1)
     region2 = MagicMock(spec=SingleObjectiveTrustRegionBox, region_index=None, dimension=1)
     tr = UpdatableTrustRegionProduct([region1, region2], region_index=2)

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -1573,12 +1573,13 @@ def test_updatable_tr_product_method_calls_subregions(
         mock.assert_called_once()  # type: ignore[attr-defined]
         call_args = mock.call_args  # type: ignore[attr-defined]
         if datasets_only_arg:
-            call_dataset = call_args.args[0]
+            call_dataset = call_args[0][0]
         else:
-            assert call_args.kwargs == {"dummy_kwarg": "dummy_kwarg_value"}
-            assert call_args.args[0] == models
-            call_dataset = call_args.args[1]
-            assert call_args.args[2] == "dummy_arg"
+            print(call_args[1])
+            assert call_args[1] == {"dummy_kwarg": "dummy_kwarg_value"}
+            assert call_args[0][0] == models
+            call_dataset = call_args[0][1]
+            assert call_args[0][2] == "dummy_arg"
 
         if exp_d is None:
             assert call_dataset is None

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1983,10 +1983,13 @@ class UpdatableTrustRegionProduct(TaggedProductSearchSpace, UpdatableTrustRegion
     def __init__(
         self,
         regions: Sequence[UpdatableTrustRegionWithGlobalSearchSpace],
+        tags: Optional[Sequence[str]] = None,
         region_index: Optional[int] = None,
     ):
         """
         :param regions: The trust sub-regions to be combined to create a product trust region.
+        :param tags: An optional list of tags giving the unique identifiers of the region's
+            sub-regions.
         :param region_index: The index of the region in a multi-region search space. This is used to
             identify the local models and datasets to use for acquisition. If `None`, the
             global models and datasets are used.
@@ -2010,7 +2013,7 @@ class UpdatableTrustRegionProduct(TaggedProductSearchSpace, UpdatableTrustRegion
             )
 
         self._global_search_space = TaggedProductSearchSpace(
-            [region.global_search_space for region in regions]
+            [region.global_search_space for region in regions], tags
         )
 
         TaggedProductSearchSpace.__init__(self, regions)

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -2013,11 +2013,6 @@ class UpdatableTrustRegionProduct(TaggedProductSearchSpace, UpdatableTrustRegion
             [region.global_search_space for region in regions]
         )
 
-        # Find the most general dtype of all the regions.
-        dtypes = [np.array(region.location).dtype for region in regions]
-        most_general_dtype = np.result_type(*dtypes)
-        self.dtype = most_general_dtype
-
         TaggedProductSearchSpace.__init__(self, regions)
         # When UpdatableTrustRegion sets the region_index, it will also set the region_index for
         # each region.
@@ -2052,9 +2047,7 @@ class UpdatableTrustRegionProduct(TaggedProductSearchSpace, UpdatableTrustRegion
         The location of the product trust region, concatenated from the locations of the
         sub-regions.
         """
-        return tf.concat(
-            [tf.cast(region.location, self.dtype) for region in self.regions.values()], axis=-1
-        )
+        return tf.concat([region.location for region in self.regions.values()], axis=-1)
 
     @property
     def global_search_space(self) -> TaggedProductSearchSpace:

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1005,6 +1005,10 @@ class UpdatableTrustRegion(SearchSpace):
             global models and datasets are used.
         :param input_active_dims: The active dimensions of the input space, either a slice or list
             of indices into the columns of the space. If `None`, all dimensions are active.
+
+            When this region is part of a product search-space (via `UpdatableTrustRegionProduct`),
+            this is used to select the active dimensions of the full input space that belong to this
+            region.
         """
         self.region_index = region_index
         self.input_active_dims = input_active_dims

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1898,7 +1898,7 @@ class TURBOBox(UpdatableTrustRegionBox):
 
 class UpdatableTrustRegionDiscrete(DiscreteSearchSpace, UpdatableTrustRegion):
     """
-    A simple updatable discrete search space with an associated global search space.
+    An updatable discrete search space with an associated global search space.
     """
 
     def __init__(
@@ -1971,6 +1971,10 @@ UpdatableTrustRegionWithGlobalSearchSpace = Union[
 
 
 class UpdatableTrustRegionProduct(TaggedProductSearchSpace, UpdatableTrustRegion):
+    """
+    An updatable mixed search space that is the product of multiple updatable trust sub-regions.
+    """
+
     def __init__(
         self,
         regions: Sequence[UpdatableTrustRegionWithGlobalSearchSpace],

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1991,8 +1991,8 @@ class UpdatableTrustRegionProduct(TaggedProductSearchSpace, UpdatableTrustRegion
                 for region in regions
                 if region.region_index is not None
             ), (
-                f"all regions should have the same index, if set, as the "
-                "product region ({region_index})"
+                "all regions should have the same index, if set, as the "
+                f"product region ({region_index})"
             )
         else:
             assert all(region.region_index is None for region in regions), (

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1100,7 +1100,27 @@ class UpdatableTrustRegion(SearchSpace):
         else:
             return selected_input
 
-    def select_in_region(self, mapping: Optional[Mapping[Tag, T]]) -> Optional[Mapping[Tag, T]]:
+    @overload
+    def select_in_region(self, mapping: None) -> None:
+        ...
+
+    @overload
+    def select_in_region(self, mapping: Mapping[Tag, TensorType]) -> Mapping[Tag, TensorType]:
+        ...
+
+    @overload
+    def select_in_region(self, mapping: Mapping[Tag, Dataset]) -> Mapping[Tag, Dataset]:
+        ...
+
+    @overload
+    def select_in_region(
+        self, mapping: Mapping[Tag, ProbabilisticModel]
+    ) -> Mapping[Tag, ProbabilisticModel]:
+        ...
+
+    def select_in_region(
+        self, mapping: Optional[Mapping[Tag, Union[TensorType, Dataset, ProbabilisticModel]]]
+    ) -> Optional[Mapping[Tag, Union[TensorType, Dataset, ProbabilisticModel]]]:
         """
         Select items belonging to this region for acquisition.
 

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1930,7 +1930,9 @@ class UpdatableTrustRegionDiscrete(DiscreteSearchSpace, UpdatableTrustRegion):
 
 class FixedPointTrustRegionDiscrete(UpdatableTrustRegionDiscrete):
     """
-    A discrete trust region with a fixed point location that does not change.
+    A discrete trust region with a fixed point location that does not change across active learning
+    steps. The fixed point is selected at random from the global (discrete) search space at
+    initialization time.
     """
 
     def __init__(
@@ -1973,6 +1975,9 @@ UpdatableTrustRegionWithGlobalSearchSpace = Union[
 class UpdatableTrustRegionProduct(TaggedProductSearchSpace, UpdatableTrustRegion):
     """
     An updatable mixed search space that is the product of multiple updatable trust sub-regions.
+
+    This is useful for combining different types of search spaces, such as continuous and discrete,
+    to form a mixed search space for trust region acquisition rules.
     """
 
     def __init__(

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1978,6 +1978,8 @@ class UpdatableTrustRegionProduct(TaggedProductSearchSpace, UpdatableTrustRegion
 
     This is useful for combining different types of search spaces, such as continuous and discrete,
     to form a mixed search space for trust region acquisition rules.
+
+    Note: the dtype of all the component search spaces must be the same.
     """
 
     def __init__(

--- a/trieste/experimental/plotting/plotting.py
+++ b/trieste/experimental/plotting/plotting.py
@@ -555,6 +555,7 @@ def plot_trust_region_history_2d(
     history: Record[StateType, ProbabilisticModel] | FrozenRecord[StateType, ProbabilisticModel],
     num_query_points: Optional[int] = None,
     num_init: Optional[int] = None,
+    alpha: float = 0.3,
 ) -> tuple[Optional[Figure], Optional[Axes]]:
     """
     Plot the contour of the objective function, query points and the trust regions for a particular
@@ -566,6 +567,7 @@ def plot_trust_region_history_2d(
     :param history: the optimization history for a particular step of the optimization process
     :param num_query_points: total number of query points in this step
     :param num_init: initial number of BO points
+    :param alpha: transparency for the trust regions
     :return: figure and axes
     """
 
@@ -645,7 +647,7 @@ def plot_trust_region_history_2d(
                 ub[1] - lb[1],
                 facecolor=space_colors[i],
                 edgecolor=space_colors[i],
-                alpha=0.3,
+                alpha=alpha,
             )
         )
 

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -999,6 +999,8 @@ class TaggedProductSearchSpace(CollectionSearchSpace):
         decision_space = Box([-1, -2], [2, 3])
         mixed_space = TaggedProductSearchSpace(spaces=[context_space, decision_space])
 
+    Note: the dtype of all the component search spaces must be the same.
+
     Note that this class assumes that individual points in product spaces are
     represented with their inputs in the same order as specified when initializing
     the space.


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Trust regions with mixed search spaces are implemented by introducing the concept of a "product" trust region (and matching rule). This is analogous to `TaggedProductSearchSpace`.

`TaggedProductSearchSpace` internally contains a list of `SearchSpace` spaces; similarly `UpdatableTrustRegionProduct` contains a list of `UpdatableTrustRegion` regions.

The `mixed_search_spaces` notebook has been updated to show usage, and unit and integration tests have been added.

~~Integration tests do not exist for mixed search spaces (trust region or otherwise), mainly because we do not have a synthetic problem. The notebook creates a problem by discretizing one of the Branin dimensions. We could move this out of the notebook to create integration tests, or alternatively treat the notebook as "integration testing" for now.~~

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [X] Any new features are well-documented (in docstrings or notebooks)
