### PR TITLE
Pass TF dataset to DeepEnsemble model.fit

### DIFF
--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -18,6 +18,7 @@ import operator
 import tempfile
 import unittest.mock
 from typing import Any, Optional
+from unittest.mock import MagicMock
 
 import numpy as np
 import numpy.testing as npt
@@ -544,29 +545,46 @@ def test_deep_ensemble_predict_ensemble() -> None:
 
 @random_seed
 def test_deep_ensemble__with_steps_per_epoch_and_validation_split() -> None:
-    example_data = _get_example_data([100, 1])
+    n_rows = 150
+    example_data = _get_example_data([n_rows, 1])
 
+    batch_size = 100
     epochs = 10
     steps_per_epoch = 20
+    validation_split_proportion = 0.5
 
     keras_ensemble = trieste_keras_ensemble_model(example_data, ensemble_size=10)
+    model_fit_spy = MagicMock(side_effect=keras_ensemble.model.fit)
+    keras_ensemble.model.fit = model_fit_spy
 
     optimizer = tf_keras.optimizers.Adam()
-
     fit_args = {
-        "batch_size": 100,
+        "batch_size": batch_size,
         "epochs": epochs,
         "callbacks": [],
         "verbose": 0,
         "steps_per_epoch": steps_per_epoch,
-        "validation_split": 0.5,
+        "validation_split": validation_split_proportion,
     }
     optimizer_wrapper = KerasOptimizer(optimizer, fit_args)
 
-    model = DeepEnsemble(keras_ensemble, optimizer_wrapper)
+    model = DeepEnsemble(keras_ensemble, optimizer_wrapper, bootstrap=True)
     model.optimize(example_data)
 
     assert optimizer.iterations.numpy() == steps_per_epoch * epochs
+
+    keras_ensemble.model.fit.assert_called_once()
+    validation_data = model_fit_spy.call_args_list[0].kwargs["validation_data"]
+
+    n_expected_validation_data = int(n_rows * validation_split_proportion)
+    assert len(validation_data) == n_expected_validation_data
+
+    validation_data_x, _ = tf.data.Dataset.get_single_element(
+        validation_data.batch(n_expected_validation_data)
+    )
+    for _x in validation_data_x.values():
+        # check for repeated values to verify that validation data has not been bootstrapped
+        assert tf.size(tf.unique(_x[:, 0])[0]) == n_expected_validation_data
 
 
 @random_seed

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -546,15 +546,19 @@ def test_deep_ensemble_predict_ensemble() -> None:
 def test_deep_ensemble__with_steps_per_epoch_and_validation_split() -> None:
     example_data = _get_example_data([100, 1])
 
+    epochs = 10
+    steps_per_epoch = 20
+
     keras_ensemble = trieste_keras_ensemble_model(example_data, ensemble_size=10)
 
     optimizer = tf_keras.optimizers.Adam()
+
     fit_args = {
         "batch_size": 100,
-        "epochs": 10,
+        "epochs": epochs,
         "callbacks": [],
         "verbose": 0,
-        "steps_per_epoch": 20,
+        "steps_per_epoch": steps_per_epoch,
         "validation_split": 0.5,
     }
     optimizer_wrapper = KerasOptimizer(optimizer, fit_args)
@@ -562,7 +566,7 @@ def test_deep_ensemble__with_steps_per_epoch_and_validation_split() -> None:
     model = DeepEnsemble(keras_ensemble, optimizer_wrapper)
     model.optimize(example_data)
 
-    assert optimizer.iterations.numpy() == fit_args["steps_per_epoch"] * fit_args["epochs"]
+    assert optimizer.iterations.numpy() == steps_per_epoch * epochs
 
 
 @random_seed

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -562,8 +562,7 @@ def test_deep_ensemble__with_steps_per_epoch_and_validation_split() -> None:
     model = DeepEnsemble(keras_ensemble, optimizer_wrapper)
     model.optimize(example_data)
 
-    losses = model.model.history.history["loss"]
-    assert len(losses) == fit_args["epochs"]
+    assert optimizer.iterations.numpy() == fit_args["steps_per_epoch"] * fit_args["epochs"]
 
 
 @random_seed

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -543,6 +543,30 @@ def test_deep_ensemble_predict_ensemble() -> None:
 
 
 @random_seed
+def test_deep_ensemble__with_steps_per_epoch_and_validation_split() -> None:
+    example_data = _get_example_data([100, 1])
+
+    keras_ensemble = trieste_keras_ensemble_model(example_data, ensemble_size=10)
+
+    optimizer = tf_keras.optimizers.Adam()
+    fit_args = {
+        "batch_size": 100,
+        "epochs": 10,
+        "callbacks": [],
+        "verbose": 0,
+        "steps_per_epoch": 20,
+        "validation_split": 0.5,
+    }
+    optimizer_wrapper = KerasOptimizer(optimizer, fit_args)
+
+    model = DeepEnsemble(keras_ensemble, optimizer_wrapper)
+    model.optimize(example_data)
+
+    losses = model.model.history.history["loss"]
+    assert len(losses) == fit_args["epochs"]
+
+
+@random_seed
 def test_deep_ensemble_sample() -> None:
     example_data = _get_example_data([100, 1])
     model, _, _ = trieste_deep_ensemble_model(example_data, _ENSEMBLE_SIZE, False, False)

