### PR TITLE
Skip failing slow TR reload test

### DIFF
--- a/tests/integration/test_ask_tell_optimization.py
+++ b/tests/integration/test_ask_tell_optimization.py
@@ -73,6 +73,11 @@ OPTIMIZER_PARAMS = (
             True,
             lambda: BatchTrustRegionBox(TREGOBox(ScaledBranin.search_space)),
             id="TREGO/reload_state",
+            # TODO: trust regions maintain internal state and do not fully support the functional
+            # API for reloading from acquisition state. So this test is skipped for now.
+            marks=pytest.mark.skip(
+                reason="Trust regions do not support reloading from acquisition state"
+            ),
         ),
         pytest.param(
             10,


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Skip failing trust-regions slow test. This is due to trust-regions not supporting the functional API for reloading acquisition state.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
