### PR TITLE
Repeat dataset when steps_per_epoch is used with DeepEnsemble

### DIFF
--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -25,6 +25,7 @@ import numpy.testing as npt
 import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
+from _pytest.logging import LogCaptureFixture
 from gpflow.keras import tf_keras
 from tensorflow.python.keras.callbacks import Callback
 
@@ -490,7 +491,7 @@ def test_deep_ensemble_optimize(ensemble_size: int, bootstrap_data: bool, epochs
 
 
 @random_seed
-def test_deep_ensemble_optimize__with_steps_per_epoch(caplog) -> None:
+def test_deep_ensemble_optimize__with_steps_per_epoch(caplog: LogCaptureFixture) -> None:
     """
     Test that DeepEnsemble.optimize will repeat the dataset if `steps_per_epoch`
     is set, rather than finishing early if the dataset doesn't contain at

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import operator
 import tempfile
 import unittest.mock
@@ -486,6 +487,44 @@ def test_deep_ensemble_optimize(ensemble_size: int, bootstrap_data: bool, epochs
     assert loss[-1] < loss[0]
     assert len(loss) == epochs
     assert sum(ensemble_losses) == ensemble_size
+
+
+@random_seed
+def test_deep_ensemble_optimize__with_steps_per_epoch(caplog) -> None:
+    """
+    Test that DeepEnsemble.optimize will repeat the dataset if `steps_per_epoch`
+    is set, rather than finishing early if the dataset doesn't contain at
+    least epochs * steps_per_epoch many rows.
+    """
+    example_data = _get_example_data([100, 1])
+
+    keras_ensemble = trieste_keras_ensemble_model(example_data, ensemble_size=2)
+
+    custom_optimizer = tf_keras.optimizers.RMSprop()
+
+    # N.B. custom fit args are constructed such that 26 * 5 = 130 rows of data will be required
+    # to complete all 5 iterations. However, the dataset only contains 100 rows, so it will
+    # be exhausted part way through the 4th epoch.
+    custom_fit_args = {
+        "verbose": 0,
+        "epochs": 5,
+        "steps_per_epoch": 26,
+        "batch_size": 10,
+    }
+    custom_loss = tf_keras.losses.MeanSquaredError()
+    optimizer_wrapper = KerasOptimizer(custom_optimizer, custom_fit_args, custom_loss)
+
+    model = DeepEnsemble(keras_ensemble, optimizer_wrapper)
+
+    model.optimize(example_data)
+    loss = model.model.history.history["loss"]
+
+    warning_messages = [x.message for x in caplog.records if x.levelno >= logging.WARNING]
+    assert not any(warning_messages), f"Warnings were logged:\n{warning_messages}"
+
+    # If training finishes early (i.e. before the final epoch starts), then the length
+    # of the loss history will be less than the number of requested epochs.
+    assert len(loss) == custom_fit_args["epochs"]
 
 
 @random_seed

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -480,9 +480,17 @@ class DeepEnsemble(
             fit_args["epochs"] = fit_args["epochs"] + self._absolute_epochs
 
         x, y = self.prepare_dataset(dataset)
+        tf_dataset = tf.data.Dataset.from_tensor_slices((x, y))
+
+        if "steps_per_epoch" in fit_args:
+            tf_dataset = (
+                tf_dataset.prefetch(tf.data.experimental.AUTOTUNE)
+                .repeat()
+                .batch(fit_args["batch_size"], drop_remainder=True)
+            )
+
         history = self.model.fit(
-            x=x,
-            y=y,
+            tf_dataset,
             **fit_args,
             initial_epoch=self._absolute_epochs,
         )

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -480,20 +480,27 @@ class DeepEnsemble(
             fit_args["epochs"] = fit_args["epochs"] + self._absolute_epochs
 
         x, y = self.prepare_dataset(dataset)
-        tf_dataset = tf.data.Dataset.from_tensor_slices((x, y))
 
         if "steps_per_epoch" in fit_args:
             tf_dataset = (
-                tf_dataset.prefetch(tf.data.experimental.AUTOTUNE)
+                tf.data.Dataset.from_tensor_slices((x, y))
+                .prefetch(tf.data.experimental.AUTOTUNE)
                 .repeat()
                 .batch(fit_args["batch_size"], drop_remainder=True)
             )
+            history = self.model.fit(
+                tf_dataset,
+                **fit_args,
+                initial_epoch=self._absolute_epochs,
+            )
+        else:
+            history = self.model.fit(
+                x=x,
+                y=y,
+                **fit_args,
+                initial_epoch=self._absolute_epochs,
+            )
 
-        history = self.model.fit(
-            tf_dataset,
-            **fit_args,
-            initial_epoch=self._absolute_epochs,
-        )
         if self._continuous_optimisation:
             self._absolute_epochs = self._absolute_epochs + len(history.history["loss"])
 


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

...

This PR repeats the dataset if necessary if `steps_per_epoch` is used with DeepEnsemble. Previously, if the dataset didn't contain at least `epochs` * `steps_per_epoch` many rows, then training would finish early after every row was seen, albeit with a warning message that could be easily missed. By setting `steps_per_epoch` and `epochs`, users likely intend to execute that precise number of steps and epochs, so it's preferable to repeat the dataset as needed to fulfil this expectation.

The current behaviour is particularly problematic for small datasets, as the model cannot train to convergence by seeing each row only once.

**Fully backwards compatible:** yes / no

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
