### PR TITLE
Add `zeta` param to control TR `eps` init

### DIFF
--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1545,7 +1545,7 @@ class SingleObjectiveTrustRegionBox(UpdatableTrustRegionBox):
         :param beta: The inverse of the trust region contraction factor.
         :param kappa: Scales the threshold for the minimal improvement required for a step to be
             considered a success.
-        :param zeta: The initial size of the search space is ``zeta`` times the size of the global
+        :param zeta: The initial size of the trust region is ``zeta`` times the size of the global
             search space.
         :param min_eps: The minimal size of the search space. If the size of the search space is
             smaller than this, the search space is reinitialized.
@@ -2124,7 +2124,7 @@ class SingleObjectiveTrustRegionDiscrete(UpdatableTrustRegionDiscrete):
         :param beta: The inverse of the trust region contraction factor.
         :param kappa: Scales the threshold for the minimal improvement required for a step to be
             considered a success.
-        :param zeta: The initial size of the search space is ``zeta`` times the size of the global
+        :param zeta: The initial size of the trust region is ``zeta`` times the size of the global
             search space.
         :param min_eps: The minimal size of the search space. If the size of the search space is
             smaller than this, the search space is reinitialized.


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Updated how `eps` is initialized for `SingleObjectiveTrustRegionBox` and `SingleObjectiveTrustRegionDiscrete` regions. There is a new `zeta` parameter to control this.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [X] Any new features are well-documented (in docstrings or notebooks)
