### PR TITLE
feat(space): add HierarchicalSearchSpace activity/task logic

### DIFF
--- a/docs/notebooks/hierarchical_search_space.pct.py
+++ b/docs/notebooks/hierarchical_search_space.pct.py
@@ -1,0 +1,293 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: .venv_310
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Hierarchical search spaces
+#
+# This notebook demonstrates Trieste's `HierarchicalSearchSpace`, a search space that
+# represents the conditional activation structure of a Generalized Disjunctive Program (GDP).
+# Variables in such a space are gated by *indicator variables* (binary or categorical)
+# that decide which other dimensions are meaningful.
+#
+# The core primitives introduced:
+#
+# - `BooleanSearchSpace`: a one-dimensional discrete space restricted to ``{0, 1}``.
+# - `CategoricalSearchSpace`: a one-dimensional discrete space over ``K`` named or
+#   indexed categories.
+# - `gpflow.kernels.HierarchyNode` (re-exported as `trieste.space.HierarchyNode`): a
+#   GPflow primitive describing one disjunction via `feature_dims` (integer flat-vector
+#   columns), `feature_bounds`, and an `ActivityCondition` whose `requirements` map
+#   indicator local indices to required integer values.
+# - `hierarchy_node_from_tags`: a thin tag-based factory that resolves
+#   `subspace_tags` / `activity_condition_tags` against a `subspaces` mapping and
+#   returns a populated `HierarchyNode`. User-facing examples use this factory rather
+#   than constructing `HierarchyNode` by hand.
+# - `HierarchicalSearchSpace`: a `CollectionSearchSpace` that wires the indicators and
+#   nodes together and exposes a tag-based query API for downstream consumers.
+#
+# We walk through the API on two small examples: a Boolean indicator (the canonical
+# four-variable disjunction) and a 3-ary categorical indicator. The notebook stops at
+# the search-space layer.
+# %%
+import numpy as np
+import tensorflow as tf
+
+from trieste.space import (
+    BooleanSearchSpace,
+    Box,
+    CategoricalSearchSpace,
+    HierarchicalSearchSpace,
+    hierarchy_node_from_tags,
+)
+
+np.random.seed(1793)
+tf.random.set_seed(1793)
+
+# %% [markdown]
+# ## Boolean-indicator example
+#
+# Consider a four-variable space with one Boolean indicator. Variable $x_1$ is
+# continuous and always active; $y_1$ is the indicator; $x_2$ is continuous and active
+# only when $y_1 = 1$; $x_3$ is continuous and active only when $y_1 = 0$.
+#
+# We give each subspace a tag in the `subspaces` mapping (iteration order defines
+# the flat-vector layout), then describe the hierarchy as three nodes — one
+# unconditional ("shared") and two gated by `y1`. `hierarchy_node_from_tags`
+# resolves the tag-based inputs to a populated `gpflow.kernels.HierarchyNode`.
+
+# %%
+subspaces = {
+    "x1": Box([0.0], [1.0]),  # unconditional
+    "y1": BooleanSearchSpace(),  # Boolean indicator
+    "x2": Box([0.0], [5.0]),  # active when y1 = 1
+    "x3": Box([-1.0], [1.0]),  # active when y1 = 0
+}
+hierarchy = [
+    hierarchy_node_from_tags(
+        "shared",
+        subspace_tags=["x1"],
+        subspaces=subspaces,
+        indicator_tags=["y1"],
+    ),
+    hierarchy_node_from_tags(
+        "branch_A",
+        subspace_tags=["x2"],
+        activity_condition_tags={"y1": 1},
+        subspaces=subspaces,
+        indicator_tags=["y1"],
+    ),
+    hierarchy_node_from_tags(
+        "branch_B",
+        subspace_tags=["x3"],
+        activity_condition_tags={"y1": 0},
+        subspaces=subspaces,
+        indicator_tags=["y1"],
+    ),
+]
+space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"])
+
+print("dimension:", int(space.dimension))
+print("indicator_tags:", space.indicator_tags)
+print("non_indicator_tags:", space.non_indicator_tags)
+print("indicator_value_sets:", space.indicator_value_sets)
+
+# %% [markdown]
+# ### Sampling and the flat-vector layout
+#
+# Points are represented as flat vectors `[x1, y1, x2, x3]` concatenated in tag order,
+# the same convention as `TaggedProductSearchSpace`. For a sample with $y_1 = 1$ the
+# `x3` column is *inactive*: its value is still present in the vector but has no
+# semantic meaning. Downstream kernels (Arc, Wedge, Conditional) handle inactive
+# columns according to their respective axioms.
+
+# %%
+samples = space.sample(8)
+print("samples shape:", samples.shape)
+print(samples.numpy())
+
+# %% [markdown]
+# `get_subspace_component` slices the columns belonging to a given tag. It works on
+# any batch shape because indexing is on the trailing axis.
+
+# %%
+print("y1 column:", space.get_subspace_component("y1", samples).numpy().ravel())
+print("x2 column:", space.get_subspace_component("x2", samples).numpy().ravel())
+
+# %% [markdown]
+# ### Hierarchy queries
+#
+# Several methods expose the hierarchy programmatically. `enumerate_tasks` returns
+# every indicator configuration; `active_subspace_tags` returns the non-indicator
+# tags active for one configuration; `is_active` answers the per-tag question; and
+# `node_for_subspace` returns the nodes that contain a given tag.
+
+# %%
+print("enumerate_tasks:", space.enumerate_tasks())
+print("active for y1=1:", space.active_subspace_tags({"y1": 1}))
+print("active for y1=0:", space.active_subspace_tags({"y1": 0}))
+print("x2 is_active when y1=1:", space.is_active("x2", {"y1": 1}))
+print("x2 is_active when y1=0:", space.is_active("x2", {"y1": 0}))
+print("nodes containing 'x1':", [n.name for n in space.node_for_subspace("x1")])
+print("nodes containing 'x2':", [n.name for n in space.node_for_subspace("x2")])
+
+# %% [markdown]
+# ## Categorical-indicator example
+#
+# When a disjunction has more than two branches, a single $K$-ary categorical
+# indicator is the natural representation. Suppose $y_1$ now selects among three unit
+# types $\{0\colon\text{shared-only},\;1\colon\text{branch A},\;2\colon\text{branch B}\}$.
+
+# %%
+subspaces_c = {
+    "x1": Box([0.0], [1.0]),  # unconditional
+    "y1": CategoricalSearchSpace(3),  # 3-ary indicator
+    "x2": Box([0.0], [5.0]),  # active when y1 = 1
+    "x3": Box([-1.0], [1.0]),  # active when y1 = 2
+}
+hierarchy_c = [
+    hierarchy_node_from_tags(
+        "shared",
+        subspace_tags=["x1"],
+        subspaces=subspaces_c,
+        indicator_tags=["y1"],
+    ),
+    hierarchy_node_from_tags(
+        "branch_A",
+        subspace_tags=["x2"],
+        activity_condition_tags={"y1": 1},
+        subspaces=subspaces_c,
+        indicator_tags=["y1"],
+    ),
+    hierarchy_node_from_tags(
+        "branch_B",
+        subspace_tags=["x3"],
+        activity_condition_tags={"y1": 2},
+        subspaces=subspaces_c,
+        indicator_tags=["y1"],
+    ),
+]
+space_c = HierarchicalSearchSpace(
+    subspaces_c, hierarchy_c, indicator_tags=["y1"]
+)
+
+print("indicator_value_sets:", space_c.indicator_value_sets)
+print("enumerate_tasks:", space_c.enumerate_tasks())
+print("active for y1=0:", space_c.active_subspace_tags({"y1": 0}))
+print("active for y1=1:", space_c.active_subspace_tags({"y1": 1}))
+print("active for y1=2:", space_c.active_subspace_tags({"y1": 2}))
+
+# %% [markdown]
+# ## Mixing indicator kinds
+#
+# Boolean and categorical indicators can be combined in a single
+# `HierarchicalSearchSpace`. `enumerate_tasks` then returns the Cartesian product of
+# every indicator's permitted set: $|\{0,1\}| \times |\{0,1,2\}| = 6$ tasks below.
+
+# %%
+subspaces_mix = {
+    "x1": Box([0.0], [1.0]),
+    "y1": BooleanSearchSpace(),
+    "y2": CategoricalSearchSpace(3),
+    "x2": Box([0.0], [5.0]),
+}
+hierarchy_mix = [
+    hierarchy_node_from_tags(
+        "shared",
+        subspace_tags=["x1"],
+        subspaces=subspaces_mix,
+        indicator_tags=["y1", "y2"],
+    ),
+    hierarchy_node_from_tags(
+        "branch",
+        subspace_tags=["x2"],
+        activity_condition_tags={"y1": 1, "y2": 2},
+        subspaces=subspaces_mix,
+        indicator_tags=["y1", "y2"],
+    ),
+]
+space_mix = HierarchicalSearchSpace(
+    subspaces_mix, hierarchy_mix, indicator_tags=["y1", "y2"]
+)
+tasks = space_mix.enumerate_tasks()
+print(f"number of tasks: {len(tasks)}")
+for t in tasks:
+    print(" ", t)
+
+# %% [markdown]
+# ## Validation rules
+#
+# Construction fails fast with a `ValueError` when the inputs are inconsistent. A few
+# representative rejections:
+#
+# - an indicator tag that does not point to a `BooleanSearchSpace` or a
+#   one-dimensional `CategoricalSearchSpace`;
+# - an `activity_condition` required value that is outside the indicator's permitted
+#   set (e.g. `5` for a 3-ary categorical, or any non-Boolean value for a
+#   `BooleanSearchSpace`);
+# - an indicator that gates nothing (does not appear as a key in any node).
+
+
+# %%
+def _expect_value_error(fn):
+    try:
+        fn()
+    except ValueError as e:
+        print("rejected:", str(e).split("\n")[0])
+    else:
+        raise AssertionError("expected ValueError but none was raised")
+
+
+# Out-of-permitted-set required value: y1 is a 3-ary categorical, so 5 is invalid.
+_subspaces_oor = {
+    "x1": Box([0.0], [1.0]),
+    "y1": CategoricalSearchSpace(3),
+}
+_expect_value_error(
+    lambda: HierarchicalSearchSpace(
+        _subspaces_oor,
+        [
+            hierarchy_node_from_tags(
+                "n",
+                subspace_tags=["x1"],
+                activity_condition_tags={"y1": 5},
+                subspaces=_subspaces_oor,
+                indicator_tags=["y1"],
+            )
+        ],
+        indicator_tags=["y1"],
+    )
+)
+
+# Indicator subspace must be dimension-1: a 2-D CategoricalSearchSpace is rejected.
+_subspaces_2d = {
+    "x1": Box([0.0], [1.0]),
+    "y1": CategoricalSearchSpace([3, 2]),
+}
+_expect_value_error(
+    lambda: HierarchicalSearchSpace(
+        _subspaces_2d,
+        [
+            hierarchy_node_from_tags(
+                "n",
+                subspace_tags=["x1"],
+                activity_condition_tags={"y1": 1},
+                subspaces=_subspaces_2d,
+                indicator_tags=["y1"],
+            )
+        ],
+        indicator_tags=["y1"],
+    )
+)

