### PR TITLE
Update dill pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     python_requires="~=3.7",
     install_requires=[
         "absl-py",
-        "dill!=0.3.6",
+        "dill<0.3.6",
         "gpflow>=2.8.1",
         "gpflux>=0.4.2",
         "numpy",

--- a/tests/latest/constraints.txt
+++ b/tests/latest/constraints.txt
@@ -15,7 +15,7 @@ cvxpy==1.4.2
 cycler==0.12.1
 decorator==5.1.1
 Deprecated==1.2.14
-dill==0.3.8
+dill==0.3.5.1
 dm-tree==0.1.8
 dropstackframe==0.1.0
 ecos==2.0.13
@@ -51,7 +51,7 @@ osqp==0.6.5
 packaging==23.2
 pillow==10.2.0
 pluggy==1.4.0
-protobuf==4.23.4
+protobuf==4.25.2
 pyasn1==0.5.1
 pyasn1-modules==0.3.0
 pybind11==2.11.1
@@ -68,7 +68,7 @@ scipy==1.11.4
 scs==3.2.4.post1
 six==1.16.0
 tabulate==0.9.0
-tensorboard==2.15.1
+tensorboard==2.15.2
 tensorboard-data-server==0.7.2
 tensorflow==2.15.0
 tensorflow-estimator==2.15.0

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -667,9 +667,6 @@ class _DecreasingVarianceModel(QuadraticMeanAndRBFKernel, TrainableProbabilistic
 
 @pytest.mark.parametrize("save_to_disk", [False, True])
 def test_bayesian_optimizer_optimize_tracked_state(save_to_disk: bool) -> None:
-    if save_to_disk and Version(tfp.__version__) >= Version("0.23.0"):
-        # TODO: the latest tfp seems to have broken pickling QuadraticMeanAndRBFKernel
-        pytest.skip()
 
     class _CountingRule(AcquisitionRule[State[Optional[int], TensorType], Box, ProbabilisticModel]):
         def acquire(

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -21,9 +21,7 @@ from typing import NoReturn, Optional
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
-import tensorflow_probability as tfp
 from check_shapes import inherit_check_shapes
-from packaging.version import Version
 
 from tests.unit.test_ask_tell_optimization import DatasetChecker, LocalDatasetsFixedAcquisitionRule
 from tests.util.misc import (

--- a/tests/unit/test_bayesian_optimizer.py
+++ b/tests/unit/test_bayesian_optimizer.py
@@ -667,7 +667,6 @@ class _DecreasingVarianceModel(QuadraticMeanAndRBFKernel, TrainableProbabilistic
 
 @pytest.mark.parametrize("save_to_disk", [False, True])
 def test_bayesian_optimizer_optimize_tracked_state(save_to_disk: bool) -> None:
-
     class _CountingRule(AcquisitionRule[State[Optional[int], TensorType], Box, ProbabilisticModel]):
         def acquire(
             self,


### PR DESCRIPTION
**Related issue(s)/PRs:** https://github.com/uqfoundation/dill/issues/647

## Summary

Pin dill to <0.3.6 for now, as later versions don't seem to serialise some tensorflow-probability kernels.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
