### PR TITLE
Add optional predict fn to IndependentReparametrizationSampler.__init__

### DIFF
--- a/tests/unit/models/gpflow/test_sampler.py
+++ b/tests/unit/models/gpflow/test_sampler.py
@@ -53,6 +53,7 @@ from trieste.models.gpflow.sampler import (
     qmc_normal_samples,
 )
 from trieste.models.interfaces import (
+    ProbabilisticModel,
     ReparametrizationSampler,
     SupportsGetInducingVariables,
     SupportsPredictJoint,
@@ -169,6 +170,50 @@ def _dim_two_gp(mean_shift: tuple[float, float] = (0.0, 0.0)) -> GaussianProcess
         [lambda x: mean_shift[0] + Branin.objective(x), lambda x: mean_shift[1] + quadratic(x)],
         [matern52, rbf()],
     )
+
+
+@pytest.mark.parametrize(
+    ["n_latent_dims", "batch_shape"],
+    [
+        (1, (5,)),
+        (2, (5, 6)),
+    ],
+)
+def test_independent_reparametrization_sampler_custom_predict_function(
+    n_latent_dims: int,
+    batch_shape: Tuple[int],
+) -> None:
+    """
+    Test that it's possible to construct an IndependentReparametrizationSampler
+    with a custom prediction function, and that this function
+    is called rather than model.predict.
+    """
+
+    model = MagicMock(spec=ProbabilisticModel)
+    model.predict = MagicMock()
+
+    def fn_predict(x: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
+        shape = x.shape[:-1] + [n_latent_dims]
+        return (
+            tf.random.uniform(shape=shape),
+            tf.random.uniform(shape=shape),
+        )
+
+    mock_predict = MagicMock(side_effect=fn_predict)
+
+    sample_size = 123
+    sampler = IndependentReparametrizationSampler(
+        sample_size=sample_size, model=model, fn_predict=mock_predict
+    )
+
+    n_model_inputs = 3
+    input_point = tf.random.uniform(shape=batch_shape + (1, n_model_inputs))  # value doesn't matter
+
+    samples = sampler.sample(input_point)
+    assert samples.shape == batch_shape + (sample_size, 1, n_latent_dims)
+
+    model.predict.assert_not_called()
+    mock_predict.assert_called()
 
 
 @random_seed

--- a/tests/unit/models/gpflow/test_sampler.py
+++ b/tests/unit/models/gpflow/test_sampler.py
@@ -179,9 +179,11 @@ def _dim_two_gp(mean_shift: tuple[float, float] = (0.0, 0.0)) -> GaussianProcess
         (2, (5, 6)),
     ],
 )
+@pytest.mark.parametrize("compile", [False, True])
 def test_independent_reparametrization_sampler_custom_predict_function(
     n_latent_dims: int,
     batch_shape: Tuple[int],
+    compile: bool,
 ) -> None:
     """
     Test that it's possible to construct an IndependentReparametrizationSampler
@@ -190,7 +192,6 @@ def test_independent_reparametrization_sampler_custom_predict_function(
     """
 
     model = MagicMock(spec=ProbabilisticModel)