--- a/docs/notebooks/hierarchical_search_space_constraints.pct.py
+++ b/docs/notebooks/hierarchical_search_space_constraints.pct.py
@@ -1,0 +1,267 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: .venv_310
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Constraints on a `HierarchicalSearchSpace`
+#
+# The previous notebooks built a `HierarchicalSearchSpace` and a GPflow
+# `ArcHierarchical` kernel over it. Real disjunctive-design problems usually also
+# carry **constraints**. Trieste's `HierarchicalSearchSpace` supports three kinds,
+# all reusing the standard search-space contract (`constraints_residuals` /
+# `is_feasible`), so a constrained space drops straight into the usual Bayesian
+# optimization machinery:
+#
+# * **Global constraints** — ordinary `LinearConstraint` / `NonlinearConstraint`
+#   objects enforced on the full flat vector (the same `constraints=` argument as
+#   `Box`).
+# * **Conditional (disjunctive) constraints** — `ConditionalConstraint`, enforced
+#   only when a set of indicators take specified values. On inactive rows the
+#   residual is the big-M sentinel `INACTIVE_CONSTRAINT_RESIDUAL`, so the point is
+#   trivially feasible there and gradient-based polish never crosses the indicator
+#   discontinuity.
+# * **Logical propositions** — `LogicalProposition`, a boolean condition on the
+#   indicators alone (no gradient); checked in `is_feasible` only.
+
+# %%
+import gpflow
+import numpy as np
+import tensorflow as tf
+from gpflow.kernels import ArcHierarchical
+
+from trieste.acquisition.function import ExpectedImprovement
+from trieste.acquisition.rule import EfficientGlobalOptimization
+from trieste.bayesian_optimizer import BayesianOptimizer
+from trieste.models.gpflow import GaussianProcessRegression
+from trieste.objectives import mk_observer
+from trieste.space import (
+    INACTIVE_CONSTRAINT_RESIDUAL,
+    BooleanSearchSpace,
+    Box,
+    ConditionalConstraint,
+    HierarchicalSearchSpace,
+    LinearConstraint,
+    LogicalProposition,
+    hierarchy_node_from_tags,
+)
+
+np.random.seed(1793)
+tf.random.set_seed(1793)
+
+# %% [markdown]
+# ## A constrained disjunctive space
+#
+# Canonical four-variable disjunction: $x_1$ unconditional, $y_1$ a Boolean
+# indicator, $x_2$ active when $y_1 = 1$, $x_3$ active when $y_1 = 0$. We attach:
+#
+# * a **global** constraint $x_1 + 0.5\,x_2 \leq 0.9$;
+# * a **conditional** constraint $x_3 \geq -0.5$, enforced only on the $y_1 = 0$
+#   branch.
+
+# %%
+subspaces = {
+    "x1": Box([0.0], [1.0]),
+    "y1": BooleanSearchSpace(),
+    "x2": Box([0.0], [5.0]),
+    "x3": Box([-1.0], [1.0]),
+}
+hierarchy = [
+    hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces, indicator_tags=["y1"]),
+    hierarchy_node_from_tags(
+        "branch_A", subspace_tags=["x2"], activity_condition_tags={"y1": 1},
+        subspaces=subspaces, indicator_tags=["y1"],
+    ),
+    hierarchy_node_from_tags(
+        "branch_B", subspace_tags=["x3"], activity_condition_tags={"y1": 0},
+        subspaces=subspaces, indicator_tags=["y1"],
+    ),
+]
+
+# Global: x1 + 0.5 x2 <= 0.9  (flat columns [x1, y1, x2, x3] -> A picks x1 and x2).
+global_constraint = LinearConstraint(
+    A=tf.constant([[1.0, 0.0, 0.5, 0.0]], dtype=tf.float64),
+    lb=[-INACTIVE_CONSTRAINT_RESIDUAL],
+    ub=[0.9],
+)
+# Conditional: x3 >= -0.5 only when y1 == 0.
+conditional_constraint = ConditionalConstraint(
+    constraint=LinearConstraint(
+        A=tf.constant([[1.0]], dtype=tf.float64), lb=[-0.5], ub=[INACTIVE_CONSTRAINT_RESIDUAL]
+    ),
+    indicator_conditions={"y1": 0},
+    active_subspace_tags=["x3"],
+)
+
+space = HierarchicalSearchSpace(
+    subspaces,
+    hierarchy,
+    indicator_tags=["y1"],
+    constraints=[global_constraint],
+    conditional_constraints=[conditional_constraint],
+)
+print("has_constraints:", space.has_constraints)
+
+# %% [markdown]
+# ## Residuals and the big-M sentinel
+#
+# `constraints_residuals` stacks the global and conditional residual columns.
+# On a row where the conditional constraint is *inactive* ($y_1 = 1$) its columns
+# are the big-M sentinel — that point is feasible with respect to the conditional
+# constraint regardless of $x_3$.
+
+# %%
+# x2 = 0.4 keeps the global constraint x1 + 0.5 x2 = 0.5 <= 0.9 satisfied, so the rows
+# differ only in the conditional constraint.
+demo = tf.constant(
+    [
+        [0.3, 0.0, 0.4, 0.2],   # y1=0: conditional active (x3=0.2 >= -0.5 ok) -> feasible
+        [0.3, 0.0, 0.4, -0.8],  # y1=0: conditional active (x3=-0.8 violates) -> infeasible
+        [0.3, 1.0, 0.4, -0.8],  # y1=1: conditional inactive -> big-M -> feasible
+    ],
+    dtype=tf.float64,
+)
+print("residuals (cols: global[lo,hi], conditional[lo,hi]):")
+print(f"  (inactive sentinel = {INACTIVE_CONSTRAINT_RESIDUAL})")
+print(space.constraints_residuals(demo).numpy())
+print("is_feasible:", space.is_feasible(demo).numpy())
+
+# %% [markdown]
+# ## Logical propositions (indicator-only)
+#
+# A `LogicalProposition` constrains the indicators alone. With two indicators we
+# can express "if $y_2 = 1$ then $y_1 = 1$". It is checked by `is_feasible` but,
+# having no continuous gradient, is excluded from `constraints_residuals`.
+
+# %%
+subspaces_2 = {
+    "x1": Box([0.0], [1.0]),
+    "y1": BooleanSearchSpace(),
+    "y2": BooleanSearchSpace(),
+    "x2": Box([0.0], [1.0]),
+}
+hierarchy_2 = [
+    hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces_2, indicator_tags=["y1", "y2"]),
+    hierarchy_node_from_tags(
+        "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1, "y2": 1},
+        subspaces=subspaces_2, indicator_tags=["y1", "y2"],
+    ),
+]
+space_2 = HierarchicalSearchSpace(
+    subspaces_2,
+    hierarchy_2,
+    indicator_tags=["y1", "y2"],
+    logical_propositions=[
+        LogicalProposition(
+            fun=lambda ind: tf.logical_or(
+                tf.not_equal(ind["y2"][..., 0], 1.0), tf.equal(ind["y1"][..., 0], 1.0)
+            ),
+            name="y2_implies_y1",
+        )
+    ],
+)
+pts_2 = tf.constant(
+    [
+        [0.5, 1.0, 1.0, 0.5],  # y2=1, y1=1 -> ok
+        [0.5, 0.0, 1.0, 0.5],  # y2=1, y1=0 -> violates implication
+    ],
+    dtype=tf.float64,
+)
+print("logical is_feasible:", space_2.is_feasible(pts_2).numpy())
+
+# %% [markdown]
+# ## Constrained Bayesian optimization
+#
+# We minimise a synthetic disjunctive objective over the constrained `space` with
+# trieste's standard `EfficientGlobalOptimization` rule and `ExpectedImprovement`
+# acquisition, wrapping a GPflow `ArcHierarchical` GPR in a trieste
+# `GaussianProcessRegression`.
+#
+# Feasibility needs a little care. The generic continuous acquisition optimizer
+# would *relax* the Boolean indicators to $[0, 1]$ and only pass the **global**
+# constraints to the solver — it does not see the conditional/logical constraints,
+# nor the discreteness of the indicators. Since this space's feasibility is a known
+# boolean function (`space.is_feasible`), the idiomatic approach is a small custom
+# acquisition optimizer that rejection-samples **feasible** candidates (which are
+# valid by construction) and returns the one maximising the acquisition.
+
+
+# %%
+def objective(X):
+    X = np.asarray(X)
+    x1, y1, x2, x3 = X[:, 0], X[:, 1], X[:, 2], X[:, 3]
+    branch_a = y1.round().astype(bool)  # y1 == 1 branch (x2 active) vs y1 == 0 branch (x3 active)
+    y = (
+        np.sin(2.0 * np.pi * x1)
+        + np.where(branch_a, 0.5 * np.cos(np.pi * x2 / 5.0), 0.5 * x3)
+    ).reshape(-1, 1)
+    return tf.constant(y, dtype=tf.float64)
+
+
+def feasible_sample(n, max_tries=100):
+    """Rejection-sample ``n`` feasible points from the constrained space."""
+    kept, tries = [], 0
+    while sum(len(k) for k in kept) < n:
+        if tries >= max_tries:
+            raise RuntimeError(f"Could not draw {n} feasible points in {max_tries} tries.")
+        pool = space.sample(4 * n)
+        kept.append(tf.boolean_mask(pool, space.is_feasible(pool)).numpy())
+        tries += 1
+    return np.concatenate(kept, axis=0)[:n]
+
+
+def feasible_acquisition_optimizer(space, target_func):
+    """Maximise the acquisition over a pool of rejection-sampled feasible candidates."""
+    # ``EfficientGlobalOptimization`` may pass ``(function, vectorization)``; we use one point.
+    target_func = target_func[0] if isinstance(target_func, tuple) else target_func
+    candidates = tf.convert_to_tensor(feasible_sample(200), dtype=tf.float64)  # [N, D]
+    acquisition = target_func(candidates[:, None, :])  # [N, 1]
+    return candidates[int(tf.argmax(acquisition[:, 0]))][None]  # [1, D]
+
+
+observer = mk_observer(objective)
+active_dims = list(range(int(space.dimension)))
+initial_data = observer(tf.convert_to_tensor(feasible_sample(15), dtype=tf.float64))
+
+# Wrap a GPflow ArcHierarchical GPR as a trieste model.
+kernel = gpflow.kernels.Constant() * ArcHierarchical(
+    list(space.hierarchy), active_dims=active_dims
+)
+gpr = gpflow.models.GPR(
+    (initial_data.query_points, initial_data.observations), kernel=kernel, noise_variance=0.01
+)
+# num_kernel_samples=0: skip the random-restart hyperparameter sampling, which doesn't support
+# ArcHierarchical's vector-valued ``angle`` parameter; we just optimise from the default init.
+model = GaussianProcessRegression(gpr, num_kernel_samples=0)
+
+rule = EfficientGlobalOptimization(
+    builder=ExpectedImprovement(), optimizer=feasible_acquisition_optimizer
+)
+result = BayesianOptimizer(observer, space).optimize(3, initial_data, model, rule)
+
+final_data = result.try_get_final_dataset()
+print(f"best feasible objective = {float(tf.reduce_min(final_data.observations)):+.3f}")
+
+# %% [markdown]
+# ## What this shows
+#
+# * `HierarchicalSearchSpace` carries global, conditional, and logical constraints
+#   behind the standard `is_feasible` / `constraints_residuals` interface.
+# * A constrained disjunctive space drops into trieste's usual machinery — an
+#   `ArcHierarchical` GPR wrapped in `GaussianProcessRegression`, optimised by
+#   `EfficientGlobalOptimization` with `ExpectedImprovement`.
+# * Feasibility (including the discrete indicators and the conditional/logical
+#   constraints) enters through a one-line custom acquisition optimizer that maximises
+#   the acquisition over `space.is_feasible` candidates; the big-M residual keeps
+#   inactive disjunctive branches feasible without special-casing.

