### PR TITLE
Trajectory sampling additive kernels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "absl-py",
         "dill<0.3.6",
         "gpflow>=2.9.2",
-        "gpflux@ git+https://github.com/secondmind-labs/GPflux.git@khurram/rff_additive_kernels",
+        "gpflux@ git+https://github.com/secondmind-labs/GPflux.git@uri/rff_additive_kernels",
         "numpy",
         "tensorflow>=2.5,<2.17; platform_system!='Darwin' or platform_machine!='arm64'",
         "tensorflow-macos>=2.5,<2.17; platform_system=='Darwin' and platform_machine=='arm64'",

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -811,11 +811,11 @@ class ResampleableRandomFourierFeatureFunctions(RandomFourierFeaturesCosine):
                 b.assign(self._bias_init(tf.shape(b), dtype=self._dtype))
 
         if isinstance(self.W, tf.Variable):
-            self.W.assign(self._weights_init(self.kernel)(tf.shape(self.W), dtype=self._dtype))
+            self.W.assign(self._weights_init(self.kernel)(tf.shape(self.W), self._dtype))
         else:
             tf.debugging.Assert(isinstance(self.W, list), [])
             for W, k in zip(self.W, cycle(self.sub_kernels)):
-                W.assign(self._weights_init(k)(tf.shape(W), dtype=self._dtype))
+                W.assign(self._weights_init(k)(tf.shape(W), self._dtype))
 
 
 class ResampleableDecoupledFeatureFunctions(ResampleableRandomFourierFeatureFunctions):

--- a/trieste/models/gpflux/sampler.py
+++ b/trieste/models/gpflux/sampler.py
@@ -453,11 +453,11 @@ class ResampleableDecoupledDeepGaussianProcessFeatureFunctions(RandomFourierFeat
                 b.assign(self._bias_init(tf.shape(b), dtype=self._dtype))
 
         if isinstance(self.W, tf.Variable):
-            self.W.assign(self._weights_init(self.kernel)(tf.shape(self.W), dtype=self._dtype))
+            self.W.assign(self._weights_init(self.kernel)(tf.shape(self.W), self._dtype))
         else:
             tf.debugging.Assert(isinstance(self.W, list), [])
             for W, k in zip(self.W, cycle(self.sub_kernels)):
-                W.assign(self._weights_init(k)(tf.shape(W), dtype=self._dtype))
+                W.assign(self._weights_init(k)(tf.shape(W), self._dtype))
 
     def __call__(self, x: TensorType) -> TensorType:  # [N, D] -> [N, L + M] or [P, N, L + M]
         """


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

Changes to no longer handle active_dims for trajectory sampling in trieste (it's now done in gpflux) and to update resampling to support the combination kernel case. Also a test to check the combination case.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes / no

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
