### PR TITLE
fix jitter bug in Deep ensemble trajectory sampler

### DIFF
--- a/tests/unit/models/keras/test_sampler.py
+++ b/tests/unit/models/keras/test_sampler.py
@@ -479,3 +479,40 @@ def test_ensemble_trajectory_sampler_returns_state(batch_size: int, diversify: b
     assert state_post_call["batch_size"] == batch_size
     assert tf.equal(tf.size(state_post_call[rnd_state_name]), batch_size)
     assert state_post_call[rnd_state_name].dtype == dtype
+
+
+def test_ensemble_trajectory_sampler_handles_negative_variances() -> None:
+    """Test that trajectory sampler correctly handles potentially negative variances."""
+    # Create a small dataset
+    query_points = tf.constant([[0.0], [1.0]], dtype=tf.float64)
+    observations = tf.constant([[0.0], [1.0]], dtype=tf.float64)
+    dataset = Dataset(query_points, observations)
+
+    # Create a model with a custom predict method that returns negative variances
+    model, _, _ = trieste_deep_ensemble_model(dataset, _ENSEMBLE_SIZE, False, True)
+    
+    # Create a custom predict method that returns negative variances
+    original_predict = model.predict
+    
+    def predict_with_negative_vars(x: TensorType) -> tuple[TensorType, TensorType]:
+        means, _ = original_predict(x)
+        # Return some negative variances to test ensure_positive
+        return means, tf.constant([[-1.0], [-0.5]], dtype=tf.float64)
+    
+    # Monkey patch the predict method
+    model.predict = predict_with_negative_vars  # type: ignore
+    
+    # Create trajectory sampler and get trajectory
+    sampler = DeepEnsembleTrajectorySampler(model, diversify=True)  # diversify=True to test variance handling
+    trajectory = sampler.get_trajectory()
+    
+    # Sample trajectories - this should not raise any errors and return valid values
+    samples = trajectory(tf.expand_dims(query_points, -2))  # [N, 1, D]
+    
+    # Check that samples have correct shape and are finite
+    assert samples.shape == (2, 1, 1)  # [N, B, L]
+    assert tf.reduce_all(tf.math.is_finite(samples))
+    
+    # The samples should be different from the means due to the variance
+    means, _ = model.predict(query_points)
+    assert not tf.reduce_all(tf.equal(samples[:, 0, :], means))

--- a/tests/unit/models/keras/test_sampler.py
+++ b/tests/unit/models/keras/test_sampler.py
@@ -490,29 +490,31 @@ def test_ensemble_trajectory_sampler_handles_negative_variances() -> None:
 
     # Create a model with a custom predict method that returns negative variances
     model, _, _ = trieste_deep_ensemble_model(dataset, _ENSEMBLE_SIZE, False, True)
-    
+
     # Create a custom predict method that returns negative variances
     original_predict = model.predict
-    
+
     def predict_with_negative_vars(x: TensorType) -> tuple[TensorType, TensorType]:
         means, _ = original_predict(x)
         # Return some negative variances to test ensure_positive
         return means, tf.constant([[-1.0], [-0.5]], dtype=tf.float64)
-    
+
     # Monkey patch the predict method
     model.predict = predict_with_negative_vars  # type: ignore
-    
+
     # Create trajectory sampler and get trajectory
-    sampler = DeepEnsembleTrajectorySampler(model, diversify=True)  # diversify=True to test variance handling
+    sampler = DeepEnsembleTrajectorySampler(
+        model, diversify=True
+    )  # diversify=True to test variance handling
     trajectory = sampler.get_trajectory()
-    
+
     # Sample trajectories - this should not raise any errors and return valid values
     samples = trajectory(tf.expand_dims(query_points, -2))  # [N, 1, D]
-    
+
     # Check that samples have correct shape and are finite
     assert samples.shape == (2, 1, 1)  # [N, B, L]
     assert tf.reduce_all(tf.math.is_finite(samples))
-    
+
     # The samples should be different from the means due to the variance
     means, _ = model.predict(query_points)
     assert not tf.reduce_all(tf.equal(samples[:, 0, :], means))

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -247,4 +247,6 @@ def test_flatten_leading_dims_invalid_output_dims(output_dims: int) -> None:
     ],
 )
 def test_ensure_positive(t: TensorType, expected: TensorType) -> None:
-    npt.assert_array_equal(ensure_positive(t), expected)
+    result = ensure_positive(t)
+    npt.assert_array_equal(result, expected)
+    assert result.dtype == t.dtype

--- a/trieste/models/keras/sampler.py
+++ b/trieste/models/keras/sampler.py
@@ -23,8 +23,10 @@ from typing import Dict, Optional
 
 import tensorflow as tf
 
+from trieste.utils.misc import ensure_positive
+
 from ...types import TensorType
-from ...utils import DEFAULTS, flatten_leading_dims
+from ...utils import flatten_leading_dims
 from ..interfaces import TrajectoryFunction, TrajectoryFunctionClass, TrajectorySampler
 from .interface import DeepEnsembleModel
 from .utils import sample_model_index
@@ -169,7 +171,7 @@ class deep_ensemble_trajectory(TrajectoryFunctionClass):
 
         if self._diversify:
             predicted_means, predicted_vars = self._model.predict(flat_x)  # ([N*B, L], [N*B, L])
-            predicted_vars = predicted_vars + tf.constant(DEFAULTS.JITTER, predicted_vars.dtype)
+            predicted_vars = ensure_positive(predicted_vars)
             predictions = predicted_means + tf.sqrt(predicted_vars) * tf.tile(
                 self._eps, [tf.shape(x)[0], 1]
             )  # [N*B, L]


### PR DESCRIPTION
there is a subtle bug in the sampler when adding jitter to the variances (only when diversify is true) - because the constant is too large it introduces discontinuities in trajectories