--- a/docs/notebooks/hierarchical_search_space_gpflow_kernel.pct.py
+++ b/docs/notebooks/hierarchical_search_space_gpflow_kernel.pct.py
@@ -1,0 +1,271 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: .venv_310
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # A GPflow hierarchical kernel over a `HierarchicalSearchSpace`
+#
+# The previous notebook introduced `HierarchicalSearchSpace`, the conditional /
+# disjunctive search space that gates non-indicator subspaces by indicator
+# values. To do Bayesian optimisation over such a space we need a covariance
+# function that respects the activation structure: a point whose conditional
+# feature is *inactive* should not be confused with one whose feature is
+# *active and equal in value* — the two live in fundamentally different
+# regions of the space.
+#
+# GPflow ships such kernels: `gpflow.kernels.ArcHierarchical` (the **Arc**
+# kernel of Swersky et al. 2014) and `gpflow.kernels.WedgeHierarchical` (the
+# **Wedge** kernel of Horn et al. 2019). This notebook shows how to feed a
+# Trieste `HierarchicalSearchSpace` straight into `ArcHierarchical` and fit a
+# GP — i.e. the integration glue between Trieste's search-space layer and
+# GPflow's kernel layer. The only real work is a small coordinate-system
+# adapter, explained below.
+
+# %%
+import gpflow
+import numpy as np
+import tensorflow as tf
+from gpflow.kernels import ArcHierarchical, WedgeHierarchical
+
+from trieste.space import (
+    BooleanSearchSpace,
+    Box,
+    HierarchicalSearchSpace,
+    hierarchy_node_from_tags,
+)
+
+np.random.seed(1793)
+tf.random.set_seed(1793)
+
+# %% [markdown]
+# ## Three axioms for a conditional distance
+#
+# Let $\mathbf{x}^{nc}$ be the always-active (unconditional) coordinates and
+# $\mathbf{x}^{c}$ the indicator-gated (conditional) ones. A useful per-dimension
+# distance $d_i(\mathbf{x}, \mathbf{x}')$ on a *conditional* dimension $i$
+# should satisfy:
+#
+# 1. **both inactive:** $d_i = 0$ — the value is meaningless on either side.
+# 2. **both active:** $d_i$ is a function of the difference in feature value.
+# 3. **incomparable** (one active, one inactive): $d_i$ is positive and places
+#    the two points in distinct regions of the embedded space.
+#
+# Both `ArcHierarchical` and `WedgeHierarchical` enforce these axioms by
+# **embedding each conditional dimension into $\mathbb{R}^2$**: inactive points
+# map to the origin, active points to a value-dependent point off the origin. A
+# stationary base kernel (Matérn-5/2 by default) then evaluates the covariance
+# in the joint embedded space. We do not have to implement any of this — we
+# only have to describe the activation structure to the kernel.
+
+# %% [markdown]
+# ## Build the search space
+#
+# Canonical four-variable disjunction: $x_1$ unconditional, $y_1$ a Boolean
+# indicator, $x_2$ active when $y_1 = 1$, $x_3$ active when $y_1 = 0$. This is
+# the same space as the previous notebook.
+
+# %%
+subspaces = {
+    "x1": Box([0.0], [1.0]),  # unconditional
+    "y1": BooleanSearchSpace(),  # Boolean indicator
+    "x2": Box([0.0], [5.0]),  # active when y1 = 1
+    "x3": Box([-1.0], [1.0]),  # active when y1 = 0
+}
+hierarchy = [
+    hierarchy_node_from_tags(
+        "shared",
+        subspace_tags=["x1"],
+        subspaces=subspaces,
+        indicator_tags=["y1"],
+    ),
+    hierarchy_node_from_tags(
+        "branch_A",
+        subspace_tags=["x2"],
+        activity_condition_tags={"y1": 1},
+        subspaces=subspaces,
+        indicator_tags=["y1"],
+    ),
+    hierarchy_node_from_tags(
+        "branch_B",
+        subspace_tags=["x3"],
+        activity_condition_tags={"y1": 0},
+        subspaces=subspaces,
+        indicator_tags=["y1"],
+    ),
+]
+space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"])
+print("dimension:     ", int(space.dimension))
+print("indicator_tags:", space.indicator_tags)
+print("indicator_dims:", space.indicator_dims)
+
+# %% [markdown]
+# ## From a `HierarchicalSearchSpace` to a GPflow hierarchy
+#
+# `ArcHierarchical` takes a sequence of `gpflow.kernels.HierarchyNode` plus an
+# `active_dims` argument:
+#
+# ```python
+# ArcHierarchical(hierarchy, base_kernel=None, *, active_dims, name=None)
+# ```
+#
+# Each node carries `feature_dims` (the real-valued columns it owns),
+# `feature_bounds` (for normalisation), and an `ActivityCondition` whose
+# `requirements` map gates those columns. The kernel **infers** the indicator
+# columns as the union of all `requirements` keys, slices its input down to
+# `active_dims`, and validates that the feature columns and the inferred
+# indicator columns together tile the sliced vector contiguously.
+#
+# `HierarchicalSearchSpace.hierarchy` exposes exactly these `HierarchyNode`
+# objects: Trieste keys both `feature_dims` and the `requirements` map by global
+# flat-vector column (the same convention the kernel uses), so the nodes can be
+# passed straight to `ArcHierarchical` — no adapter needed. Since every column of
+# an HSS flat vector is either a feature or an indicator, we slice on **all**
+# columns — `active_dims = range(dimension)` — so the sliced and global
+# coordinate systems coincide.
+
+# %%
+active_dims = list(range(int(space.dimension)))
+for node in space.hierarchy:
+    print(
+        f"{node.name:9s} feature_dims={list(node.feature_dims)} "
+        f"requirements={dict(node.activity_condition.requirements)}"
+    )
+print("active_dims:", active_dims)
+
+# %% [markdown]
+# ## Construct the Arc kernel
+#
+# With the hierarchy and `active_dims` in hand, the kernel is a one-liner. (The
+# hierarchical kernels are flagged `@experimental` in GPflow 2.11, so
+# constructing one emits a `UserWarning` — that is expected.)
+
+# %%
+arc = ArcHierarchical(list(space.hierarchy), active_dims=active_dims)
+print(type(arc).__name__, "built over active_dims", active_dims)
+
+# %% [markdown]
+# ## Inspect the covariance on a hand-crafted batch
+#
+# The flat-vector layout is `[x1, y1, x2, x3]`. The two rows below share
+# $x_1 = 0.5$ and the *same stored* $x_2 = 2.5$, but differ in the indicator:
+# the first has $y_1 = 1$ (so $x_2$ is active, $x_3$ inactive) and the second
+# has $y_1 = 0$ (so $x_3$ is active, $x_2$ inactive). A conditional kernel must
+# place them in different regions, so their cross-covariance is well below the
+# unit diagonal.
+
+# %%
+X_demo = tf.constant(
+    [
+        [0.5, 1.0, 2.5, 0.0],  # y1 = 1: x1 + x2 active
+        [0.5, 0.0, 2.5, 0.0],  # y1 = 0: x1 + x3 active
+    ],
+    dtype=tf.float64,
+)
+print("K(X_demo):")
+print(arc.K(X_demo).numpy())
+
+# %% [markdown]
+# ## Worked example: fit a GP on a synthetic disjunctive function
+#
+# Synthetic objective whose two branches carry different signal:
+#
+# $$f(x_1, y_1, x_2, x_3) =
+#     \sin(2\pi x_1)
+#   \;+\; \mathbf{1}[y_1 = 1] \cdot \tfrac{1}{2} \cos(\pi x_2 / 5)
+#   \;+\; \mathbf{1}[y_1 = 0] \cdot \tfrac{1}{2} x_3.$$
+#
+# The conditional kernel must "switch off" the inactive branch's contribution
+# to similarity for that to be learnable from a finite sample.
+
+
+# %%
+def objective(X):
+    X = np.asarray(X)
+    x1, y1, x2, x3 = X[:, 0], X[:, 1], X[:, 2], X[:, 3]
+    return (
+        np.sin(2.0 * np.pi * x1)
+        + (y1 > 0.5).astype(float) * 0.5 * np.cos(np.pi * x2 / 5.0)
+        + (y1 < 0.5).astype(float) * 0.5 * x3
+    ).reshape(-1, 1)
+
+
+X_train = space.sample(40).numpy()
+Y_train = objective(X_train) + 0.05 * np.random.randn(40, 1)
+
+# Wrap in a Constant() factor so the GP can learn an overall variance.
+kernel = gpflow.kernels.Constant() * ArcHierarchical(
+    list(space.hierarchy), active_dims=active_dims
+)
+gpr = gpflow.models.GPR(
+    data=(X_train, Y_train), kernel=kernel, noise_variance=0.05
+)
+
+print(f"LML before fit: {gpr.log_marginal_likelihood().numpy():+.3f}")
+gpflow.optimizers.Scipy().minimize(
+    gpr.training_loss, gpr.trainable_variables, options={"maxiter": 100}
+)
+print(f"LML after fit:  {gpr.log_marginal_likelihood().numpy():+.3f}")
+
+# %% [markdown]
+# ## Predict on held-out points
+#
+# We evaluate on a small held-out batch covering both branches. The kernel
+# places the two test rows on different parts of the embedded space, so their
+# predicted means follow the corresponding branch's signal.
+
+# %%
+X_test = np.array(
+    [
+        [0.3, 1.0, 2.0, 0.0],  # y1 = 1
+        [0.3, 0.0, 0.0, 0.5],  # y1 = 0
+        [0.7, 1.0, 4.0, 0.0],  # y1 = 1
+        [0.7, 0.0, 0.0, -0.4],  # y1 = 0
+    ]
+)
+mean, var = gpr.predict_f(X_test)
+print("test predictions vs ground truth:")
+truth = objective(X_test).ravel()
+for x, m, v, t in zip(X_test, mean.numpy().ravel(), var.numpy().ravel(), truth):
+    print(
+        f"  x = {x.tolist()}  ->  mean = {m:+.3f}  var = {v:.3f}  truth = {t:+.3f}"
+    )
+
+# %% [markdown]
+# ## Swapping in the Wedge kernel
+#
+# `WedgeHierarchical` has the identical constructor, so switching embeddings is
+# a one-line change. Its "incomparable" distance scales with the active value
+# $v_c$ rather than being constant in it — often closer to what a practitioner
+# expects near disjunction boundaries.
+
+# %%
+wedge = WedgeHierarchical(list(space.hierarchy), active_dims=active_dims)
+print("Wedge kernel matrix on demo points:")
+print(wedge.K(X_demo).numpy())
+
+# %% [markdown]
+# ## What this shows
+#
+# A conditional GP over a disjunctive space needs only:
+#
+# * `BooleanSearchSpace`, `Box`, `HierarchicalSearchSpace`,
+#   `hierarchy_node_from_tags` from `trieste.space` to describe the structure;
+# * `list(space.hierarchy)` passed straight to the kernel — Trieste keys the
+#   hierarchy in GPflow's column convention, so no adapter is needed;
+# * `gpflow.kernels.ArcHierarchical` (or `WedgeHierarchical`) for the covariance.
+#
+# No bespoke kernel code is required — the hierarchy carried by
+# `HierarchicalSearchSpace` is exactly the information GPflow's hierarchical
+# kernels consume.

--- a/docs/notebooks/quickrun/hierarchical_search_space_constraints.yaml
+++ b/docs/notebooks/quickrun/hierarchical_search_space_constraints.yaml
@@ -1,0 +1,3 @@
+replace:
+  - { from: "n_bo_steps = \\d+", to: "n_bo_steps = 1" }
+  - { from: "feasible_sample\\(200\\)", to: "feasible_sample(20)" }

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -43,6 +43,9 @@ The following tutorials illustrate solving different types of optimization probl
    notebooks/rembo
    notebooks/trust_region
    notebooks/mixed_search_spaces
+   notebooks/hierarchical_search_space
+   notebooks/hierarchical_search_space_gpflow_kernel
+   notebooks/hierarchical_search_space_constraints
 
 Frequently asked questions
 --------------------------

--- a/tests/unit/test_hierarchical_search_space.py
+++ b/tests/unit/test_hierarchical_search_space.py
@@ -20,13 +20,18 @@ import pytest
 import tensorflow as tf
 
 from trieste.space import (
+    INACTIVE_CONSTRAINT_RESIDUAL,
     ActivityCondition,
     BooleanSearchSpace,
     Box,
     CategoricalSearchSpace,
+    ConditionalConstraint,
     DiscreteSearchSpace,
     HierarchicalSearchSpace,
     HierarchyNode,
+    LinearConstraint,
+    LogicalProposition,
+    NonlinearConstraint,
     SearchSpace,
     hierarchy_node_from_tags,
 )
@@ -618,6 +623,88 @@ def test_categorical_hss_active_subspaces() -> None:
     assert set(space.active_subspace_tags({"y1": 2})) == {"x1", "x3"}
 
 
