### PR TITLE
Use different seeds for subspace sampling

### DIFF
--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -973,6 +973,18 @@ def test_collection_space_sampling_raises_for_invalid_sample_size(
         collection_space.sample(num_samples)
 
 
+@pytest.mark.parametrize("search_space_type", [TaggedMultiSearchSpace, TaggedProductSearchSpace])
+def test_collection_space_sampling_uses_different_seeds_for_subspaces(
+    search_space_type: Type[CollectionSearchSpace],
+) -> None:
+    box = Box([0], [1])
+    collection_space = search_space_type(spaces=[box, box])
+    samples = collection_space.sample(5, seed=42)
+    # check that all the points are unique despite the seed
+    flattened = samples.numpy().flatten()
+    assert len(flattened) == len(set(flattened))
+
+
 @pytest.mark.parametrize(
     "search_space_type, space_A",
     [

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -1229,7 +1229,11 @@ class CollectionSearchSpace(SearchSpace):
         tf.debugging.assert_non_negative(num_samples)
         if seed is not None:  # ensure reproducibility
             tf.random.set_seed(seed)
-        return [self._spaces[tag].sample(num_samples, seed=seed) for tag in self._tags]
+        return [
+            # ensure subspaces (which may be identical) don't all use the same seed
+            self._spaces[tag].sample(num_samples, seed=None if seed is None else seed + i)
+            for i, tag in enumerate(self._tags)
+        ]
 
     def __eq__(self, other: object) -> bool:
         """


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

When sampled with a specific seed, product spaces currently pass that seed to each of their subspaces. This means that a space A * A for example would return identical samples from both subspaces. This fixes that by offsetting the seed passed to each subspace.

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
