### PR TITLE
Fix SafeModeScope import

### DIFF
--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -29,8 +29,9 @@ import tensorflow_probability as tfp
 from gpflow.keras import tf_keras
 
 try:
-    SafeModeScope = tf_keras.src.saving.serialization_lib.SafeModeScope
-except AttributeError:  # pragma: no cover (tested but not by coverage)
+    # (note that this isn't always defined in tf_keras!)
+    from keras.src.saving.serialization_lib import SafeModeScope
+except ImportError:  # pragma: no cover (tested but not by coverage)
     SafeModeScope = contextlib.nullcontext
 from tensorflow_probability.python.layers.distribution_layer import DistributionLambda, _serialize
 

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -29,10 +29,13 @@ import tensorflow_probability as tfp
 from gpflow.keras import tf_keras
 
 try:
-    # (note that this isn't always defined in tf_keras!)
-    from keras.src.saving.serialization_lib import SafeModeScope
-except ImportError:  # pragma: no cover (tested but not by coverage)
-    SafeModeScope = contextlib.nullcontext
+    SafeModeScope = tf_keras.src.saving.serialization_lib.SafeModeScope
+except AttributeError:  # pragma: no cover (tested but not by coverage)
+    try:
+        # in TF 2.14 it's in keras but not in tf_keras (but vice versa in TF 2.16)!
+        from keras.src.saving.serialization_lib import SafeModeScope
+    except (ImportError, ModuleNotFoundError):
+        SafeModeScope = contextlib.nullcontext
 from tensorflow_probability.python.layers.distribution_layer import DistributionLambda, _serialize
 
 from trieste.types import TensorType

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -33,7 +33,7 @@ try:
 except AttributeError:  # pragma: no cover (tested but not by coverage)
     try:
         # in TF 2.14 it's in keras but not in tf_keras (but vice versa in TF 2.16)!
-        from keras.src.saving.serialization_lib import SafeModeScope
+        from keras.src.saving.serialization_lib import SafeModeScope  # type:ignore[no-redef]
     except (ImportError, ModuleNotFoundError):
         SafeModeScope = contextlib.nullcontext
 from tensorflow_probability.python.layers.distribution_layer import DistributionLambda, _serialize


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

Fix SafeModeScope import to work with TF 2.14.

Testing against TF 2.14 will follow in a later PR after GPflow has been updated (currently blocked by [this weirdness](https://app.circleci.com/pipelines/github/GPflow/GPflow/5244/workflows/c3ea261a-d307-4ed7-9a87-3c95ff919b52/jobs/24330)).

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