+# ===== product =====
+
+
+def _make_second_hss(**kwargs) -> HierarchicalSearchSpace:
+    """A second, disjoint hierarchical space (tags z1/w1/z2) for product tests.
+
+    Columns: z1 (uncond), w1 (Boolean indicator), z2 gated by w1=1. Extra keyword
+    arguments (e.g. ``constraints=``) are forwarded to the constructor.
+    """
+    subspaces = {
+        "z1": Box([0.0], [1.0]),
+        "w1": BooleanSearchSpace(),
+        "z2": Box([0.0], [2.0]),
+    }
+    hierarchy = [
+        hierarchy_node_from_tags(
+            "z_shared",
+            subspace_tags=["z1"],
+            subspaces=subspaces,
+            indicator_tags=["w1"],
+        ),
+        hierarchy_node_from_tags(
+            "z_branch",
+            subspace_tags=["z2"],
+            activity_condition_tags={"w1": 1},
+            subspaces=subspaces,
+            indicator_tags=["w1"],
+        ),
+    ]
+    return HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["w1"], **kwargs)
+
+
+def test_hss_product_combines_tags_dimension_and_indicators() -> None:
+    combined = _make_worked_example_hss().product(_make_second_hss())
+    assert combined.subspace_tags == ("x1", "y1", "x2", "x4", "x3", "z1", "w1", "z2")
+    assert int(combined.dimension) == 8
+    assert combined.indicator_tags == ("y1", "w1")
+    # y1 is column 1, w1 is column 6 in the combined flat vector.
+    assert combined.indicator_dims == [1, 6]
+
+
+def test_hss_product_is_order_dependent() -> None:
+    # product concatenates self's layout then other's, so A x B != B x A.
+    a, b = _make_worked_example_hss(), _make_second_hss()
+    ab = a.product(b)
+    ba = b.product(a)
+    assert ab.subspace_tags == ("x1", "y1", "x2", "x4", "x3", "z1", "w1", "z2")
+    assert ba.subspace_tags == ("z1", "w1", "z2", "x1", "y1", "x2", "x4", "x3")
+
+
+def test_hss_product_shifts_other_feature_dims_and_requirements() -> None:
+    combined = _make_worked_example_hss().product(_make_second_hss())
+    # ``other``'s node feature_dims and activity_condition requirement columns are
+    # both shifted by self.dimension (5): z2 -> column 7, and w1 (other column 1)
+    # -> combined column 6.
+    z_branch = next(node for node in combined.hierarchy if node.name == "z_branch")
+    assert list(z_branch.feature_dims) == [7]
+    assert dict(z_branch.activity_condition.requirements) == {6: 1}
+    # feature_bounds describe values, not columns, so they are carried over unshifted.
+    assert z_branch.feature_bounds.numpy().tolist() == [[0.0, 2.0]]
+
+
+def test_hss_product_active_subspaces_and_is_active() -> None:
+    combined = _make_worked_example_hss().product(_make_second_hss())
+    assert set(combined.active_subspace_tags({"y1": 1, "w1": 1})) == {
+        "x1",
+        "x2",
+        "x4",
+        "z1",
+        "z2",
+    }
+    assert set(combined.active_subspace_tags({"y1": 0, "w1": 0})) == {"x1", "x3", "z1"}
+    assert combined.is_active("z2", {"y1": 0, "w1": 1})
+    assert not combined.is_active("z2", {"y1": 0, "w1": 0})
+
+
+def test_hss_product_raises_on_overlapping_tags() -> None:
+    space = _make_worked_example_hss()
+    with pytest.raises(ValueError, match="overlapping tags"):
+        space.product(space)
+
+
 # ===== additional validation =====
 
 
@@ -783,6 +870,8 @@ def test_hss_repr_includes_hierarchy_and_indicator_tags() -> None:
     assert "hierarchy" in text
     assert "indicator_tags" in text
     assert "y1" in text
+    assert "constraints" in text
+    assert "ctol" in text
 
 
 # ===== gpflow kernel integration =====
@@ -817,3 +906,525 @@ def test_hss_hierarchy_is_directly_consumable_by_arc_hierarchical() -> None:
     )
     cov = kernel.K(x).numpy()
     assert cov[0, 1] < cov[0, 0]
