### PR TITLE
Use correct dtype for empty box samples

### DIFF
--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -1577,3 +1577,17 @@ def test_nonlinear_constraints_multioutput_raises() -> None:
     )
     with pytest.raises(TF_DEBUGGING_ERROR_TYPES):
         nlc.residual(points)
+
+
+@pytest.mark.parametrize("dtype", [tf.float32, tf.float64])
+def test_box_empty_sobol_sampling_returns_correct_dtype(dtype: tf.DType) -> None:
+    box = Box(tf.zeros((3,), dtype=dtype), tf.ones((3,), dtype=dtype))
+    sobol_samples = box.sample_sobol(0)
+    assert sobol_samples.dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", [tf.float32, tf.float64])
+def test_box_empty_halton_sampling_returns_correct_dtype(dtype: tf.DType) -> None:
+    box = Box(tf.zeros((3,), dtype=dtype), tf.ones((3,), dtype=dtype))
+    sobol_samples = box.sample_halton(0)
+    assert sobol_samples.dtype == dtype

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -627,7 +627,7 @@ class Box(SearchSpace):
         # Internal common method to sample from the space using a Halton sequence.
         tf.debugging.assert_non_negative(num_samples)
         if num_samples == 0:
-            return tf.constant([])
+            return tf.constant([], dtype=self._lower.dtype)
         if seed is not None:  # ensure reproducibility
             tf.random.set_seed(seed)
         dim = tf.shape(self._lower)[-1]
@@ -660,7 +660,7 @@ class Box(SearchSpace):
         """
         tf.debugging.assert_non_negative(num_samples)
         if num_samples == 0:
-            return tf.constant([])
+            return tf.constant([], dtype=self._lower.dtype)
         if skip is None:  # generate random skip
             skip = tf.random.uniform([1], maxval=2**16, dtype=tf.int32)[0]
         dim = tf.shape(self._lower)[-1]


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

sample_sobol and sample_halton should return an empty sample with the correct dtype for num_samples = 0

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes / no

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