--- a/tests/unit/models/keras/test_models.py
+++ b/tests/unit/models/keras/test_models.py
@@ -544,16 +544,16 @@ def test_deep_ensemble_predict_ensemble() -> None:
 
 
 @random_seed
-def test_deep_ensemble__with_steps_per_epoch_and_validation_split() -> None:
+def test_deep_ensemble__with_steps_per_epoch_and_validation_split(bootstrap_data: bool) -> None:
     n_rows = 150
     example_data = _get_example_data([n_rows, 1])
 
     batch_size = 100
     epochs = 10
     steps_per_epoch = 20
-    validation_split_proportion = 0.5
+    validation_split_proportion = 0.3
 
-    keras_ensemble = trieste_keras_ensemble_model(example_data, ensemble_size=10)
+    keras_ensemble = trieste_keras_ensemble_model(example_data, ensemble_size=2)
     model_fit_spy = MagicMock(side_effect=keras_ensemble.model.fit)
     keras_ensemble.model.fit = model_fit_spy
 
@@ -568,7 +568,7 @@ def test_deep_ensemble__with_steps_per_epoch_and_validation_split() -> None:
     }
     optimizer_wrapper = KerasOptimizer(optimizer, fit_args)
 
-    model = DeepEnsemble(keras_ensemble, optimizer_wrapper, bootstrap=True)
+    model = DeepEnsemble(keras_ensemble, optimizer_wrapper, bootstrap=bootstrap_data)
     model.optimize(example_data)
 
     assert optimizer.iterations.numpy() == steps_per_epoch * epochs

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -26,7 +26,7 @@ from gpflow.keras import tf_keras
 from tensorflow.python.keras.callbacks import Callback
 
 from ... import logging
-from ...data import Dataset
+from ...data import Dataset, split_dataset_randomly
 from ...space import EncoderFunction
 from ...types import TensorType
 from ...utils import flatten_leading_dims
@@ -481,10 +481,19 @@ class DeepEnsemble(
         if "epochs" in fit_args:
             fit_args["epochs"] = fit_args["epochs"] + self._absolute_epochs
 
+        if "validation_split" in fit_args:
+            dataset, validation_dataset = split_dataset_randomly(
+                dataset, fit_args["validation_split"]
+            )
+            x_val, y_val = self.prepare_dataset(validation_dataset, do_not_bootstrap=True)
+            del fit_args["validation_split"]
+            fit_args["validation_data"] = tf.data.Dataset.from_tensor_slices((x_val, y_val))
+
         x, y = self.prepare_dataset(dataset)
+        tf_train_dataset = self._build_tf_dataset(x, y)
+
         history = self.model.fit(
-            x=x,
-            y=y,
+            tf_train_dataset,
             **fit_args,
             initial_epoch=self._absolute_epochs,
         )
@@ -501,6 +510,20 @@ class DeepEnsemble(
             self.optimizer.optimizer.lr.assign(self.original_lr)
 
         return history
+
+    def _build_tf_dataset(
+        self, x: Dict[str, tf.Tensor], y: Dict[str, tf.Tensor]
+    ) -> tf.data.Dataset:
+        tf_dataset = tf.data.Dataset.from_tensor_slices((x, y))
+
+        if "steps_per_epoch" in self.optimizer.fit_args:
+            tf_dataset = tf_dataset.prefetch(tf.data.experimental.AUTOTUNE).repeat()
+
+        if "batch_size" in self.optimizer.fit_args:
+            batch_size = self.optimizer.fit_args["batch_size"]
+            tf_dataset = tf_dataset.batch(batch_size)
+
+        return tf_dataset
 
     def log(self, dataset: Optional[Dataset] = None) -> None:
         """

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -482,7 +482,7 @@ class DeepEnsemble(
             fit_args["epochs"] = fit_args["epochs"] + self._absolute_epochs
 
         if "validation_split" in fit_args:
-            dataset, validation_dataset = split_dataset_randomly(
+            validation_dataset, dataset = split_dataset_randomly(
                 dataset, fit_args["validation_split"]
             )
             x_val, y_val = self.prepare_dataset(validation_dataset, do_not_bootstrap=True)


### PR DESCRIPTION
**Related issue(s)/PRs:** 

[using tf.data for fit method in DeepEnsemble model](https://github.com/secondmind-labs/trieste/pull/890/files)

## Summary


This PR enables passing a `tf.data.Dataset` to Keras's `model.fit` in `DeepEnsemble`. This allows us to support training for a specified number of steps (rather than a number of epochs) for small datasets, which might require data repetition to meet the desired step count.

A limitation with Keras's `model.fit` is its incompatibility with simultaneously accepting `tf.data.Dataset` inputs and a `validation_split` parameter. This means, that if we want to pass `tf.data.Dataset`s to `model.fit`, then we need to form the validation split in Trieste, before passing the training split to `model.fit`. It's possible to do this in Trieste because we have access to the raw `x`, and `y` tensors before creating the `tf.data.Dataset`.

This PR essentially does the same thing as this [PR](https://github.com/secondmind-labs/trieste/pull/890) from @hrvoje but limiting the amount of additional complexity introduced to Trieste due to having to split the dataset ourselves. This is achieved by using the same method that Keras's `model.fit` uses internally to form the validation split.


...

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes 

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [x] The quality checks are all passing
- [x] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