-    model.predict = MagicMock()
 
     def fn_predict(x: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
         shape = x.shape[:-1] + [n_latent_dims]
@@ -203,17 +204,26 @@ def test_independent_reparametrization_sampler_custom_predict_function(
 
     sample_size = 123
     sampler = IndependentReparametrizationSampler(
-        sample_size=sample_size, model=model, fn_predict=mock_predict
+        sample_size=sample_size, model=model, predict_fn=mock_predict
     )
 
     n_model_inputs = 3
     input_point = tf.random.uniform(shape=batch_shape + (1, n_model_inputs))  # value doesn't matter
 
-    samples = sampler.sample(input_point)
+    sample_fn = sampler.sample
+
+    if compile:
+        sample_fn = tf.function(sample_fn)
+
+    samples = sample_fn(input_point)
     assert samples.shape == batch_shape + (sample_size, 1, n_latent_dims)
 
     model.predict.assert_not_called()
-    mock_predict.assert_called()
+    if compile:
+        # If we compile, the mock will be called twice.
+        mock_predict.assert_called()
+    else:
+        mock_predict.assert_called_once()
 
 
 @random_seed

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -95,7 +95,12 @@ class IndependentReparametrizationSampler(ReparametrizationSampler[Probabilistic
     """Number of sobol sequence points to skip. This is incremented for each sampler."""
 
     def __init__(
-        self, sample_size: int, model: ProbabilisticModel, qmc: bool = False, qmc_skip: bool = True
+        self,
+        sample_size: int,
+        model: ProbabilisticModel,
+        fn_predict: Optional[Callable[[TensorType], tuple[TensorType, TensorType]]] = None,
+        qmc: bool = False,
+        qmc_skip: bool = True,
     ):
         """
         :param sample_size: The number of samples to take at each point. Must be positive.
@@ -108,6 +113,7 @@ class IndependentReparametrizationSampler(ReparametrizationSampler[Probabilistic
         """
         super().__init__(sample_size, model)
         self._eps: Optional[tf.Variable] = None
+        self._fn_predict = fn_predict or self._model.predict
         self._qmc = qmc
         self._qmc_skip = qmc_skip
 
@@ -132,7 +138,7 @@ class IndependentReparametrizationSampler(ReparametrizationSampler[Probabilistic
         :raise ValueError (or InvalidArgumentError): If ``at`` has an invalid shape or ``jitter``
             is negative.
         """
-        mean, var = self._model.predict(at[..., None, :, :])  # [..., 1, 1, L], [..., 1, 1, L]
+        mean, var = self._fn_predict(at[..., None, :, :])  # [..., 1, 1, L], [..., 1, 1, L]
         var = ensure_positive(var) if jitter < 0 else (var + jitter)
 
         def sample_eps() -> tf.Tensor:

--- a/trieste/models/gpflow/sampler.py
+++ b/trieste/models/gpflow/sampler.py
@@ -98,9 +98,9 @@ class IndependentReparametrizationSampler(ReparametrizationSampler[Probabilistic
         self,
         sample_size: int,
         model: ProbabilisticModel,
-        fn_predict: Optional[Callable[[TensorType], tuple[TensorType, TensorType]]] = None,
         qmc: bool = False,
         qmc_skip: bool = True,
+        predict_fn: Optional[Callable[[TensorType], tuple[TensorType, TensorType]]] = None,
     ):
         """
         :param sample_size: The number of samples to take at each point. Must be positive.
@@ -109,11 +109,12 @@ class IndependentReparametrizationSampler(ReparametrizationSampler[Probabilistic
             sampling more accurately approximates a normal distribution than truly random samples.
         :param qmc_skip: Whether to use the skip parameter to ensure the QMC sampler gives different
             samples whenever it is reset. This is not supported with XLA.
+        :param predict_fn: A function to use instead of the model's predict method.
         :raise ValueError (or InvalidArgumentError): If ``sample_size`` is not positive.
         """
         super().__init__(sample_size, model)
         self._eps: Optional[tf.Variable] = None
-        self._fn_predict = fn_predict or self._model.predict
+        self._predict_fn = predict_fn or self._model.predict
         self._qmc = qmc
         self._qmc_skip = qmc_skip
 
@@ -138,7 +139,7 @@ class IndependentReparametrizationSampler(ReparametrizationSampler[Probabilistic
         :raise ValueError (or InvalidArgumentError): If ``at`` has an invalid shape or ``jitter``
             is negative.
         """
-        mean, var = self._fn_predict(at[..., None, :, :])  # [..., 1, 1, L], [..., 1, 1, L]
+        mean, var = self._predict_fn(at[..., None, :, :])  # [..., 1, 1, L], [..., 1, 1, L]
         var = ensure_positive(var) if jitter < 0 else (var + jitter)
 
         def sample_eps() -> tf.Tensor:


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

...

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes / no

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
