### PR TITLE
Fix tags assert in filter_datasets

### DIFF
--- a/trieste/acquisition/rule.py
+++ b/trieste/acquisition/rule.py
@@ -1514,7 +1514,7 @@ class BatchTrustRegion(
             state: BatchTrustRegionState[UpdatableTrustRegionType] | None,
         ) -> Tuple[BatchTrustRegionState[UpdatableTrustRegionType] | None, Mapping[Tag, Dataset]]:
             if state is not None:
-                assert self._tags == state.subspace_tags, (
+                assert self._tags == tuple(state.subspace_tags), (
                     f"The tags of the state acquisition space "
                     f"{state.subspace_tags} should be the same as the tags of the "
                     f"BatchTrustRegion acquisition rule {self._tags}"


### PR DESCRIPTION
**Related issue(s)/PRs:** None <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary
Fix missing conversion to `tuple` in `filter_datasets` assertion.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
