### PR TITLE
Fix ask_tell global `dataset_len` detection

### DIFF
--- a/tests/unit/test_ask_tell_optimization.py
+++ b/tests/unit/test_ask_tell_optimization.py
@@ -945,6 +945,7 @@ def test_ask_tell_optimizer_dataset_len_variables(
         dataset = init_dataset
 
     assert AskTellOptimizer.dataset_len({"tag": dataset}) == 2
+    assert AskTellOptimizer.dataset_len({"tag1": dataset, "tag2": dataset}) == 2
 
 
 def test_ask_tell_optimizer_dataset_len_raises_on_inconsistently_sized_datasets(

--- a/trieste/ask_tell_optimization.py
+++ b/trieste/ask_tell_optimization.py
@@ -442,8 +442,8 @@ class AskTellOptimizerABC(ABC, Generic[SearchSpaceType, ProbabilisticModelType])
             for tag, dataset in datasets.items()
             if not LocalizedTag.from_tag(tag).is_local
         ]
-        unique_lens, unique_idxs = tf.unique(dataset_lens)
-        if len(unique_idxs) == 1:
+        unique_lens, _ = tf.unique(dataset_lens)
+        if len(unique_lens) == 1:
             return int(unique_lens[0])
         else:
             raise ValueError(f"Expected unique global dataset size, got {unique_lens}")


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Quick fix for `dataset_len` detection. `tf.unique` returns a list of indices of the same length as the input, so we should use `unique_lens` to check the length instead.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