+
+
+# ===== global constraints (standard SearchSpace contract) =====
+
+
+def _make_constrained_hss(constraints, ctol: float = 1e-7) -> HierarchicalSearchSpace:
+    subspaces = _worked_example_subspaces()
+    return HierarchicalSearchSpace(
+        subspaces,
+        _worked_example_hierarchy(subspaces),
+        indicator_tags=["y1"],
+        constraints=constraints,
+        ctol=ctol,
+    )
+
+
+def test_hss_has_no_constraints_by_default() -> None:
+    space = _make_worked_example_hss()
+    assert space.has_constraints is False
+    assert list(space.constraints) == []
+    # With no constraints every point is feasible, and residuals are unavailable.
+    pts = tf.constant([[0.5, 1.0, 2.0, 0.0, 0.0]], dtype=tf.float64)
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [True])
+    with pytest.raises(NotImplementedError):
+        space.constraints_residuals(pts)
+
+
+def test_hss_global_linear_constraint_residuals_and_feasibility() -> None:
+    # 0.3 <= x1 <= 0.8, where x1 is flat-vector column 0.
+    A = tf.constant([[1.0, 0.0, 0.0, 0.0, 0.0]], dtype=tf.float64)
+    space = _make_constrained_hss([LinearConstraint(A=A, lb=[0.3], ub=[0.8])])
+    assert space.has_constraints is True
+    pts = tf.constant(
+        [
+            [0.5, 1.0, 2.0, 0.0, 0.0],  # x1 = 0.5 -> feasible
+            [0.1, 0.0, 2.0, 0.0, 0.0],  # x1 = 0.1 < 0.3 -> infeasible
+            [0.9, 1.0, 2.0, 0.0, 0.0],  # x1 = 0.9 > 0.8 -> infeasible
+        ],
+        dtype=tf.float64,
+    )
+    residuals = space.constraints_residuals(pts).numpy()
+    # residual = [x1 - lb, ub - x1]
+    npt.assert_allclose(residuals, [[0.2, 0.3], [-0.2, 0.7], [0.6, -0.1]])
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [True, False, False])
+
+
+def test_hss_global_nonlinear_constraint_feasibility() -> None:
+    # 0 <= x1**2 <= 0.5.
+    space = _make_constrained_hss(
+        [
+            NonlinearConstraint(
+                lambda x: tf.reduce_sum(x[..., :1] ** 2, axis=-1, keepdims=True),
+                lb=0.0,
+                ub=0.5,
+            )
+        ]
+    )
+    pts = tf.constant(
+        [
+            [0.5, 1.0, 2.0, 0.0, 0.0],  # 0.25 in [0, 0.5] -> feasible
+            [0.9, 0.0, 2.0, 0.0, 0.0],  # 0.81 > 0.5 -> infeasible
+        ],
+        dtype=tf.float64,
+    )
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [True, False])
+
+
+def test_hss_product_combines_global_linear_constraints() -> None:
+    # self (dim 5, cols [x1,y1,x2,x4,x3]) constrains 0.3 <= x1 <= 0.8 (col 0).
+    self_space = _make_constrained_hss(
+        [LinearConstraint(A=tf.constant([[1.0, 0.0, 0.0, 0.0, 0.0]], dtype=tf.float64), lb=[0.3], ub=[0.8])]
+    )
+    # other (dim 3, cols [z1,w1,z2]) constrains 0.0 <= z1 <= 0.5 (its col 0 -> combined col 5).
+    other = _make_second_hss(
+        constraints=[LinearConstraint(A=tf.constant([[1.0, 0.0, 0.0]], dtype=tf.float64), lb=[0.0], ub=[0.5])]
+    )
+    combined = self_space.product(other)
+    assert int(combined.dimension) == 8
+    assert len(combined.constraints) == 2
+
+    # combined columns: [x1, y1, x2, x4, x3, z1, w1, z2]
+    pts = tf.constant(
+        [
+            [0.5, 1.0, 2.0, 0.0, 0.0, 0.3, 1.0, 1.0],  # x1 & z1 ok -> feasible
+            [0.1, 1.0, 2.0, 0.0, 0.0, 0.3, 1.0, 1.0],  # x1 = 0.1 < 0.3 -> infeasible
+            [0.5, 1.0, 2.0, 0.0, 0.0, 0.7, 1.0, 1.0],  # z1 = 0.7 > 0.5 -> infeasible
+        ],
+        dtype=tf.float64,
+    )
+    assert combined.constraints_residuals(pts).shape == (3, 4)  # 2 linear constraints x [lo, hi]
+    npt.assert_array_equal(combined.is_feasible(pts).numpy(), [True, False, False])
+
+
+def test_hss_product_embeds_nonlinear_constraint_on_correct_block() -> None:
+    # other constrains z1**2 <= 0.25 on its own column 0 (-> combined column 5).
+    other = _make_second_hss(
+        constraints=[
+            NonlinearConstraint(
+                lambda x: tf.reduce_sum(x[..., :1] ** 2, axis=-1, keepdims=True), lb=0.0, ub=0.25
+            )
+        ]
+    )
+    combined = _make_worked_example_hss().product(other)
+    base = tf.constant([[0.5, 1.0, 2.0, 0.0, 0.0, 0.3, 1.0, 1.0]], dtype=tf.float64)  # z1=0.3
+    bad_z1 = tf.constant([[0.5, 1.0, 2.0, 0.0, 0.0, 0.9, 1.0, 1.0]], dtype=tf.float64)  # z1=0.9
+    moved_x1 = tf.constant([[0.9, 1.0, 4.0, 1.0, 0.5, 0.3, 0.0, 1.5]], dtype=tf.float64)  # z1 unchanged
+
+    npt.assert_array_equal(combined.is_feasible(base).numpy(), [True])  # 0.09 in [0, 0.25]
+    npt.assert_array_equal(combined.is_feasible(bad_z1).numpy(), [False])  # 0.81 > 0.25
+    # The embedded constraint reads only the z1 block: changing x-columns leaves the residual fixed.
+    npt.assert_allclose(
+        combined.constraints_residuals(base).numpy(), combined.constraints_residuals(moved_x1).numpy()
+    )
+
+
+def test_hss_product_uses_min_ctol() -> None:
+    # The combined space takes the tighter (minimum) tolerance, regardless of operand order.
+    constrained = _make_constrained_hss(
+        [LinearConstraint(A=tf.constant([[1.0, 0.0, 0.0, 0.0, 0.0]], dtype=tf.float64), lb=[0.3], ub=[0.8])],
+        ctol=1e-3,
+    )
+    other = _make_second_hss()  # default ctol 1e-7 (tighter)
+    assert constrained.product(other).ctol == 1e-7
+    assert other.product(constrained).ctol == 1e-7
+
+
+# ===== conditional (disjunctive) constraints =====
+
+
+def _hss_with_conditional(cc: ConditionalConstraint) -> HierarchicalSearchSpace:
+    subspaces = _worked_example_subspaces()
+    return HierarchicalSearchSpace(
+        subspaces,
+        _worked_example_hierarchy(subspaces),
+        indicator_tags=["y1"],
+        conditional_constraints=[cc],
+    )
+
+
+def _x3_in_unit_when_y1_zero() -> ConditionalConstraint:
+    # -0.5 <= x3 <= 1.0, enforced only when y1 == 0.
+    return ConditionalConstraint(
+        constraint=LinearConstraint(A=tf.constant([[1.0]], dtype=tf.float64), lb=[-0.5], ub=[1.0]),
+        indicator_conditions={"y1": 0},
+        active_subspace_tags=["x3"],
+    )
+
+
+def test_conditional_constraint_active_returns_real_residual() -> None:
+    space = _hss_with_conditional(_x3_in_unit_when_y1_zero())
+    # y1 = 0 (active), x3 = 0.0 -> residual = [x3 - (-0.5), 1.0 - x3] = [0.5, 1.0]
+    pts = tf.constant([[0.5, 0.0, 2.0, 0.0, 0.0]], dtype=tf.float64)
+    npt.assert_allclose(space.constraints_residuals(pts).numpy(), [[0.5, 1.0]])
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [True])
+
+
+def test_conditional_constraint_inactive_returns_big_m() -> None:
+    space = _hss_with_conditional(_x3_in_unit_when_y1_zero())
+    # y1 = 1 (inactive): x3 = -0.8 would violate, but the constraint does not apply.
+    pts = tf.constant([[0.5, 1.0, 2.0, 0.0, -0.8]], dtype=tf.float64)
+    residuals = space.constraints_residuals(pts).numpy()
+    npt.assert_array_equal(residuals, [[INACTIVE_CONSTRAINT_RESIDUAL] * 2])
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [True])
+
+
+def test_conditional_constraint_mixed_batch_feasibility() -> None:
+    space = _hss_with_conditional(_x3_in_unit_when_y1_zero())
+    pts = tf.constant(
+        [
+            [0.5, 0.0, 2.0, 0.0, 0.0],   # y1=0 active, x3=0.0 -> feasible
+            [0.5, 0.0, 2.0, 0.0, -0.8],  # y1=0 active, x3=-0.8 -> infeasible
+            [0.5, 1.0, 2.0, 0.0, -0.8],  # y1=1 inactive -> feasible (big-M)
+        ],
+        dtype=tf.float64,
+    )
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [True, False, True])
+
+
+def test_conditional_constraint_categorical_indicator_matches_only_target() -> None:
+    subspaces = {
+        "x1": Box([0.0], [1.0]),
+        "y1": CategoricalSearchSpace(3),  # column 1
+        "x2": Box([-1.0], [1.0]),  # column 2
+    }
+    hierarchy = [
+        hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces, indicator_tags=["y1"]),
+        hierarchy_node_from_tags(
+            "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 2},
+            subspaces=subspaces, indicator_tags=["y1"],
+        ),
+    ]
+    cc = ConditionalConstraint(
+        constraint=LinearConstraint(A=tf.constant([[1.0]], dtype=tf.float64), lb=[0.0], ub=[1.0]),
+        indicator_conditions={"y1": 2},
+        active_subspace_tags=["x2"],
+    )
+    space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"], conditional_constraints=[cc])
+    pts = tf.constant(
+        [
+            [0.5, 2.0, -0.8],  # y1=2 active, x2=-0.8 < 0 -> infeasible
+            [0.5, 1.0, -0.8],  # y1=1 inactive -> feasible
+        ],
+        dtype=tf.float64,
+    )
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [False, True])
+
+
+def test_conditional_constraint_nonlinear_inner() -> None:
+    cc = ConditionalConstraint(
+        constraint=NonlinearConstraint(
+            lambda x: tf.reduce_sum(x ** 2, axis=-1, keepdims=True), lb=0.0, ub=0.25
+        ),
+        indicator_conditions={"y1": 0},
+        active_subspace_tags=["x3"],
+    )
+    space = _hss_with_conditional(cc)
+    pts = tf.constant(
+        [
+            [0.5, 0.0, 2.0, 0.0, 0.3],  # y1=0 active, 0.09 in [0,0.25] -> feasible
+            [0.5, 0.0, 2.0, 0.0, 0.9],  # y1=0 active, 0.81 > 0.25 -> infeasible
+        ],
+        dtype=tf.float64,
+    )
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [True, False])
+
+
+def test_hss_raises_if_conditional_constraint_unknown_indicator() -> None:
+    cc = ConditionalConstraint(
+        constraint=LinearConstraint(A=tf.constant([[1.0]], dtype=tf.float64), lb=[0.0], ub=[1.0]),
+        indicator_conditions={"nope": 0},
+        active_subspace_tags=["x3"],
+    )
+    with pytest.raises(ValueError, match="not a declared indicator"):
+        _hss_with_conditional(cc)
+
+
+def test_hss_raises_if_conditional_constraint_value_out_of_permitted_set() -> None:
+    cc = ConditionalConstraint(
+        constraint=LinearConstraint(A=tf.constant([[1.0]], dtype=tf.float64), lb=[0.0], ub=[1.0]),
+        indicator_conditions={"y1": 5},  # Boolean indicator only permits {0, 1}
+        active_subspace_tags=["x3"],
+    )
+    with pytest.raises(ValueError, match="permitted set"):
+        _hss_with_conditional(cc)
+
+
+def test_hss_raises_if_conditional_constraint_unknown_active_subspace_tag() -> None:
+    cc = ConditionalConstraint(
+        constraint=LinearConstraint(A=tf.constant([[1.0]], dtype=tf.float64), lb=[0.0], ub=[1.0]),
+        indicator_conditions={"y1": 0},
+        active_subspace_tags=["does_not_exist"],
+    )
+    with pytest.raises(ValueError, match="not a key of"):
+        _hss_with_conditional(cc)
+
+
+def test_hss_raises_if_conditional_constraint_active_subspace_tag_is_indicator() -> None:
+    cc = ConditionalConstraint(
+        constraint=LinearConstraint(A=tf.constant([[1.0]], dtype=tf.float64), lb=[0.0], ub=[1.0]),
+        indicator_conditions={"y1": 0},
+        active_subspace_tags=["y1"],  # an indicator
+    )
+    with pytest.raises(ValueError, match="is an indicator"):
+        _hss_with_conditional(cc)
+
+
+def test_hss_product_propagates_conditional_constraints() -> None:
+    space = _hss_with_conditional(_x3_in_unit_when_y1_zero())
+    combined = space.product(_make_second_hss())
+    assert len(combined.conditional_constraints) == 1
+    assert combined.has_constraints is True
+    # The conditional still evaluates on the combined 8-D layout (tag references survive product):
+    # combined columns are [x1=0, y1=1, x2=2, x4=3, x3=4, z1=5, w1=6, z2=7].
+    active_pt = tf.constant([[0.5, 0.0, 2.0, 0.0, 0.0, 0.5, 0.0, 0.5]], dtype=tf.float64)
+    npt.assert_allclose(combined.constraints_residuals(active_pt).numpy(), [[0.5, 1.0]])
+    npt.assert_array_equal(combined.is_feasible(active_pt).numpy(), [True])
+    inactive_pt = tf.constant([[0.5, 1.0, 2.0, 0.0, -0.8, 0.5, 0.0, 0.5]], dtype=tf.float64)
+    npt.assert_array_equal(
+        combined.constraints_residuals(inactive_pt).numpy(), [[INACTIVE_CONSTRAINT_RESIDUAL] * 2]
+    )
+
+
+def test_conditional_constraint_residuals_are_differentiable() -> None:
+    # The big-M reformulation exists so gradient-based polish can flow through the residual; verify
+    # constraints_residuals is differentiable w.r.t. x on the active branch (d/dx3 of [x3+0.5,
+    # 1.0-x3] is [+1, -1]).
+    space = _hss_with_conditional(_x3_in_unit_when_y1_zero())
+    x = tf.Variable([[0.5, 0.0, 2.0, 0.0, 0.0]], dtype=tf.float64)  # y1 = 0 -> active
+    with tf.GradientTape() as tape:
+        residuals = space.constraints_residuals(x)  # shape [1, 2]
+    jac = tape.jacobian(residuals, x)
+    assert jac is not None
+    npt.assert_allclose(jac.numpy()[0, :, 0, 4], [1.0, -1.0])
+    # Inactive branch: finite big-M residual and a defined (zero) gradient, no NaN/None.
+    x_inactive = tf.Variable([[0.5, 1.0, 2.0, 0.0, 0.0]], dtype=tf.float64)  # y1 = 1 -> inactive
+    with tf.GradientTape() as tape:
+        residuals = space.constraints_residuals(x_inactive)
+    jac_inactive = tape.jacobian(residuals, x_inactive)
+    assert jac_inactive is not None
+    npt.assert_array_equal(jac_inactive.numpy()[0, :, 0, 4], [0.0, 0.0])
+
+
+def _two_indicator_subspaces() -> dict[str, SearchSpace]:
+    # Columns: [x1=0, y1=1, y2=2, x2=3]; y1, y2 Boolean indicators.
+    return {
+        "x1": Box([0.0], [1.0]),
+        "y1": BooleanSearchSpace(),
+        "y2": BooleanSearchSpace(),
+        "x2": Box([-1.0], [1.0]),
+    }
+
+
+def _two_indicator_hierarchy(subspaces: dict[str, SearchSpace]) -> list[HierarchyNode]:
+    # x2 is active (and both y1, y2 are thereby gated) only when y1 == 0 AND y2 == 1.
+    return [
+        hierarchy_node_from_tags(
+            "shared", subspace_tags=["x1"], subspaces=subspaces, indicator_tags=["y1", "y2"]
+        ),
+        hierarchy_node_from_tags(
+            "branch",
+            subspace_tags=["x2"],
+            activity_condition_tags={"y1": 0, "y2": 1},
+            subspaces=subspaces,
+            indicator_tags=["y1", "y2"],
+        ),
+    ]
+
+
+def test_hss_is_active_multi_indicator_node() -> None:
+    # A node gated on two indicators is active only when BOTH conditions hold (logical AND).
+    subspaces = _two_indicator_subspaces()
+    space = HierarchicalSearchSpace(
+        subspaces, _two_indicator_hierarchy(subspaces), indicator_tags=["y1", "y2"]
+    )
+    assert space.is_active("x2", {"y1": 0, "y2": 1})
+    assert not space.is_active("x2", {"y1": 0, "y2": 0})
+    assert not space.is_active("x2", {"y1": 1, "y2": 1})
+    assert set(space.active_subspace_tags({"y1": 0, "y2": 1})) == {"x1", "x2"}
+    assert set(space.active_subspace_tags({"y1": 0, "y2": 0})) == {"x1"}
+
+
+def test_conditional_constraint_multiple_indicator_conditions() -> None:
+    # A conditional constraint gated on two indicators is active only when BOTH hold.
+    subspaces = _two_indicator_subspaces()
+    cc = ConditionalConstraint(
+        constraint=LinearConstraint(A=tf.constant([[1.0]], dtype=tf.float64), lb=[0.0], ub=[1.0]),
+        indicator_conditions={"y1": 0, "y2": 1},
+        active_subspace_tags=["x2"],
+    )
+    space = HierarchicalSearchSpace(
+        subspaces,
+        _two_indicator_hierarchy(subspaces),
+        indicator_tags=["y1", "y2"],
+        conditional_constraints=[cc],
+    )
+    # columns: [x1=0, y1=1, y2=2, x2=3]; x2 < 0 violates 0 <= x2 <= 1 only when active.
+    pts = tf.constant(
+        [
+            [0.5, 0.0, 1.0, -0.8],  # y1=0, y2=1 active, x2=-0.8 -> infeasible
+            [0.5, 0.0, 0.0, -0.8],  # y2 != 1 -> inactive -> feasible
+            [0.5, 1.0, 1.0, -0.8],  # y1 != 0 -> inactive -> feasible
+        ],
+        dtype=tf.float64,
+    )
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [False, True, True])
+
+
+# ===== logical propositions =====
+
+
+def _implies_proposition() -> LogicalProposition:
+    # "y2 = 1 implies y1 = 1", i.e. feasible unless (y2 == 1 and y1 == 0).
+    return LogicalProposition(
+        fun=lambda ind: tf.logical_or(
+            tf.not_equal(ind["y2"][..., 0], 1.0), tf.equal(ind["y1"][..., 0], 1.0)
+        ),
+        name="y2_implies_y1",
+    )
+
+
+def _two_indicator_hss(**kwargs) -> HierarchicalSearchSpace:
+    # Columns: x1(0), y1(1), y2(2), x2(3).
+    subspaces = {
+        "x1": Box([0.0], [1.0]),
+        "y1": BooleanSearchSpace(),
+        "y2": BooleanSearchSpace(),
+        "x2": Box([0.0], [1.0]),
+    }
+    hierarchy = [
+        hierarchy_node_from_tags(
+            "shared", subspace_tags=["x1"], subspaces=subspaces, indicator_tags=["y1", "y2"]
+        ),
+        hierarchy_node_from_tags(
+            "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1, "y2": 1},
+            subspaces=subspaces, indicator_tags=["y1", "y2"],
+        ),
+    ]
+    return HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1", "y2"], **kwargs)
+
+
+def test_logical_proposition_filters_violating_points() -> None:
+    space = _two_indicator_hss(logical_propositions=[_implies_proposition()])
+    pts = tf.constant(
+        [
+            [0.5, 1.0, 1.0, 0.5],  # y2=1, y1=1 -> ok
+            [0.5, 0.0, 1.0, 0.5],  # y2=1, y1=0 -> violates implication
+            [0.5, 0.0, 0.0, 0.5],  # y2=0 -> ok
+        ],
+        dtype=tf.float64,
+    )
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [True, False, True])
+
+
+def test_logical_proposition_only_has_constraints_but_no_residuals() -> None:
+    space = _two_indicator_hss(logical_propositions=[_implies_proposition()])
+    assert space.has_constraints is True
+    # No gradient-compatible constraints -> residuals are unavailable.
+    pts = tf.constant([[0.5, 1.0, 1.0, 0.5]], dtype=tf.float64)
+    with pytest.raises(NotImplementedError):
+        space.constraints_residuals(pts)
+
+
+def test_constraints_residuals_excludes_logical_propositions() -> None:
+    # A global constraint plus a logical proposition: residuals reflect only the global one.
+    A = tf.constant([[1.0, 0.0, 0.0, 0.0]], dtype=tf.float64)
+    space = _two_indicator_hss(
+        constraints=[LinearConstraint(A=A, lb=[0.3], ub=[0.8])],
+        logical_propositions=[_implies_proposition()],
+    )
+    pts = tf.constant([[0.5, 0.0, 1.0, 0.5]], dtype=tf.float64)  # global ok, proposition violated
+    # residual columns come only from the global constraint (shape [N, 2]).
+    assert space.constraints_residuals(pts).shape == (1, 2)
+    # is_feasible still folds the proposition in and rejects the point.
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [False])
+
+
+def test_is_feasible_conjunction_across_all_sources() -> None:
+    A = tf.constant([[1.0, 0.0, 0.0, 0.0]], dtype=tf.float64)
+    space = _two_indicator_hss(
+        constraints=[LinearConstraint(A=A, lb=[0.3], ub=[0.8])],
+        conditional_constraints=[
+            ConditionalConstraint(
+                constraint=LinearConstraint(
+                    A=tf.constant([[1.0]], dtype=tf.float64), lb=[0.0], ub=[0.6]
+                ),
+                indicator_conditions={"y1": 1, "y2": 1},
+                active_subspace_tags=["x2"],
+            )
+        ],
+        logical_propositions=[_implies_proposition()],
+    )
+    pts = tf.constant(
+        [
+            [0.5, 1.0, 1.0, 0.5],  # global ok, conditional active & ok, proposition ok -> True
+            [0.1, 1.0, 1.0, 0.5],  # global x1=0.1<0.3 -> False
+            [0.5, 1.0, 1.0, 0.9],  # conditional active, x2=0.9>0.6 -> False
+            [0.5, 0.0, 1.0, 0.5],  # proposition violated (y2=1,y1=0) -> False
+        ],
+        dtype=tf.float64,
+    )
+    npt.assert_array_equal(space.is_feasible(pts).numpy(), [True, False, False, False])
+
+
+def test_hss_product_propagates_logical_propositions() -> None:
+    space = _two_indicator_hss(logical_propositions=[_implies_proposition()])
+    other = _make_second_hss()  # disjoint tags z1/w1/z2
+    combined = space.product(other)
+    assert len(combined.logical_propositions) == 1
+    assert combined.has_constraints is True
+
+
+def test_hss_enumerate_tasks_feasible_only_filters_propositions() -> None:
+    # "y2 = 1 implies y1 = 1" makes {"y1": 0, "y2": 1} infeasible.
+    space = _two_indicator_hss(logical_propositions=[_implies_proposition()])
+    assert len(space.enumerate_tasks()) == 4  # default: full product, propositions ignored
+    feasible = space.enumerate_tasks(feasible_only=True)
+    assert {"y1": 0, "y2": 1} not in feasible
+    assert len(feasible) == 3
+    assert all(not (t["y2"] == 1 and t["y1"] == 0) for t in feasible)
+
+
+def test_hss_product_combines_all_constraint_sources() -> None:
+    # self (cols [x1, y1, y2, x2]) carries a global, a conditional, and a logical constraint.
+    self_space = _two_indicator_hss(
+        constraints=[
+            LinearConstraint(A=tf.constant([[1.0, 0.0, 0.0, 0.0]], dtype=tf.float64), lb=[0.0], ub=[0.8])
+        ],
+        conditional_constraints=[
+            ConditionalConstraint(
+                constraint=LinearConstraint(
+                    A=tf.constant([[1.0]], dtype=tf.float64), lb=[0.0], ub=[0.6]
+                ),
+                indicator_conditions={"y1": 1, "y2": 1},
+                active_subspace_tags=["x2"],
+            )
+        ],
+        logical_propositions=[_implies_proposition()],
+    )
+    # other (cols [z1, w1, z2]) carries a global constraint (z1 -> combined col 4).
+    other = _make_second_hss(
+        constraints=[
+            LinearConstraint(A=tf.constant([[1.0, 0.0, 0.0]], dtype=tf.float64), lb=[0.0], ub=[0.5])
+        ]
+    )
+    combined = self_space.product(other)
+
+    # combined columns: [x1, y1, y2, x2, z1, w1, z2]
+    assert int(combined.dimension) == 7
+    assert len(combined.constraints) == 2  # self x1 + other z1, embedded into the wide vector
+    assert len(combined.conditional_constraints) == 1
+    assert len(combined.logical_propositions) == 1
+
+    pts = tf.constant(
+        [
+            [0.5, 1.0, 1.0, 0.5, 0.3, 1.0, 1.0],  # every source satisfied -> feasible
+            [0.5, 0.0, 1.0, 0.5, 0.3, 1.0, 1.0],  # logical violated (y2=1, y1=0) -> infeasible
+            [0.5, 1.0, 1.0, 0.5, 0.7, 1.0, 1.0],  # other global z1=0.7 > 0.5 -> infeasible
+            [0.5, 1.0, 1.0, 0.9, 0.3, 1.0, 1.0],  # conditional active, x2=0.9 > 0.6 -> infeasible
+        ],
+        dtype=tf.float64,
+    )
+    npt.assert_array_equal(combined.is_feasible(pts).numpy(), [True, False, False, False])

