### PR TITLE
Don't save TR `ymin` from init dataset

### DIFF
--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1576,7 +1576,7 @@ class HypercubeTrustRegion(UpdatableTrustRegion):
         self._update_domain()
         # Initial value of the region minimum is set to infinity as we have not yet observed any
         # data.
-        self._y_min = np.inf
+        self._y_min = tf.constant(np.inf, dtype=self.location.dtype)
 
     def _init_eps(self) -> None:
         self.eps = self._zeta * (self.global_search_space.upper - self.global_search_space.lower)
@@ -1620,7 +1620,9 @@ class HypercubeTrustRegion(UpdatableTrustRegion):
         self._step_is_success = False
         self._init_eps()
         self._update_domain()
-        _, self._y_min = self.get_dataset_min(datasets)
+        # We haven't necessarily observed any data yet for this region; force first step to always
+        # be successful by setting the minimum to infinity.
+        self._y_min = tf.constant(np.inf, dtype=self.location.dtype)
         self._initialized = True
 
     def update(


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Tweaked TR initialization algorithm to not take the `y_min` value from the initial dataset, and instead leave it at `inf`. The previous version had the inconsistency that at initialisation the saved `y_min` value was not at the region center/location. This change means that the first update/step will always be successful.

Discussed and agreed this change with @vpicheny.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
