### PR TITLE
Fix bug where TREGO zeta init arg was missing

### DIFF
--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1897,16 +1897,18 @@ class TREGOBox(SingleObjectiveTrustRegionBox):
         global_search_space: Box,
         beta: float = 0.7,
         kappa: float = 1e-4,
+        zeta: float = 0.5,
         min_eps: float = 1e-2,
         region_index: Optional[int] = None,
         input_active_dims: Optional[Union[slice, Sequence[int]]] = None,
     ):
         self._is_global = False
         super().__init__(
-            global_search_space,
-            beta,
-            kappa,
-            min_eps,
+            global_search_space=global_search_space,
+            beta=beta,
+            kappa=kappa,
+            zeta=zeta,
+            min_eps=min_eps,
             region_index=region_index,
             input_active_dims=input_active_dims,
         )


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Add missing `zeta` arg for TREGO.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