--- a/tests/unit/test_hierarchical_search_space.py
+++ b/tests/unit/test_hierarchical_search_space.py
@@ -349,6 +349,111 @@ def test_hss_get_subspace_component() -> None:
     npt.assert_array_almost_equal(space.get_subspace_component("x3", point), [[-0.5]])
 
 
+# ===== Hierarchy queries =====
+
+
+def test_hss_active_subspace_tags_y1_true() -> None:
+    space = _make_worked_example_hss()
+    active = space.active_subspace_tags({"y1": 1})
+    assert set(active) == {"x1", "x2", "x4"}
+
+
+def test_hss_active_subspace_tags_y1_false() -> None:
+    space = _make_worked_example_hss()
+    active = space.active_subspace_tags({"y1": 0})
+    assert set(active) == {"x1", "x3"}
+
+
+def test_hss_active_subspace_tags_with_bool_input() -> None:
+    """Boolean indicator values are accepted and compared as 1/0, since ``bool`` is a
+    subtype of ``int`` in Python (``True == 1``, ``False == 0``)."""
+    space = _make_worked_example_hss()
+    assert set(space.active_subspace_tags({"y1": True})) == {"x1", "x2", "x4"}
+    assert set(space.active_subspace_tags({"y1": False})) == {"x1", "x3"}
+
+
+def test_hss_enumerate_tasks_boolean() -> None:
+    space = _make_worked_example_hss()
+    tasks = space.enumerate_tasks()
+    assert len(tasks) == 2
+    assert {"y1": 0} in tasks
+    assert {"y1": 1} in tasks
+
+
+def test_hss_enumerate_tasks_no_indicators() -> None:
+    # A space with no indicators has a single (empty) task.
+    subspaces = {"x1": Box([0.0], [1.0])}
+    hierarchy = [hierarchy_node_from_tags("only", subspace_tags=["x1"], subspaces=subspaces)]
+    space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=[])
+    assert space.enumerate_tasks() == [{}]
+
+
+def test_hss_enumerate_tasks_two_indicators() -> None:
+    subspaces = {
+        "x1": Box([0.0], [1.0]),
+        "y1": BooleanSearchSpace(),
+        "y2": BooleanSearchSpace(),
+        "x2": Box([0.0], [1.0]),
+        "x3": Box([0.0], [1.0]),
+    }
+    hierarchy = [
+        hierarchy_node_from_tags(
+            "shared",
+            subspace_tags=["x1"],
+            subspaces=subspaces,
+            indicator_tags=["y1", "y2"],
+        ),
+        hierarchy_node_from_tags(
+            "a",
+            subspace_tags=["x2"],
+            activity_condition_tags={"y1": 1},
+            subspaces=subspaces,
+            indicator_tags=["y1", "y2"],
+        ),
+        hierarchy_node_from_tags(
+            "b",
+            subspace_tags=["x3"],
+            activity_condition_tags={"y2": 1},
+            subspaces=subspaces,
+            indicator_tags=["y1", "y2"],
+        ),
+    ]
+    space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1", "y2"])
+    assert len(space.enumerate_tasks()) == 4
+
+
+def test_hss_is_active() -> None:
+    space = _make_worked_example_hss()
+    assert space.is_active("x1", {"y1": 1})
+    assert space.is_active("x1", {"y1": 0})
+    assert space.is_active("x2", {"y1": 1})
+    assert not space.is_active("x2", {"y1": 0})
+    assert space.is_active("x4", {"y1": 1})
+    assert not space.is_active("x4", {"y1": 0})
+    assert space.is_active("x3", {"y1": 0})
+    assert not space.is_active("x3", {"y1": 1})
+
+
+def test_hss_active_subspace_tags_requires_complete_config() -> None:
+    # A partial config (an indicator omitted) is rejected rather than silently treated as off.
+    space = _make_worked_example_hss()  # one indicator: y1
+    with pytest.raises(ValueError, match="every indicator"):
+        space.active_subspace_tags({})
+    with pytest.raises(ValueError, match="every indicator"):
+        space.is_active("x2", {})
+
+
+def test_hss_node_for_subspace_shared_branch() -> None:
+    space = _make_worked_example_hss()
+    nodes_x1 = space.node_for_subspace("x1")
+    assert [n.name for n in nodes_x1] == ["shared"]
+    nodes_x2 = space.node_for_subspace("x2")
+    assert [n.name for n in nodes_x2] == ["branch_A"]
+    # branch_A also owns x4 — same node should come back.
+    nodes_x4 = space.node_for_subspace("x4")
+    assert [n.name for n in nodes_x4] == ["branch_A"]
+
+
 # ===== Validation =====
 
 
@@ -464,6 +569,53 @@ def test_hss_raises_if_unused_indicator() -> None:
     ]
     with pytest.raises(ValueError, match="unused"):
         HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1", "y2"])
+
+
+# ===== Categorical-indicator variant =====
+
+
+def _make_categorical_hss() -> HierarchicalSearchSpace:
+    subspaces = {
+        "x1": Box([0.0], [1.0]),
+        "y1": CategoricalSearchSpace(3),
+        "x2": Box([0.0], [5.0]),
+        "x3": Box([-1.0], [1.0]),
+    }
+    hierarchy = [
+        hierarchy_node_from_tags(
+            "shared",
+            subspace_tags=["x1"],
+            subspaces=subspaces,
+            indicator_tags=["y1"],
+        ),
+        hierarchy_node_from_tags(
+            "branch_A",
+            subspace_tags=["x2"],
+            activity_condition_tags={"y1": 1},
+            subspaces=subspaces,
+            indicator_tags=["y1"],
+        ),
+        hierarchy_node_from_tags(
+            "branch_B",
+            subspace_tags=["x3"],
+            activity_condition_tags={"y1": 2},
+            subspaces=subspaces,
+            indicator_tags=["y1"],
+        ),
+    ]
+    return HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"])
+
+
+def test_categorical_hss_enumerate_tasks_three_configs() -> None:
+    tasks = _make_categorical_hss().enumerate_tasks()
+    assert tasks == [{"y1": 0}, {"y1": 1}, {"y1": 2}]
+
+
+def test_categorical_hss_active_subspaces() -> None:
+    space = _make_categorical_hss()
+    assert space.active_subspace_tags({"y1": 0}) == ["x1"]
+    assert set(space.active_subspace_tags({"y1": 1})) == {"x1", "x2"}
+    assert set(space.active_subspace_tags({"y1": 2})) == {"x1", "x3"}
 
 
 # ===== additional validation =====

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import operator
 from abc import ABC, abstractmethod
 from collections import Counter
+from dataclasses import dataclass
 from functools import reduce
 from itertools import chain
 from itertools import product as itertools_product
@@ -218,6 +219,50 @@ Constraint = Union[LinearConstraint, NonlinearConstraint]
 """ Type alias for constraints. """
 
 
+def _embed_constraint(
+    constraint: Constraint, offset: int, part_dim: int, combined_dim: int
+) -> Constraint:
+    """Re-express a constraint defined on a ``part_dim``-wide sub-vector so it applies to a wider
+    ``combined_dim``-wide flat vector, with the sub-vector occupying columns
+    ``[offset, offset + part_dim)`` and all other columns ignored.
+
+    Used to carry a search space's (positional) constraints through a Cartesian product, where the
+    space's columns are relocated to a contiguous block of the combined flat vector.
+
+    :param constraint: A :class:`LinearConstraint` or :class:`NonlinearConstraint` over the
+        ``part_dim``-wide sub-vector.
+    :param offset: Index of the sub-vector's first column in the combined vector.
+    :param part_dim: Width of the sub-vector the constraint was defined on.
+    :param combined_dim: Width of the combined vector.
+    :return: An equivalent constraint over the combined vector.
+    :raises NotImplementedError: For an unsupported constraint type.
+    """
+    if isinstance(constraint, LinearConstraint):
+        A = tf.convert_to_tensor(constraint.A)
+        if int(A.shape[-1]) != part_dim:
+            raise ValueError(
+                f"LinearConstraint matrix A has {int(A.shape[-1])} columns but the space it "
+                f"constrains has dimension {part_dim}; global constraints must span the full "
+                f"flat vector."
+            )
+        padded = tf.pad(A, [[0, 0], [offset, combined_dim - offset - part_dim]])
+        return LinearConstraint(padded, constraint.lb, constraint.ub, constraint.keep_feasible)
+    if isinstance(constraint, NonlinearConstraint):
+        orig_fun = constraint._orig_fun
+
+        def shifted_fun(
+            x: TensorType, _fun: Callable = orig_fun, _o: int = offset, _w: int = part_dim
+        ) -> TensorType:
+            return _fun(x[..., _o : _o + _w])
+
+        return NonlinearConstraint(
+            shifted_fun, constraint.lb, constraint.ub, constraint.keep_feasible
+        )
+    raise NotImplementedError(
+        f"Cannot embed constraint of type {type(constraint).__name__} into a wider space."
+    )
+
+
 class SearchSpace(ABC):
     """
     A :class:`SearchSpace` represents the domain over which an objective function is optimized.
@@ -322,7 +367,8 @@ class SearchSpace(ABC):
         """
         :param other: A search space.
         :return: The Cartesian product of this search space with the ``other``.
