### PR TITLE
Updatable discrete trust region

### DIFF
--- a/docs/notebooks/mixed_search_spaces.pct.py
+++ b/docs/notebooks/mixed_search_spaces.pct.py
@@ -251,6 +251,10 @@ model = GaussianProcessRegression(gpflow_model)
 # `SingleObjectiveTrustRegionDiscrete`, which follows a very similar algorithm to the continuous
 # one, but with a region defined by a set of neighboring points. Both the continuous and
 # discrete sub-regions are updated at each step of the optimization.
+#
+# Note that `SingleObjectiveTrustRegionDiscrete` is designed for discrete numerical
+# variables only, which we have in this example. It is not suitable for qualitative (categorical,
+# ordinal and binary) variables.
 
 # %%
 from trieste.acquisition import ParallelContinuousThompsonSampling

--- a/docs/notebooks/mixed_search_spaces.pct.py
+++ b/docs/notebooks/mixed_search_spaces.pct.py
@@ -241,7 +241,7 @@ model = GaussianProcessRegression(gpflow_model)
 # trust regions; 5 in this example. Each trust regions is defined as a product of a discrete and a
 # continuous trust sub-region, analogous to a `TaggedProductSearchSpace`. The base rule is then
 # called to optimize the acquisition function within each region.
-
+#
 # This setup is similar to the one used in the "Batch trust region rule"
 # section of the [trust region Bayesian optimization notebook](trust_region.ipynb). That notebook
 # creates trust regions of type `SingleObjectiveTrustRegionBox`. Here, we create trust regions that

--- a/tests/integration/test_mixed_space_bayesian_optimization.py
+++ b/tests/integration/test_mixed_space_bayesian_optimization.py
@@ -31,8 +31,8 @@ from trieste.acquisition.rule import (
     AcquisitionRule,
     BatchTrustRegionProduct,
     EfficientGlobalOptimization,
-    FixedPointTrustRegionDiscrete,
     SingleObjectiveTrustRegionBox,
+    SingleObjectiveTrustRegionDiscrete,
     UpdatableTrustRegionProduct,
 )
 from trieste.bayesian_optimizer import BayesianOptimizer
@@ -102,7 +102,7 @@ mixed_search_space = _get_mixed_search_space()
                 [
                     UpdatableTrustRegionProduct(
                         [
-                            FixedPointTrustRegionDiscrete(
+                            SingleObjectiveTrustRegionDiscrete(
                                 cast(
                                     DiscreteSearchSpace, mixed_search_space.get_subspace("discrete")
                                 )
@@ -113,17 +113,14 @@ mixed_search_space = _get_mixed_search_space()
                         ],
                         tags=mixed_search_space.subspace_tags,
                     )
-                    for _ in range(10)
+                    for _ in range(3)
                 ],
                 EfficientGlobalOptimization(
                     ParallelContinuousThompsonSampling(),
-                    # Use a large batch to ensure discrete init finds a good point.
-                    # We are using a fixed point trust region for the discrete space, so
-                    # the init point is randomly chosen and then never updated.
-                    num_query_points=10,
+                    num_query_points=3,
                 ),
             ),
-            id="TrustRegionSingleObjectiveFixed",
+            id="TrustRegionSingleObjective",
         ),
     ],
 )

