### PR TITLE
Handle the case where either query points or observations have unspec…

### DIFF
--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import contextlib
 import copy
 
 import numpy as np

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 from __future__ import annotations
 
+import contextlib
 import copy
 
+import numpy as np
 import numpy.testing as npt
 import pytest
 import tensorflow as tf
@@ -66,6 +68,47 @@ def test_dataset_raises_for_different_leading_shapes(
 
     with pytest.raises(ValueError, match="(L|l)eading"):
         Dataset(query_points, observations)
+
+
+def test_dataset_does_not_raise_with_unspecified_leading_dimension() -> None:
+    @contextlib.contextmanager
+    def does_not_raise():
+        try:
+            yield
+        except Exception as e:
+            pytest.fail(f"An exception was raised: {e}")
+
+    query_points = tf.zeros((2, 2))
+    observations = tf.zeros((2, 1))
+
+    query_points_var = tf.Variable(
+        initial_value=np.zeros((0, 2)),
+        shape=(None, 2),
+        dtype=tf.float64,
+    )
+    observations_var = tf.Variable(
+        initial_value=np.zeros((0, 1)),
+        shape=(None, 1),
+        dtype=tf.float64,
+    )
+
+    with does_not_raise():
+        Dataset(
+            query_points=query_points_var,
+            observations=observations
+        )
+
+    with does_not_raise():
+        Dataset(
+            query_points=query_points,
+            observations=observations_var
+        )
+
+    with does_not_raise():
+        Dataset(
+            query_points=query_points_var,
+            observations=observations_var
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -71,13 +71,6 @@ def test_dataset_raises_for_different_leading_shapes(
 
 
 def test_dataset_does_not_raise_with_unspecified_leading_dimension() -> None:
-    @contextlib.contextmanager
-    def does_not_raise() -> None:
-        try:
-            yield
-        except Exception as e:
-            pytest.fail(f"An exception was raised: {e}")
-
     query_points = tf.zeros((2, 2))
     observations = tf.zeros((2, 1))
 
@@ -92,23 +85,9 @@ def test_dataset_does_not_raise_with_unspecified_leading_dimension() -> None:
         dtype=tf.float64,
     )
 
-    with does_not_raise():
-        Dataset(
-            query_points=query_points_var,
-            observations=observations
-        )
-
-    with does_not_raise():
-        Dataset(
-            query_points=query_points,
-            observations=observations_var
-        )
-
-    with does_not_raise():
-        Dataset(
-            query_points=query_points_var,
-            observations=observations_var
-        )
+    Dataset(query_points=query_points_var, observations=observations)
+    Dataset(query_points=query_points, observations=observations_var)
+    Dataset(query_points=query_points_var, observations=observations_var)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -72,7 +72,7 @@ def test_dataset_raises_for_different_leading_shapes(
 
 def test_dataset_does_not_raise_with_unspecified_leading_dimension() -> None:
     @contextlib.contextmanager
-    def does_not_raise():
+    def does_not_raise() -> None:
         try:
             yield
         except Exception as e:

--- a/trieste/data.py
+++ b/trieste/data.py
@@ -52,7 +52,7 @@ class Dataset:
         if (
             self.query_points.shape[:-1] != self.observations.shape[:-1]
             # can't check dynamic shapes, so trust that they're ok (if not, they'll fail later)
-            and None not in self.query_points.shape[:-1]
+            and None not in self.query_points.shape[:-1] and None not in self.observations.shape[:-1]
         ):
             raise ValueError(
                 f"Leading shapes of query_points and observations must match. Got shapes"

--- a/trieste/data.py
+++ b/trieste/data.py
@@ -52,7 +52,8 @@ class Dataset:
         if (
             self.query_points.shape[:-1] != self.observations.shape[:-1]
             # can't check dynamic shapes, so trust that they're ok (if not, they'll fail later)
-            and None not in self.query_points.shape[:-1] and None not in self.observations.shape[:-1]
+            and None not in self.query_points.shape[:-1]
+            and None not in self.observations.shape[:-1]
         ):
             raise ValueError(
                 f"Leading shapes of query_points and observations must match. Got shapes"


### PR DESCRIPTION
…ified leading dimension.

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

<!-- A clear and concise description of the contents of this pull request. -->

There might be situations where not only the query points, but also the observations might have an unspecified leading dim. This PR is addressing this case. It is also adding previously missing tests for the existing case, and also in combination for the one considered here.

**Fully backwards compatible:** yes 

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