-            If both spaces are of the same type then this calls the :meth:`product` method.
+            If both spaces are of the same type (and have no constraints)
+            then this calls the :meth:`product` method.
             Otherwise, it generates a :class:`TaggedProductSearchSpace`.
         """
         # If the search space has any constraints, always return a tagged product search space.
@@ -1614,6 +1660,81 @@ def hierarchy_node_from_tags(
     )
 
 
+INACTIVE_CONSTRAINT_RESIDUAL: float = 1e10
+"""Large positive residual returned for an inactive :class:`ConditionalConstraint`, so the
+point is trivially feasible with respect to that constraint. This is the "big-M" sentinel of
+the MI(N)LP reformulation of a generalized disjunctive program: it keeps the residual smooth
+and feasible-with-huge-margin on the inactive branch, so gradient-based polish never has to
+cross the indicator discontinuity."""
+
+
+@dataclass(frozen=True)
+class ConditionalConstraint:
+    r"""A disjunctive constraint :math:`h(x) \leq 0` enforced only when a set of indicator
+    variables take specified values.
+
+    When the ``indicator_conditions`` all hold for a point, the wrapped ``constraint`` is
+    evaluated on the slice of that point identified by ``active_subspace_tags`` (concatenated in
+    the given order). When they do not hold, the residual is set to
+    :data:`INACTIVE_CONSTRAINT_RESIDUAL`, making the point feasible with respect to this
+    constraint. References are by tag, so a conditional constraint survives
+    :meth:`HierarchicalSearchSpace.product` unchanged.
+
+    :param constraint: The underlying :class:`LinearConstraint` / :class:`NonlinearConstraint`,
+        defined on the concatenated ``active_subspace_tags`` slice.
+    :param indicator_conditions: ``{indicator_tag: required_value}`` gating the constraint.
+    :param active_subspace_tags: Non-indicator subspace tags whose columns the constraint reads.
+    """
+
+    constraint: Constraint
+    indicator_conditions: Mapping[str, int]
+    active_subspace_tags: Sequence[str]
+
+    def residual(self, points: TensorType, space: HierarchicalSearchSpace) -> TensorType:
+        """Constraint residuals, big-M where the indicator conditions are not met.
+
+        :param points: Points in the flat-vector representation, shape ``[..., D]``.
+        :param space: The owning :class:`HierarchicalSearchSpace` (provides tag slicing).
+        :return: Residuals with shape ``[..., C]`` matching the wrapped constraint.
+        """
+        active = tf.ones(tf.shape(points)[:-1], dtype=tf.bool)
+        for ind_tag, required in self.indicator_conditions.items():
+            ind_vals = space.get_subspace_component(ind_tag, points)  # [..., 1]
+            target = tf.cast(int(required), ind_vals.dtype)
+            active = active & (tf.abs(ind_vals[..., 0] - target) < 0.5)
+
+        sub_points = tf.concat(
+            [space.get_subspace_component(tag, points) for tag in self.active_subspace_tags],
+            axis=-1,
+        )
+        real_residual = self.constraint.residual(sub_points)  # [..., C]
+        inactive_residual = tf.fill(
+            tf.shape(real_residual),
+            tf.constant(INACTIVE_CONSTRAINT_RESIDUAL, dtype=real_residual.dtype),
+        )
+        mask = tf.broadcast_to(active[..., None], tf.shape(real_residual))
+        return tf.where(mask, real_residual, inactive_residual)
+
+
+@dataclass(frozen=True)
+class LogicalProposition:
+    r"""A feasibility constraint on the indicator variables alone, :math:`\Omega(Y)`.
+
+    ``fun`` receives ``{indicator_tag: values}`` where each value has shape ``[..., 1]`` (values
+    in the indicator's permitted set) and must return a boolean tensor of shape ``[...]``.
+    Logical propositions are checked by :meth:`HierarchicalSearchSpace.is_feasible` but are
+    **not** included in :meth:`HierarchicalSearchSpace.constraints_residuals`, as they have no
+    useful gradient for continuous optimizers. They reference indicators by tag, so they survive
+    :meth:`HierarchicalSearchSpace.product` unchanged.
+
+    :param fun: Maps ``{indicator_tag: [..., 1]}`` to a boolean feasibility tensor ``[...]``.
+    :param name: Optional human-readable label.
+    """
+
+    fun: Callable[[Mapping[str, TensorType]], TensorType]
+    name: str = ""
+
+
 class HierarchicalSearchSpace(CollectionSearchSpace):
     r"""
     A :class:`SearchSpace` that extends :class:`CollectionSearchSpace` with a hierarchy
@@ -1687,6 +1808,10 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         subspaces: Mapping[str, SearchSpace],
         hierarchy: Sequence[HierarchyNode],
         indicator_tags: Optional[Sequence[str]] = None,
+        constraints: Optional[Sequence[Constraint]] = None,
+        conditional_constraints: Sequence[ConditionalConstraint] = (),
+        logical_propositions: Sequence[LogicalProposition] = (),
+        ctol: float | TensorType = 1e-7,
     ) -> None:
         """
         :param subspaces: Tag-keyed mapping of subspaces; iteration order
@@ -1703,12 +1828,31 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
             ``activity_condition`` keys in ``hierarchy`` (in subspace order).
             Pass it explicitly to disambiguate a Boolean intended as a plain
             feature, or to have an ungated indicator flagged as an error.
+        :param constraints: Optional explicit (global) constraints enforced on the
+            full flat-vector representation, following the same ``constraints``
+            contract as :class:`Box`. Consumed by :meth:`constraints_residuals`
+            and :meth:`is_feasible`, so a constrained space plugs into the usual
+            Bayesian optimization machinery unchanged.
+        :param conditional_constraints: Disjunctive constraints, each enforced only
+            when its indicator conditions hold (see :class:`ConditionalConstraint`);
+            inactive rows contribute :data:`INACTIVE_CONSTRAINT_RESIDUAL`.
+        :param logical_propositions: Indicator-only feasibility constraints (see
+            :class:`LogicalProposition`); applied in :meth:`is_feasible` but excluded
+            from :meth:`constraints_residuals` (no continuous gradient).
+        :param ctol: Tolerance used by :meth:`is_feasible` when checking that
+            residuals are non-negative.
         :raises ValueError: If any validation rule is violated.
         """
         subspaces = dict(subspaces)  # decouple from caller, preserve order
         super().__init__(list(subspaces.values()), list(subspaces.keys()))
         self._hierarchy = tuple(hierarchy)
         self._indicator_value_sets: dict[str, tuple[int, ...]] = {}
+        self._constraints: Sequence[Constraint] = [] if constraints is None else list(constraints)
+        self._conditional_constraints: tuple[ConditionalConstraint, ...] = tuple(
+            conditional_constraints
+        )
+        self._logical_propositions: tuple[LogicalProposition, ...] = tuple(logical_propositions)
+        self._ctol = ctol
 
         subspace_sizes = self.subspace_dimension
         self._subspace_sizes_by_tag: dict[str, TensorType] = dict(zip(self._tags, subspace_sizes))
@@ -1886,6 +2030,34 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
                 f"in any HierarchyNode.activity_condition.requirements."
             )
 
+        # Conditional constraints: indicator conditions must reference declared indicators
+        # with permitted values, and active_subspace_tags must be existing non-indicators.
+        indicator_set = set(self._indicator_tags)
+        for i, cc in enumerate(self._conditional_constraints):
+            for ind_tag, required in cc.indicator_conditions.items():
+                if ind_tag not in indicator_set:
+                    raise ValueError(
+                        f"conditional_constraints[{i}] references indicator '{ind_tag}', "
+                        f"which is not a declared indicator tag {sorted(indicator_set)}."
+                    )
+                permitted = self._indicator_value_sets[ind_tag]
+                if int(required) not in permitted:
+                    raise ValueError(
+                        f"conditional_constraints[{i}] requires indicator '{ind_tag}' = "
+                        f"{required!r}, which is not in its permitted set {list(permitted)}."
+                    )
+            for tag in cc.active_subspace_tags:
+                if tag not in all_tags:
+                    raise ValueError(
+                        f"conditional_constraints[{i}] active_subspace_tag '{tag}' is not a "
+                        f"key of `subspaces` {sorted(all_tags)}."
+                    )
+                if tag in indicator_set:
+                    raise ValueError(
+                        f"conditional_constraints[{i}] active_subspace_tag '{tag}' is an "
+                        f"indicator; constraints operate on the non-indicator slice only."
+                    )
+
     @staticmethod
     def _nodes_equal(left: Sequence[HierarchyNode], right: Sequence[HierarchyNode]) -> bool:
         """Compare two hierarchies by value. ``HierarchyNode`` is a frozen dataclass,
@@ -1919,8 +2091,12 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
             return NotImplemented
         if not super().__eq__(other):
             return False
-        return self._indicator_tags == other._indicator_tags and self._nodes_equal(
-            self._hierarchy, other._hierarchy
+        return (
+            self._indicator_tags == other._indicator_tags
+            and self._constraints == other._constraints
+            and self._conditional_constraints == other._conditional_constraints
+            and self._logical_propositions == other._logical_propositions
+            and self._nodes_equal(self._hierarchy, other._hierarchy)
         )
 
     def __repr__(self) -> str:
@@ -1929,17 +2105,10 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
             f"spaces={[self.get_subspace(tag) for tag in self.subspace_tags]}, "
             f"tags={list(self.subspace_tags)}, "
             f"hierarchy={list(self._hierarchy)}, "
-            f"indicator_tags={list(self._indicator_tags)})"
+            f"indicator_tags={list(self._indicator_tags)}, "
+            f"constraints={self._constraints!r}, "
+            f"ctol={self._ctol!r})"
         )
-
-    def product(self, other: HierarchicalSearchSpace) -> HierarchicalSearchSpace:
-        """A same-type Cartesian product is not supported here; :meth:`__mul__` falls back to a
-        :class:`TaggedProductSearchSpace`.
-
-        :param other: Another :class:`HierarchicalSearchSpace`.
-        :raises NotImplementedError: Always.
-        """
-        raise NotImplementedError
 
     @property
     def hierarchy(self) -> tuple[HierarchyNode, ...]:
@@ -1973,6 +2142,78 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         """All subspace tags that are not indicators, in tag order."""
         indicator_set = set(self._indicator_tags)
         return tuple(t for t in self.subspace_tags if t not in indicator_set)
+
+    @property
+    def constraints(self) -> Sequence[Constraint]:
+        """The explicit (global) constraints enforced on the full flat-vector representation."""
+        return self._constraints
+
+    @property
+    def ctol(self) -> float | TensorType:
+        """The tolerance applied when checking the explicit constraints."""
+        return self._ctol
+
+    @property
+    def conditional_constraints(self) -> tuple[ConditionalConstraint, ...]:
+        """The disjunctive constraints gated by indicator conditions."""
+        return self._conditional_constraints
+
+    @property
+    def logical_propositions(self) -> tuple[LogicalProposition, ...]:
+        """The indicator-only feasibility constraints."""
+        return self._logical_propositions
+
+    @property
+    def has_constraints(self) -> bool:
+        """``True`` if any global, conditional, or logical constraints are present."""
+        return bool(
+            self._constraints or self._conditional_constraints or self._logical_propositions
+        )
+
+    def constraints_residuals(self, points: TensorType) -> TensorType:
+        """
+        Return residuals for all global and conditional constraints in this search space.
+        Global constraints are evaluated on the full flat vector; conditional constraints
+        return :data:`INACTIVE_CONSTRAINT_RESIDUAL` on rows where their indicator conditions
+        do not hold. Logical propositions are excluded (no continuous gradient); use
+        :meth:`is_feasible` to account for them.
+
+        :param points: The points to get the residuals for, with shape ``[..., D]``.
+        :return: A tensor of all the residuals with shape ``[..., C]``, where ``C`` is the
+            total number of constraint residual columns.
+        :raise NotImplementedError: If this search space has no global or conditional
+            constraints.
+        """
+        residuals = [constraint.residual(points) for constraint in self._constraints]
+        residuals += [cc.residual(points, self) for cc in self._conditional_constraints]
+        if not residuals:
+            raise NotImplementedError(
+                "No constraints to compute residuals for in this search space."
+            )
+        return tf.concat(residuals, axis=-1)
+
+    def is_feasible(self, points: TensorType) -> TensorType:
+        """
+        Check whether points satisfy all constraints of this search space — global and
+        conditional (via residuals) and logical propositions. Note that membership of the space
+        (the conditional activity structure) is not checked here.
+
+        :param points: The points to check, with shape ``[..., D]``.
+        :return: A boolean tensor of shape ``[...]``, ``True`` where the point is feasible.
+        """
+        if self._constraints or self._conditional_constraints:
+            feasible = tf.math.reduce_all(self.constraints_residuals(points) >= -self._ctol, axis=-1)
+        else:
+            feasible = tf.cast(tf.ones(tf.shape(points)[:-1]), dtype=bool)
+
+        if self._logical_propositions:
+            indicator_values = {
+                tag: self.get_subspace_component(tag, points) for tag in self._indicator_tags
+            }
+            for proposition in self._logical_propositions:
+                feasible = tf.logical_and(feasible, proposition.fun(indicator_values))
+
+        return feasible
 
     @property
     @check_shapes("return: []")
@@ -2064,15 +2305,19 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
                         active.append(stag)
         return active
 
-    def enumerate_tasks(self) -> list[dict[str, int]]:
+    def enumerate_tasks(self, feasible_only: bool = False) -> list[dict[str, int]]:
         """
