### PR TITLE
One hot encoder should encode to input dtype not space dtype

### DIFF
--- a/tests/unit/test_space.py
+++ b/tests/unit/test_space.py
@@ -1778,14 +1778,29 @@ def test_categorical_search_space__to_tags_raises_for_non_integers() -> None:
             tf.constant([[0], [1], [0]], dtype=tf.float64),
         ),
         (
+            CategoricalSearchSpace(["Y", "N"]),
+            tf.constant([[0], [1], [0]], dtype=tf.float32),
+            tf.constant([[0], [1], [0]], dtype=tf.float32),
+        ),
+        (
             CategoricalSearchSpace(["R", "G", "B"], dtype=tf.float32),
             tf.constant([[0], [2], [1]], dtype=tf.float32),
             tf.constant([[1, 0, 0], [0, 0, 1], [0, 1, 0]], dtype=tf.float32),
         ),
         (
+            CategoricalSearchSpace(["R", "G", "B"], dtype=tf.float32),
+            tf.constant([[0], [2], [1]], dtype=tf.float64),
+            tf.constant([[1, 0, 0], [0, 0, 1], [0, 1, 0]], dtype=tf.float64),
+        ),
+        (
             CategoricalSearchSpace(["R", "G", "B"]),
             tf.constant([[[[[0]]]]], dtype=tf.float64),
             tf.constant([[[[[1, 0, 0]]]]], dtype=tf.float64),
+        ),
+        (
+            CategoricalSearchSpace(["R", "G", "B"]),
+            tf.constant([[[[[0]]]]], dtype=tf.float32),
+            tf.constant([[[[[1, 0, 0]]]]], dtype=tf.float32),
         ),
         (
             CategoricalSearchSpace(["R", "G", "B", "A"], dtype=tf.float32),
@@ -1814,6 +1829,11 @@ def test_categorical_search_space__to_tags_raises_for_non_integers() -> None:
             TaggedProductSearchSpace([Box([0.0], [1.0]), CategoricalSearchSpace(["R", "G", "B"])]),
             tf.constant([[[0.5, 0]], [[0.3, 2]]], dtype=tf.float64),
             tf.constant([[[0.5, 1, 0, 0]], [[0.3, 0, 0, 1]]], dtype=tf.float64),
+        ),
+        (
+            TaggedProductSearchSpace([Box([0.0], [1.0]), CategoricalSearchSpace(["R", "G", "B"])]),
+            tf.constant([[[0.5, 0]], [[0.3, 2]]], dtype=tf.float32),
+            tf.constant([[[0.5, 1, 0, 0]], [[0.3, 0, 0, 1]]], dtype=tf.float32),
         ),
         (
             Box([0.0], [1.0]),

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -673,7 +673,7 @@ class CategoricalSearchSpace(GeneralDiscreteSearchSpace, HasOneHotEncoder):
             ]
             encoded = tf.concat(
                 [
-                    tf.cast(encoder(column), dtype=self._dtype)
+                    tf.cast(encoder(column), dtype=x.dtype)
                     for encoder, column in zip(encoders, columns)
                 ],
                 axis=1,


### PR DESCRIPTION
**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

...

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes / no

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The quality checks are all passing
- [ ] The bug case / new feature is covered by tests
- [ ] Any new features are well-documented (in docstrings or notebooks)