--- a/tests/unit/acquisition/test_rule.py
+++ b/tests/unit/acquisition/test_rule.py
@@ -2158,14 +2158,14 @@ def test_trust_region_discrete_update_size(
     if success:
         # Check that the location is the new min point.
         new_point = np.squeeze(new_point)
-        npt.assert_equal(new_point, tr.location)
+        npt.assert_array_equal(new_point, tr.location)
         npt.assert_allclose(new_min, tr._y_min)
         # Check that the region is larger by beta.
         npt.assert_allclose(eps / tr._beta, tr.eps)
     else:
         # Check that the location is the old min point.
         orig_point = np.squeeze(orig_point)
-        npt.assert_equal(orig_point, tr.location)
+        npt.assert_array_equal(orig_point, tr.location)
         npt.assert_allclose(orig_min, tr._y_min)
         # Check that the region is smaller by beta.
         npt.assert_allclose(eps * tr._beta, tr.eps)
@@ -2173,8 +2173,8 @@ def test_trust_region_discrete_update_size(
     # Check the new set of neighbors.
     neighbors_mask = tf.abs(discrete_search_space.points - tr.location) <= tr.eps
     neighbors_mask = tf.reduce_all(neighbors_mask, axis=-1)
-    neighbors = discrete_search_space.points[neighbors_mask]
-    npt.assert_equal(tr.points, neighbors)
+    neighbors = tf.boolean_mask(discrete_search_space.points, neighbors_mask)
+    npt.assert_array_equal(tr.points, neighbors)
 
 
 def test_updatable_tr_product_raises_on_no_regions() -> None:

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -754,15 +754,15 @@ def get_bounds_of_optimization(space: SearchSpace, starting_points: TensorType) 
     For each starting point, the bounds are obtained as follows depending on the type of search
     space:
     - For a `TaggedProductSearchSpace`, a "continuous relaxation" of the discrete subspaces is
-      built by creating bounds around the point. The discrete components of the created
-      search space are fixed at the respective component of the point, and the
-      remaining continuous components are set to the original bounds of the search space.
+    built by creating bounds around the point. The discrete components of the created
+    search space are fixed at the respective component of the point, and the
+    remaining continuous components are set to the original bounds of the search space.
     - For a `TaggedMultiSearchSpace`, the bounds for each point are obtained in a similar
-      manner as above, but based potentially on a different subspace for each point;
-      instead of sharing a single set of bounds from the common search space.
-      The subspaces are assigned to the optimization runs in a round-robin fashion along
-      dimension 1 (of size `V`) of the starting points. An error is raised if size `V` is not a
-      multiple of the number of subspaces.
+    manner as above, but based potentially on a different subspace for each point;
+    instead of sharing a single set of bounds from the common search space.
+    The subspaces are assigned to the optimization runs in a round-robin fashion along
+    dimension 1 (of size `V`) of the starting points. An error is raised if size `V` is not a
+    multiple of the number of subspaces.
     - For other types of search spaces, the original bounds are used for each optimization run.
 
     :param space: The original search space.
@@ -774,7 +774,7 @@ def get_bounds_of_optimization(space: SearchSpace, starting_points: TensorType) 
         is equal to the number of individual optimization runs, i.e. `num_optimization_runs` x `V`.
 
     For example, for a 2D `TaggedMultiSearchSpace` with two subspaces, each with a continuous
-    and a discrete component:
+    and a discrete component::
 
         space = TaggedMultiSearchSpace(
             [
@@ -788,17 +788,17 @@ def get_bounds_of_optimization(space: SearchSpace, starting_points: TensorType) 
         )
 
     Consider 2 optimization runs per point and a vectorization `V` of 4, for a total of 8
-    optimization runs. Given the following starting points:
+    optimization runs. Given the following starting points::
 
         starting_points = tf.constant(
             [
                 [[10, 11], [12, 13], [14, 15], [16, 17]],
                 [[20, 21], [22, 23], [24, 25], [26, 27]],
             ],
-            dtype=tf.float64,
+            dtype=tf.float64
         )
 
-    The returned list of bounds for the optimization would be:
+    The returned list of bounds for the optimization would be::
 
         [
             spo.Bounds([0, 11], [1, 11]),  # For point at index [0, 0], using subspace 0

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -753,17 +753,17 @@ def get_bounds_of_optimization(space: SearchSpace, starting_points: TensorType) 
 
     For each starting point, the bounds are obtained as follows depending on the type of search
     space:
-        - For a `TaggedProductSearchSpace`, a "continuous relaxation" of the discrete subspaces is
-          built by creating bounds around the point. The discrete components of the created
-          search space are fixed at the respective component of the point, and the
-          remaining continuous components are set to the original bounds of the search space.
-        - For a `TaggedMultiSearchSpace`, the bounds for each point are obtained in a similar
-          manner as above, but based potentially on a different subspace for each point;
-          instead of sharing a single set of bounds from the common search space.
-          The subspaces are assigned to the optimization runs in a round-robin fashion along
-          dimension 1 (of size `V`) of the starting points. An error is raised if size `V` is not a
-          multiple of the number of subspaces.
-        - For other types of search spaces, the original bounds are used for each optimization run.
+    - For a `TaggedProductSearchSpace`, a "continuous relaxation" of the discrete subspaces is
+      built by creating bounds around the point. The discrete components of the created
+      search space are fixed at the respective component of the point, and the
+      remaining continuous components are set to the original bounds of the search space.
+    - For a `TaggedMultiSearchSpace`, the bounds for each point are obtained in a similar
+      manner as above, but based potentially on a different subspace for each point;
+      instead of sharing a single set of bounds from the common search space.
+      The subspaces are assigned to the optimization runs in a round-robin fashion along
+      dimension 1 (of size `V`) of the starting points. An error is raised if size `V` is not a
+      multiple of the number of subspaces.
+    - For other types of search spaces, the original bounds are used for each optimization run.
 
     :param space: The original search space.
     :param starting_points: The points at which to begin the optimizations, with shape

--- a/trieste/acquisition/optimizer.py
+++ b/trieste/acquisition/optimizer.py
@@ -831,7 +831,7 @@ def get_bounds_of_optimization(space: SearchSpace, starting_points: TensorType) 
         remainder = V % len(subspaces)
         tf.debugging.assert_equal(
             remainder,
-            tf.constant(0, dtype=remainder.dtype),
+            0,
             message=(
                 f"""
                 The vectorization of the target function {V} must be a multiple of the number of

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -2073,6 +2073,191 @@ class FixedPointTrustRegionDiscrete(UpdatableTrustRegionDiscrete):
         pass
 
 
+class SingleObjectiveTrustRegionDiscrete(UpdatableTrustRegionDiscrete):
+    """
+    An updatable discrete trust region that maintains a set of neighbouring points around a
+    single location point. The region is updated based on the best point found in the region.
+    """
+
+    def __init__(
+        self,
+        global_search_space: DiscreteSearchSpace,
+        beta: float = 0.7,
+        kappa: float = 1e-4,
+        min_eps: float = 1e-2,
+        region_index: Optional[int] = None,
+        input_active_dims: Optional[Union[slice, Sequence[int]]] = None,
+    ):
+        """
+        Select a random initial location from the global search space and select the initial
+        neighbors within the trust region.
+
+        :param global_search_space: The global search space this search space lives in.
+        :param beta: The inverse of the trust region contraction factor.
+        :param kappa: Scales the threshold for the minimal improvement required for a step to be
+            considered a success.
+        :param min_eps: The minimal size of the search space. If the size of the search space is
+            smaller than this, the search space is reinitialized.
+        :param region_index: The index of the region in a multi-region search space. This is used to
+            identify the local models and datasets to use for acquisition. If `None`, the
+            global models and datasets are used.
+        :param input_active_dims: The active dimensions of the input space, either a slice or list
+            of indices into the columns of the space. If `None`, all dimensions are active.
+        """
+        super().__init__(global_search_space, region_index, input_active_dims)
+        self._beta = beta
+        self._kappa = kappa
+        self._min_eps = min_eps
+        self._initialized = False
+        self._step_is_success = False
+
+        # Random initial location index from the global search space.
+        self._location_ix = tf.random.categorical(
+            tf.ones(
+                (
+                    1,
+                    global_search_space.points.shape[0],
+                )
+            ),
+            1,
+        )[0]
+
+        # Pairwise distances for each axis in the global search space.
+        points = global_search_space.points
+        self._global_distances = tf.stack(
+            [
+                tf.abs(tf.expand_dims(points[..., i], -1) - tf.expand_dims(points[..., i], -2))
+                for i in range(self.dimension)
+            ],
+            axis=0,
+        )
+
+        self._init_eps()
+        self._update_neighbors()
+        self._y_min = np.inf
+
+    @property
+    def location(self) -> TensorType:
+        """Center point of the region."""
+        return tf.squeeze(tf.gather(self.global_search_space.points, self._location_ix), axis=0)
+
+    def _init_eps(self) -> None:
+        global_lower = self.global_search_space.lower
+        global_upper = self.global_search_space.upper
+        self.eps = 0.5 * (global_upper - global_lower) / (5.0 ** (1.0 / global_lower.shape[-1]))
+
+    def _update_neighbors(self) -> None:
+        self._neighbor_ixs = tf.where(
+            tf.reduce_all(
+                [
+                    tf.gather(self._global_distances[i], self._location_ix) <= self.eps[i]
+                    for i in range(self.dimension)
+                ],
+                axis=0,
+            )[0]
+        )
+        self._points = tf.gather(
+            self.global_search_space.points, tf.squeeze(self._neighbor_ixs, axis=-1)
+        )
+
+    def initialize(
+        self,
+        models: Optional[Mapping[Tag, ProbabilisticModelType]] = None,
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
+    ) -> None:
+        """
+        Initialize the region by sampling a location from the global search space and selecting
+        the neighboring points within the trust region.
+
+        :param models: The model for each tag.
+        :param datasets: The dataset for each tag.
+        """
+
+        datasets = self.select_in_region(datasets)
+        self._location_ix = tf.random.categorical(
+            tf.ones(
+                (
+                    1,
+                    self.global_search_space.points.shape[0],
+                )
+            ),
+            1,
+        )[0]
+        self._step_is_success = False
+        self._init_eps()
+        self._update_neighbors()
+        _, self._y_min = self.get_dataset_min(datasets)
+        self._initialized = True
+
+    def update(
+        self,
+        models: Optional[Mapping[Tag, ProbabilisticModelType]] = None,
+        datasets: Optional[Mapping[Tag, Dataset]] = None,
+    ) -> None:
+        """
+        Update this region, including location and neighbors, using the given dataset. If the
+        size of the region is less than the minimum size, re-initialize the region.
+
+        If the new optimum improves over the previous optimum by some threshold (that scales
+        linearly with ``kappa``), the previous acquisition is considered successful.
+
+        If the previous acquisition was successful, the size is increased by a factor
+        ``1 / beta``. Conversely, if it was unsuccessful, the size is reduced by the factor
+        ``beta``.
+
+        :param models: The model for each tag.
+        :param datasets: The dataset for each tag.
+        """
+
+        if not self._initialized or tf.reduce_any(self.eps < self._min_eps):
+            self.initialize(models, datasets)
+            return
+
+        datasets = self.select_in_region(datasets)
+        x_min, y_min = self.get_dataset_min(datasets)
+        self._location_ix = tf.where(
+            tf.reduce_all(self.global_search_space.points == x_min, axis=-1)
+        )[0]
+
+        tr_volume = tf.reduce_prod(self.upper - self.lower)
+        self._step_is_success = y_min < self._y_min - self._kappa * tr_volume
+        self.eps = self.eps / self._beta if self._step_is_success else self.eps * self._beta
+        self._update_neighbors()
+        self._y_min = y_min
+
+    @check_shapes(
+        "return[0]: [D]",
+        "return[1]: []",
+    )
+    def get_dataset_min(
+        self, datasets: Optional[Mapping[Tag, Dataset]]
+    ) -> Tuple[TensorType, TensorType]:
+        """
+        Calculate the minimum of the region using the given dataset.
+
+        :param datasets: The datasets to use for finding the minimum.
+        """
+        if (
+            datasets is None
+            or len(datasets) != 1
+            or LocalizedTag.from_tag(next(iter(datasets))).global_tag != OBJECTIVE
+        ):
+            raise ValueError("""a single OBJECTIVE dataset must be provided""")
+        dataset = next(iter(datasets.values()))
+
+        in_tr = self.contains(dataset.query_points)
+        in_tr_obs = tf.where(
+            tf.expand_dims(in_tr, axis=-1),
+            dataset.observations,
+            tf.constant(np.inf, dtype=dataset.observations.dtype),
+        )
+        ix = tf.argmin(in_tr_obs)
+        x_min = tf.gather(dataset.query_points, ix)
+        y_min = tf.gather(in_tr_obs, ix)
+
+        return tf.squeeze(x_min, axis=0), tf.squeeze(y_min)
+
+
 UpdatableTrustRegionWithGlobalSearchSpace = Union[
     UpdatableTrustRegionBox, UpdatableTrustRegionDiscrete
 ]

--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -2075,7 +2075,7 @@ class FixedPointTrustRegionDiscrete(UpdatableTrustRegionDiscrete):
 
 class SingleObjectiveTrustRegionDiscrete(UpdatableTrustRegionDiscrete):
     """
-    An updatable discrete trust region that maintains a set of neighbouring points around a
+    An updatable discrete trust region that maintains a set of neighboring points around a
     single location point. The region is updated based on the best point found in the region.
     """
 


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
This PR adds a new updatable discrete trust region. This builds on the the fixed-point discrete TR added in a previous PR. The new class `SingleObjectiveTrustRegionDiscrete` is similar in behaviour to `SingleObjectiveTrustRegionBox`, but for a discrete search space.

The mixed search spaces notebook and integ tests now use this class, instead of `FixedPointTrustRegionDiscrete` from the previous PR.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [X] Any new features are well-documented (in docstrings or notebooks)