-        Return every indicator configuration as the Cartesian product of each indicator's
+        Return indicator configurations as the Cartesian product of each indicator's
         permitted value set.
 
         Both Boolean and ``K``-ary categorical indicators contribute the integer values
         ``[0, 1, ..., K-1]`` (with ``K = 2`` for Boolean indicators); the total number of
         configurations equals :math:`\\prod_k |\\mathcal{C}_k|`.
 
+        :param feasible_only: By default the full Cartesian product is returned, ignoring any
+            :class:`LogicalProposition`\\ s. When ``True``, configurations that violate any logical
+            proposition are dropped (global/conditional constraints, which involve the continuous
+            variables, are not considered here).
         :return: A list of ``{indicator_tag: value}`` dictionaries, one per task.
         """
         if not self._indicator_tags:
@@ -2080,10 +2325,22 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         per_indicator_values: list[Sequence[int]] = [
             list(self._indicator_value_sets[t]) for t in self._indicator_tags
         ]
-        return [
+        tasks = [
             dict(zip(self._indicator_tags, combo))
             for combo in itertools_product(*per_indicator_values)
         ]
+        if feasible_only and self._logical_propositions:
+            # Evaluate the propositions on all configs at once, reusing the ``{tag: [N, 1]}`` input
+            # shape that ``is_feasible`` builds from the flat vector.
+            indicator_values = {
+                tag: tf.constant([[task[tag]] for task in tasks], dtype=DEFAULT_DTYPE)
+                for tag in self._indicator_tags
+            }
+            feasible = tf.ones(len(tasks), dtype=bool)
+            for proposition in self._logical_propositions:
+                feasible = tf.logical_and(feasible, proposition.fun(indicator_values))
+            tasks = [task for task, ok in zip(tasks, feasible.numpy()) if ok]
+        return tasks
 
     def is_active(self, tag: str, indicator_config: Mapping[str, int]) -> bool:
         """
@@ -2123,6 +2380,75 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
                 f"`indicator_config` must provide a value for every indicator "
                 f"{list(self._indicator_tags)}; missing: {missing}."
             )
+
+    def product(self, other: HierarchicalSearchSpace) -> HierarchicalSearchSpace:
+        """
+        Return a new :class:`HierarchicalSearchSpace` that is the combination of this space and
+        ``other``. Tags in the two spaces must be disjoint. The hierarchy nodes are
+        concatenated; both the node ``feature_dims`` and the ``activity_condition``
+        requirement columns in ``other`` are shifted by ``self.dimension`` so they index the
+        combined flat-vector layout.
+
+        Conditional constraints reference subspaces and indicators by tag, so they compose
+        across the disjoint-tag product unchanged and are concatenated. Global (positional)
+        constraints are remapped into the combined layout via :func:`_embed_constraint`:
+        ``self``'s constraints keep columns ``[0, D_self)`` and ``other``'s are shifted to
+        ``[D_self, D_self + D_other)``. The combined space takes the tighter (minimum) of the
+        two operands' constraint tolerances.
+
+        :param other: Another :class:`HierarchicalSearchSpace`.
+        :return: The combined hierarchical space.
+        :raises ValueError: If the two spaces share any tags.
+        """
+        overlap = set(self.subspace_tags) & set(other.subspace_tags)
+        if overlap:
+            raise ValueError(f"Cannot combine spaces with overlapping tags: {overlap}")
+        combined_subspaces: dict[str, SearchSpace] = {
+            **{tag: self.get_subspace(tag) for tag in self.subspace_tags},
+            **{tag: other.get_subspace(tag) for tag in other.subspace_tags},
+        }
+        offset = int(self.dimension)
+        combined_dim = int(self.dimension) + int(other.dimension)
+        constraints = [
+            _embed_constraint(c, 0, int(self.dimension), combined_dim) for c in self._constraints
+        ] + [
+            _embed_constraint(c, offset, int(other.dimension), combined_dim)
+            for c in other._constraints
+        ]
+        shifted_other_hierarchy: list[HierarchyNode] = []
+        for node in other.hierarchy:
+            shifted_other_hierarchy.append(
+                HierarchyNode(
+                    name=node.name,
+                    feature_dims=[int(c) + offset for c in node.feature_dims],
+                    feature_bounds=node.feature_bounds,
+                    activity_condition=ActivityCondition(
+                        # requirement keys are global indicator columns; shift them
+                        # into the combined layout by the same offset as feature_dims.
+                        requirements={
+                            k + offset: v
+                            for k, v in node.activity_condition.requirements.items()
+                        }
+                    ),
+                )
+            )
+        hierarchy = list(self.hierarchy) + shifted_other_hierarchy
+        indicator_tags = list(self.indicator_tags) + list(other.indicator_tags)
+        conditional_constraints = list(self._conditional_constraints) + list(
+            other._conditional_constraints
+        )
+        logical_propositions = list(self._logical_propositions) + list(
+            other._logical_propositions
+        )
+        return HierarchicalSearchSpace(
+            combined_subspaces,
+            hierarchy,
+            indicator_tags,
+            constraints=constraints,
+            conditional_constraints=conditional_constraints,
+            logical_propositions=logical_propositions,
+            ctol=min(self.ctol, other.ctol),
+        )
 
     def _node_is_active(self, node: HierarchyNode, indicator_config: Mapping[str, int]) -> bool:
         """Check whether a node's activity_condition.requirements (keyed by indicator global

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from collections import Counter
 from functools import reduce
 from itertools import chain
+from itertools import product as itertools_product
 from typing import (
     Callable,
     Mapping,
@@ -2033,6 +2034,107 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         start = self._subspace_starting_indices[tag]
         end = start + self._subspace_sizes_by_tag[tag]
         return values[..., start:end]
+
+    def _node_subspace_tags(self, node: HierarchyNode) -> list[str]:
+        """Translate a node's ``feature_dims`` to the (unique, ordered) list of
+        non-indicator subspace tags it owns."""
+        seen: list[str] = []
+        for col in node.feature_dims:
+            tag = self._column_to_tag.get(int(col))
+            if tag is not None and tag not in seen:
+                seen.append(tag)
+        return seen
+
+    def active_subspace_tags(self, indicator_config: Mapping[str, int]) -> list[str]:
+        """
+        Return the non-indicator subspace tags that are active for a given indicator
+        configuration.
+
+        :param indicator_config: A mapping ``{indicator_tag: value}`` providing a value for
+            every indicator of this space. Extra keys are ignored.
+        :return: List of active non-indicator subspace tags.
+        :raise ValueError: If ``indicator_config`` omits any indicator.
+        """
+        self._require_complete_config(indicator_config)
+        active: list[str] = []
+        for node in self._hierarchy:
+            if self._node_is_active(node, indicator_config):
+                for stag in self._node_subspace_tags(node):
+                    if stag not in active:
+                        active.append(stag)
+        return active
+
+    def enumerate_tasks(self) -> list[dict[str, int]]:
+        """
+        Return every indicator configuration as the Cartesian product of each indicator's
+        permitted value set.
+
+        Both Boolean and ``K``-ary categorical indicators contribute the integer values
+        ``[0, 1, ..., K-1]`` (with ``K = 2`` for Boolean indicators); the total number of
+        configurations equals :math:`\\prod_k |\\mathcal{C}_k|`.
+
+        :return: A list of ``{indicator_tag: value}`` dictionaries, one per task.
+        """
+        if not self._indicator_tags:
+            return [{}]
+        per_indicator_values: list[Sequence[int]] = [
+            list(self._indicator_value_sets[t]) for t in self._indicator_tags
+        ]
+        return [
+            dict(zip(self._indicator_tags, combo))
+            for combo in itertools_product(*per_indicator_values)
+        ]
+
+    def is_active(self, tag: str, indicator_config: Mapping[str, int]) -> bool:
+        """
+        Check whether a non-indicator subspace is active for a given indicator configuration.
+
+        :param tag: A non-indicator subspace tag.
+        :param indicator_config: A mapping ``{indicator_tag: value}`` providing a value for
+            every indicator of this space. Extra keys are ignored.
+        :return: True if the subspace is active.
+        :raise ValueError: If ``indicator_config`` omits any indicator.
+        """
+        self._require_complete_config(indicator_config)
+        for node in self._hierarchy:
+            if tag in self._node_subspace_tags(node) and self._node_is_active(
+                node, indicator_config
+            ):
+                return True
+        return False
+
+    def node_for_subspace(self, tag: str) -> list[HierarchyNode]:
+        """
+        Return the :class:`HierarchyNode` objects whose ``feature_dims`` include any column
+        belonging to the given subspace tag.
+
+        :param tag: A non-indicator subspace tag.
+        :return: List of nodes containing this tag.
+        """
+        return [node for node in self._hierarchy if tag in self._node_subspace_tags(node)]
+
+    def _require_complete_config(self, indicator_config: Mapping[str, int]) -> None:
+        """Reject a partial configuration: ``indicator_config`` must provide a value for every
+        indicator of this space (extra keys are ignored). Catches forgotten or mistyped
+        indicator keys, which would otherwise be silently treated as unsatisfied."""
+        missing = [tag for tag in self._indicator_tags if tag not in indicator_config]
+        if missing:
+            raise ValueError(
+                f"`indicator_config` must provide a value for every indicator "
+                f"{list(self._indicator_tags)}; missing: {missing}."
+            )
+
+    def _node_is_active(self, node: HierarchyNode, indicator_config: Mapping[str, int]) -> bool:
+        """Check whether a node's activity_condition.requirements (keyed by indicator global
+        column) are all satisfied by ``indicator_config`` (keyed by indicator tag). Uses
+        integer equality so that K-ary categorical indicators are compared exactly rather
+        than via Boolean truthiness. Assumes a complete config (see
+        :meth:`_require_complete_config`, enforced by the public callers)."""
+        for indicator_col, required in node.activity_condition.requirements.items():
+            ind_tag = self._column_to_tag[indicator_col]
+            if int(indicator_config[ind_tag]) != int(required):
+                return False
+        return True
 
 
 class TaggedMultiSearchSpace(CollectionSearchSpace):


### PR DESCRIPTION
Add the hierarchy-query methods to HierarchicalSearchSpace: active_subspace_tags and is_active resolve which subspaces are active for a given indicator configuration, enumerate_tasks expands the indicator combinations into concrete tasks, and node_for_subspace maps a subspace tag back to its HierarchyNode(s). Adds the corresponding activity-query tests and the categorical-indicator variant.

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

...

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes 
<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [X] Any new features are well-documented (in docstrings or notebooks)
