### PR TITLE
feat(space): always infer HierarchicalSearchSpace indicators, drop in…

### DIFF
--- a/docs/notebooks/hierarchical_search_space.pct.py
+++ b/docs/notebooks/hierarchical_search_space.pct.py
@@ -27,14 +27,12 @@
 # - `BooleanSearchSpace`: a one-dimensional discrete space restricted to ``{0, 1}``.
 # - `CategoricalSearchSpace`: a one-dimensional discrete space over ``K`` named or
 #   indexed categories.
-# - `gpflow.kernels.HierarchyNode` (re-exported as `trieste.space.HierarchyNode`): a
-#   GPflow primitive describing one disjunction via `feature_dims` (integer flat-vector
-#   columns), `feature_bounds`, and an `ActivityCondition` whose `requirements` map
-#   indicator local indices to required integer values.
-# - `hierarchy_node_from_tags`: a thin tag-based factory that resolves
-#   `subspace_tags` / `activity_condition_tags` against a `subspaces` mapping and
-#   returns a populated `HierarchyNode`. User-facing examples use this factory rather
-#   than constructing `HierarchyNode` by hand.
+# - `HierarchyNode`: a trieste tag-based primitive describing one disjunction via
+#   `subspace_tags` (the non-indicator subspaces it owns) and `activity_condition_tags`
+#   (`{indicator_tag: required_value}` gating the node). The owning
+#   `HierarchicalSearchSpace` resolves these tags to GPflow's column-based representation
+#   internally (see `space.to_gpflow_hierarchy()`), so subspaces are supplied once, to the
+#   space, rather than to every node.
 # - `HierarchicalSearchSpace`: a `CollectionSearchSpace` that wires the indicators and
 #   nodes together and exposes a tag-based query API for downstream consumers.
 #
@@ -50,7 +48,7 @@ from trieste.space import (
     Box,
     CategoricalSearchSpace,
     HierarchicalSearchSpace,
-    hierarchy_node_from_tags,
+    HierarchyNode,
 )
 
 np.random.seed(1793)
@@ -65,8 +63,8 @@ tf.random.set_seed(1793)
 #
 # We give each subspace a tag in the `subspaces` mapping (iteration order defines
 # the flat-vector layout), then describe the hierarchy as three nodes — one
-# unconditional ("shared") and two gated by `y1`. `hierarchy_node_from_tags`
-# resolves the tag-based inputs to a populated `gpflow.kernels.HierarchyNode`.
+# unconditional ("shared") and two gated by `y1`. The `HierarchicalSearchSpace`
+# resolves the tag-based nodes to GPflow's column-based representation internally.
 
 # %%
 subspaces = {
@@ -76,22 +74,19 @@ subspaces = {
     "x3": Box([-1.0], [1.0]),  # active when y1 = 0
 }
 hierarchy = [
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "shared",
         subspace_tags=["x1"],
-        subspaces=subspaces,
     ),
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "branch_A",
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 1},
-        subspaces=subspaces,
     ),
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "branch_B",
         subspace_tags=["x3"],
         activity_condition_tags={"y1": 0},
-        subspaces=subspaces,
     ),
 ]
 space = HierarchicalSearchSpace(subspaces, hierarchy)
@@ -155,22 +150,19 @@ subspaces_c = {
     "x3": Box([-1.0], [1.0]),  # active when y1 = 2
 }
 hierarchy_c = [
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "shared",
         subspace_tags=["x1"],
-        subspaces=subspaces_c,
     ),
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "branch_A",
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 1},
-        subspaces=subspaces_c,
     ),
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "branch_B",
         subspace_tags=["x3"],
         activity_condition_tags={"y1": 2},
-        subspaces=subspaces_c,
     ),
 ]
 space_c = HierarchicalSearchSpace(
@@ -198,16 +190,14 @@ subspaces_mix = {
     "x2": Box([0.0], [5.0]),
 }
 hierarchy_mix = [
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "shared",
         subspace_tags=["x1"],
-        subspaces=subspaces_mix,
     ),
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "branch",
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 1, "y2": 2},
-        subspaces=subspaces_mix,
     ),
 ]
 space_mix = HierarchicalSearchSpace(
@@ -251,11 +241,10 @@ _expect_value_error(
     lambda: HierarchicalSearchSpace(
         _subspaces_oor,
         [
-            hierarchy_node_from_tags(
+            HierarchyNode(
                 "n",
                 subspace_tags=["x1"],
                 activity_condition_tags={"y1": 5},
-                subspaces=_subspaces_oor,
             )
         ],
     )
@@ -270,11 +259,10 @@ _expect_value_error(
     lambda: HierarchicalSearchSpace(
         _subspaces_2d,
         [
-            hierarchy_node_from_tags(
+            HierarchyNode(
                 "n",
                 subspace_tags=["x1"],
                 activity_condition_tags={"y1": 1},
-                subspaces=_subspaces_2d,
             )
         ],
     )

--- a/docs/notebooks/hierarchical_search_space.pct.py
+++ b/docs/notebooks/hierarchical_search_space.pct.py
@@ -80,24 +80,21 @@ hierarchy = [
         "shared",
         subspace_tags=["x1"],
         subspaces=subspaces,
-        indicator_tags=["y1"],
     ),
     hierarchy_node_from_tags(
         "branch_A",
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 1},
         subspaces=subspaces,
-        indicator_tags=["y1"],
     ),
     hierarchy_node_from_tags(
         "branch_B",
         subspace_tags=["x3"],
         activity_condition_tags={"y1": 0},
         subspaces=subspaces,
-        indicator_tags=["y1"],
     ),
 ]
-space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"])
+space = HierarchicalSearchSpace(subspaces, hierarchy)
 
 print("dimension:", int(space.dimension))
 print("indicator_tags:", space.indicator_tags)
@@ -162,25 +159,22 @@ hierarchy_c = [
         "shared",
         subspace_tags=["x1"],
         subspaces=subspaces_c,
-        indicator_tags=["y1"],
     ),
     hierarchy_node_from_tags(
         "branch_A",
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 1},
         subspaces=subspaces_c,
-        indicator_tags=["y1"],
     ),
     hierarchy_node_from_tags(
         "branch_B",
         subspace_tags=["x3"],
         activity_condition_tags={"y1": 2},
         subspaces=subspaces_c,
-        indicator_tags=["y1"],
     ),
 ]
 space_c = HierarchicalSearchSpace(
-    subspaces_c, hierarchy_c, indicator_tags=["y1"]
+    subspaces_c, hierarchy_c
 )
 
 print("indicator_value_sets:", space_c.indicator_value_sets)
@@ -208,18 +202,16 @@ hierarchy_mix = [
         "shared",
         subspace_tags=["x1"],
         subspaces=subspaces_mix,
-        indicator_tags=["y1", "y2"],
     ),
     hierarchy_node_from_tags(
         "branch",
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 1, "y2": 2},
         subspaces=subspaces_mix,
-        indicator_tags=["y1", "y2"],
     ),
 ]
 space_mix = HierarchicalSearchSpace(
-    subspaces_mix, hierarchy_mix, indicator_tags=["y1", "y2"]
+    subspaces_mix, hierarchy_mix
 )
 tasks = space_mix.enumerate_tasks()
 print(f"number of tasks: {len(tasks)}")
@@ -264,10 +256,8 @@ _expect_value_error(
                 subspace_tags=["x1"],
                 activity_condition_tags={"y1": 5},
                 subspaces=_subspaces_oor,
-                indicator_tags=["y1"],
             )
         ],
-        indicator_tags=["y1"],
     )
 )
 
@@ -285,9 +275,7 @@ _expect_value_error(
                 subspace_tags=["x1"],
                 activity_condition_tags={"y1": 1},
                 subspaces=_subspaces_2d,
-                indicator_tags=["y1"],
             )
         ],
-        indicator_tags=["y1"],
     )
 )

--- a/docs/notebooks/hierarchical_search_space_constraints.pct.py
+++ b/docs/notebooks/hierarchical_search_space_constraints.pct.py
@@ -54,7 +54,7 @@ from trieste.space import (
     HierarchicalSearchSpace,
     LinearConstraint,
     LogicalProposition,
-    hierarchy_node_from_tags,
+    HierarchyNode,
 )
 
 np.random.seed(1793)
@@ -78,14 +78,12 @@ subspaces = {
     "x3": Box([-1.0], [1.0]),
 }
 hierarchy = [
-    hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces),
-    hierarchy_node_from_tags(
+    HierarchyNode("shared", subspace_tags=["x1"]),
+    HierarchyNode(
         "branch_A", subspace_tags=["x2"], activity_condition_tags={"y1": 1},
-        subspaces=subspaces,
     ),
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "branch_B", subspace_tags=["x3"], activity_condition_tags={"y1": 0},
-        subspaces=subspaces,
     ),
 ]
 
@@ -151,10 +149,9 @@ subspaces_2 = {
     "x2": Box([0.0], [1.0]),
 }
 hierarchy_2 = [
-    hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces_2),
-    hierarchy_node_from_tags(
+    HierarchyNode("shared", subspace_tags=["x1"]),
+    HierarchyNode(
         "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1, "y2": 1},
-        subspaces=subspaces_2,
     ),
 ]
 space_2 = HierarchicalSearchSpace(
@@ -234,7 +231,7 @@ initial_data = observer(tf.convert_to_tensor(feasible_sample(15), dtype=tf.float
 
 # Wrap a GPflow ArcHierarchical GPR as a trieste model.
 kernel = gpflow.kernels.Constant() * ArcHierarchical(
-    list(space.hierarchy), active_dims=active_dims
+    space.to_gpflow_hierarchy(), active_dims=active_dims
 )
 gpr = gpflow.models.GPR(
     (initial_data.query_points, initial_data.observations), kernel=kernel, noise_variance=0.01

--- a/docs/notebooks/hierarchical_search_space_constraints.pct.py
+++ b/docs/notebooks/hierarchical_search_space_constraints.pct.py
@@ -78,14 +78,14 @@ subspaces = {
     "x3": Box([-1.0], [1.0]),
 }
 hierarchy = [
-    hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces, indicator_tags=["y1"]),
+    hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces),
     hierarchy_node_from_tags(
         "branch_A", subspace_tags=["x2"], activity_condition_tags={"y1": 1},
-        subspaces=subspaces, indicator_tags=["y1"],
+        subspaces=subspaces,
     ),
     hierarchy_node_from_tags(
         "branch_B", subspace_tags=["x3"], activity_condition_tags={"y1": 0},
-        subspaces=subspaces, indicator_tags=["y1"],
+        subspaces=subspaces,
     ),
 ]
 
@@ -107,7 +107,6 @@ conditional_constraint = ConditionalConstraint(
 space = HierarchicalSearchSpace(
     subspaces,
     hierarchy,
-    indicator_tags=["y1"],
     constraints=[global_constraint],
     conditional_constraints=[conditional_constraint],
 )
@@ -152,16 +151,15 @@ subspaces_2 = {
     "x2": Box([0.0], [1.0]),
 }
 hierarchy_2 = [
-    hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces_2, indicator_tags=["y1", "y2"]),
+    hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces_2),
     hierarchy_node_from_tags(
         "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1, "y2": 1},
-        subspaces=subspaces_2, indicator_tags=["y1", "y2"],
+        subspaces=subspaces_2,
     ),
 ]
 space_2 = HierarchicalSearchSpace(
     subspaces_2,
     hierarchy_2,
-    indicator_tags=["y1", "y2"],
     logical_propositions=[
         LogicalProposition(
             fun=lambda ind: tf.logical_or(

--- a/docs/notebooks/hierarchical_search_space_gpflow_kernel.pct.py
+++ b/docs/notebooks/hierarchical_search_space_gpflow_kernel.pct.py
@@ -43,7 +43,7 @@ from trieste.space import (
     BooleanSearchSpace,
     Box,
     HierarchicalSearchSpace,
-    hierarchy_node_from_tags,
+    HierarchyNode,
 )
 
 np.random.seed(1793)
@@ -84,22 +84,19 @@ subspaces = {
     "x3": Box([-1.0], [1.0]),  # active when y1 = 0
 }
 hierarchy = [
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "shared",
         subspace_tags=["x1"],
-        subspaces=subspaces,
     ),
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "branch_A",
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 1},
-        subspaces=subspaces,
     ),
-    hierarchy_node_from_tags(
+    HierarchyNode(
         "branch_B",
         subspace_tags=["x3"],
         activity_condition_tags={"y1": 0},
-        subspaces=subspaces,
     ),
 ]
 space = HierarchicalSearchSpace(subspaces, hierarchy)
@@ -124,17 +121,18 @@ print("indicator_dims:", space.indicator_dims)
 # `active_dims`, and validates that the feature columns and the inferred
 # indicator columns together tile the sliced vector contiguously.
 #
-# `HierarchicalSearchSpace.hierarchy` exposes exactly these `HierarchyNode`
-# objects: Trieste keys both `feature_dims` and the `requirements` map by global
-# flat-vector column (the same convention the kernel uses), so the nodes can be
-# passed straight to `ArcHierarchical` — no adapter needed. Since every column of
+# `HierarchicalSearchSpace.to_gpflow_hierarchy()` resolves the tag-based nodes to
+# exactly these `gpflow.kernels.HierarchyNode` objects: Trieste keys both
+# `feature_dims` and the `requirements` map by global flat-vector column (the same
+# convention the kernel uses), so the nodes can be passed straight to
+# `ArcHierarchical` — no adapter needed. Since every column of
 # an HSS flat vector is either a feature or an indicator, we slice on **all**
 # columns — `active_dims = range(dimension)` — so the sliced and global
 # coordinate systems coincide.
 
 # %%
 active_dims = list(range(int(space.dimension)))
-for node in space.hierarchy:
+for node in space.to_gpflow_hierarchy():
     print(
         f"{node.name:9s} feature_dims={list(node.feature_dims)} "
         f"requirements={dict(node.activity_condition.requirements)}"
@@ -149,7 +147,7 @@ print("active_dims:", active_dims)
 # constructing one emits a `UserWarning` — that is expected.)
 
 # %%
-arc = ArcHierarchical(list(space.hierarchy), active_dims=active_dims)
+arc = ArcHierarchical(space.to_gpflow_hierarchy(), active_dims=active_dims)
 print(type(arc).__name__, "built over active_dims", active_dims)
 
 # %% [markdown]
@@ -203,7 +201,7 @@ Y_train = objective(X_train) + 0.05 * np.random.randn(40, 1)
 
 # Wrap in a Constant() factor so the GP can learn an overall variance.
 kernel = gpflow.kernels.Constant() * ArcHierarchical(
-    list(space.hierarchy), active_dims=active_dims
+    space.to_gpflow_hierarchy(), active_dims=active_dims
 )
 gpr = gpflow.models.GPR(
     data=(X_train, Y_train), kernel=kernel, noise_variance=0.05
@@ -248,7 +246,7 @@ for x, m, v, t in zip(X_test, mean.numpy().ravel(), var.numpy().ravel(), truth):
 # expects near disjunction boundaries.
 
 # %%
-wedge = WedgeHierarchical(list(space.hierarchy), active_dims=active_dims)
+wedge = WedgeHierarchical(space.to_gpflow_hierarchy(), active_dims=active_dims)
 print("Wedge kernel matrix on demo points:")
 print(wedge.K(X_demo).numpy())
 
@@ -258,8 +256,8 @@ print(wedge.K(X_demo).numpy())
 # A conditional GP over a disjunctive space needs only:
 #
 # * `BooleanSearchSpace`, `Box`, `HierarchicalSearchSpace`,
-#   `hierarchy_node_from_tags` from `trieste.space` to describe the structure;
-# * `list(space.hierarchy)` passed straight to the kernel — Trieste keys the
+#   `HierarchyNode` from `trieste.space` to describe the structure;
+# * `space.to_gpflow_hierarchy()` passed straight to the kernel — Trieste keys the
 #   hierarchy in GPflow's column convention, so no adapter is needed;
 # * `gpflow.kernels.ArcHierarchical` (or `WedgeHierarchical`) for the covariance.
 #

--- a/docs/notebooks/hierarchical_search_space_gpflow_kernel.pct.py
+++ b/docs/notebooks/hierarchical_search_space_gpflow_kernel.pct.py
@@ -88,24 +88,21 @@ hierarchy = [
         "shared",
         subspace_tags=["x1"],
         subspaces=subspaces,
-        indicator_tags=["y1"],
     ),
     hierarchy_node_from_tags(
         "branch_A",
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 1},
         subspaces=subspaces,
-        indicator_tags=["y1"],
     ),
     hierarchy_node_from_tags(
         "branch_B",
         subspace_tags=["x3"],
         activity_condition_tags={"y1": 0},
         subspaces=subspaces,
-        indicator_tags=["y1"],
     ),
 ]
-space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"])
+space = HierarchicalSearchSpace(subspaces, hierarchy)
 print("dimension:     ", int(space.dimension))
 print("indicator_tags:", space.indicator_tags)
 print("indicator_dims:", space.indicator_dims)

--- a/tests/unit/test_hierarchical_search_space.py
+++ b/tests/unit/test_hierarchical_search_space.py
@@ -60,21 +60,18 @@ def _worked_example_hierarchy(subspaces: dict[str, SearchSpace]) -> list[Hierarc
             "shared",
             subspace_tags=["x1"],
             subspaces=subspaces,
-            indicator_tags=["y1"],
         ),
         hierarchy_node_from_tags(
             "branch_A",
             subspace_tags=["x2", "x4"],
             activity_condition_tags={"y1": 1},
             subspaces=subspaces,
-            indicator_tags=["y1"],
         ),
         hierarchy_node_from_tags(
             "branch_B",
             subspace_tags=["x3"],
             activity_condition_tags={"y1": 0},
             subspaces=subspaces,
-            indicator_tags=["y1"],
         ),
     ]
 
@@ -84,7 +81,6 @@ def _make_worked_example_hss() -> HierarchicalSearchSpace:
     return HierarchicalSearchSpace(
         subspaces,
         _worked_example_hierarchy(subspaces),
-        indicator_tags=["y1"],
     )
 
 
@@ -98,7 +94,6 @@ def test_helper_resolves_subspace_tags_to_columns() -> None:
         subspace_tags=["x2", "x4"],
         activity_condition_tags={"y1": 1},
         subspaces=subspaces,
-        indicator_tags=["y1"],
     )
     # x1=col0, y1=col1, x2=col2, x4=col3, x3=col4
     assert list(node.feature_dims) == [2, 3]
@@ -111,7 +106,6 @@ def test_helper_translates_activity_condition_tags_to_global_columns() -> None:
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 1},
         subspaces=subspaces,
-        indicator_tags=["y1"],
     )
     # y1 is at flat-vector column 1 (x1=0, y1=1, ...), and that column is the key.
     assert node.activity_condition.requirements == {1: 1}
@@ -128,7 +122,6 @@ def test_helper_preserves_categorical_int_value() -> None:
         subspace_tags=["x2"],
         activity_condition_tags={"y1": 2},
         subspaces=subspaces,
-        indicator_tags=["y1"],
     )
     # Value 2 must survive as int (not bool-coerced to True). y1 is at column 1.
     req = node.activity_condition.requirements
@@ -143,7 +136,6 @@ def test_helper_stacks_feature_bounds() -> None:
         subspace_tags=["x2", "x4"],
         activity_condition_tags={"y1": 1},
         subspaces=subspaces,
-        indicator_tags=["y1"],
     )
     bounds = tf.convert_to_tensor(node.feature_bounds, dtype=tf.float64).numpy()
     npt.assert_array_almost_equal(bounds, [[0.0, 5.0], [-2.0, 2.0]])
@@ -155,7 +147,6 @@ def test_helper_default_activity_condition_is_empty() -> None:
         "shared",
         subspace_tags=["x1"],
         subspaces=subspaces,
-        indicator_tags=["y1"],
     )
     assert node.activity_condition.requirements == {}
 
@@ -171,7 +162,6 @@ def test_helper_expands_multidimensional_subspace_to_one_col_per_dim() -> None:
         "shared",
         subspace_tags=["x1"],
         subspaces=subspaces,
-        indicator_tags=["y1"],
     )
     assert list(node.feature_dims) == [0, 1]
 
@@ -187,19 +177,6 @@ def test_helper_infers_indicator_when_indicator_tags_omitted() -> None:
         subspaces=subspaces,
     )
     assert node.activity_condition.requirements == {1: 1}
-
-
-def test_helper_explicit_indicator_tags_still_catches_unknown_key() -> None:
-    # When indicator_tags is supplied it remains a cross-check against typos.
-    subspaces = _worked_example_subspaces()
-    with pytest.raises(ValueError, match="is not in"):
-        hierarchy_node_from_tags(
-            "branch_A",
-            subspace_tags=["x2"],
-            activity_condition_tags={"x4": 1},  # x4 is not declared an indicator
-            subspaces=subspaces,
-            indicator_tags=["y1"],
-        )
 
 
 def test_helper_rejects_activity_condition_key_not_a_subspace() -> None:
@@ -239,17 +216,16 @@ def test_hss_multi_indicator_construction() -> None:
     }
     hierarchy = [
         hierarchy_node_from_tags(
-            "shared", subspace_tags=["x1"], subspaces=subspaces, indicator_tags=["y1", "y2"]
+            "shared", subspace_tags=["x1"], subspaces=subspaces
         ),
         hierarchy_node_from_tags(
             "branch",
             subspace_tags=["x2"],
             activity_condition_tags={"y1": 1, "y2": 0},
             subspaces=subspaces,
-            indicator_tags=["y1", "y2"],
         ),
     ]
-    space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1", "y2"])
+    space = HierarchicalSearchSpace(subspaces, hierarchy)
     assert space.indicator_tags == ("y1", "y2")
     assert list(space.indicator_dims) == [1, 2]
     assert space.non_indicator_tags == ("x1", "x2")
@@ -282,26 +258,6 @@ def test_hss_non_gated_boolean_inferred_as_feature() -> None:
     space = HierarchicalSearchSpace(subspaces, hierarchy)  # indicator_tags inferred
     assert space.indicator_tags == ("y1",)
     assert "b" in space.non_indicator_tags
-
-
-def test_hss_explicit_declaring_a_feature_boolean_as_indicator_errors() -> None:
-    # Same space as the inference test above: omitting indicator_tags treats ``b`` as a feature.
-    # The explicit override is the safety net -- declaring the feature Boolean ``b`` an indicator
-    # is rejected (its column is already a feature_dim, so it cannot also be an indicator).
-    subspaces = {
-        "x1": Box([0.0], [1.0]),
-        "b": BooleanSearchSpace(),
-        "y1": BooleanSearchSpace(),
-        "x2": Box([0.0], [1.0]),
-    }
-    hierarchy = [
-        hierarchy_node_from_tags("shared", subspace_tags=["x1", "b"], subspaces=subspaces),
-        hierarchy_node_from_tags(
-            "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1}, subspaces=subspaces
-        ),
-    ]
-    with pytest.raises(ValueError, match="indicator column"):
-        HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1", "b"])
 
 
 def test_hss_inferred_box_indicator_rejected_by_type_check() -> None:
@@ -389,7 +345,7 @@ def test_hss_enumerate_tasks_no_indicators() -> None:
     # A space with no indicators has a single (empty) task.
     subspaces = {"x1": Box([0.0], [1.0])}
     hierarchy = [hierarchy_node_from_tags("only", subspace_tags=["x1"], subspaces=subspaces)]
-    space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=[])
+    space = HierarchicalSearchSpace(subspaces, hierarchy)
     assert space.enumerate_tasks() == [{}]
 
 
@@ -406,24 +362,21 @@ def test_hss_enumerate_tasks_two_indicators() -> None:
             "shared",
             subspace_tags=["x1"],
             subspaces=subspaces,
-            indicator_tags=["y1", "y2"],
         ),
         hierarchy_node_from_tags(
             "a",
             subspace_tags=["x2"],
             activity_condition_tags={"y1": 1},
             subspaces=subspaces,
-            indicator_tags=["y1", "y2"],
         ),
         hierarchy_node_from_tags(
             "b",
             subspace_tags=["x3"],
             activity_condition_tags={"y2": 1},
             subspaces=subspaces,
-            indicator_tags=["y1", "y2"],
         ),
     ]
-    space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1", "y2"])
+    space = HierarchicalSearchSpace(subspaces, hierarchy)
     assert len(space.enumerate_tasks()) == 4
 
 
@@ -462,21 +415,6 @@ def test_hss_node_for_subspace_shared_branch() -> None:
 # ===== Validation =====
 
 
-def test_hss_raises_if_indicator_tag_not_a_key_of_subspaces() -> None:
-    subspaces = {"x1": Box([0.0], [1.0]), "y1": BooleanSearchSpace()}
-    hierarchy = [
-        hierarchy_node_from_tags(
-            "n",
-            subspace_tags=["x1"],
-            activity_condition_tags={"y1": 1},
-            subspaces=subspaces,
-            indicator_tags=["y1"],
-        )
-    ]
-    with pytest.raises(ValueError, match="not a key of"):
-        HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y_missing"])
-
-
 def test_hss_raises_if_indicator_tag_refs_non_indicator_subspace() -> None:
     subspaces = {
         "x1": Box([0.0], [1.0]),
@@ -493,7 +431,7 @@ def test_hss_raises_if_indicator_tag_refs_non_indicator_subspace() -> None:
         )
     ]
     with pytest.raises(ValueError, match="BooleanSearchSpace"):
-        HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"])
+        HierarchicalSearchSpace(subspaces, hierarchy)
 
 
 @pytest.mark.parametrize(
@@ -522,7 +460,7 @@ def test_hss_construction_rejects_invalid_nodes(
         activity_condition=ActivityCondition(requirements),
     )
     with pytest.raises(ValueError, match=match):
-        HierarchicalSearchSpace(subspaces, [bad_node], indicator_tags=["y1"])
+        HierarchicalSearchSpace(subspaces, [bad_node])
 
 
 def test_hss_raises_if_required_value_not_in_permitted_set() -> None:
@@ -534,7 +472,7 @@ def test_hss_raises_if_required_value_not_in_permitted_set() -> None:
         activity_condition=ActivityCondition({1: 5}),  # y1 at column 1; K=3, so 5 invalid
     )
     with pytest.raises(ValueError, match="permitted set"):
-        HierarchicalSearchSpace(subspaces, [bad_node], indicator_tags=["y1"])
+        HierarchicalSearchSpace(subspaces, [bad_node])
 
 
 def test_hss_raises_if_orphan_non_indicator_column() -> None:
@@ -550,30 +488,10 @@ def test_hss_raises_if_orphan_non_indicator_column() -> None:
             subspace_tags=["x1"],
             activity_condition_tags={"y1": 1},
             subspaces=subspaces,
-            indicator_tags=["y1"],
         )
     ]
     with pytest.raises(ValueError, match="orphan"):
-        HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"])
-
-
-def test_hss_raises_if_unused_indicator() -> None:
-    subspaces = {
-        "x1": Box([0.0], [1.0]),
-        "y1": BooleanSearchSpace(),
-        "y2": BooleanSearchSpace(),
-    }
-    hierarchy = [
-        hierarchy_node_from_tags(
-            "n",
-            subspace_tags=["x1"],
-            activity_condition_tags={"y1": 1},
-            subspaces=subspaces,
-            indicator_tags=["y1", "y2"],
-        )
-    ]
-    with pytest.raises(ValueError, match="unused"):
-        HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1", "y2"])
+        HierarchicalSearchSpace(subspaces, hierarchy)
 
 
 # ===== Categorical-indicator variant =====
@@ -591,24 +509,21 @@ def _make_categorical_hss() -> HierarchicalSearchSpace:
             "shared",
             subspace_tags=["x1"],
             subspaces=subspaces,
-            indicator_tags=["y1"],
         ),
         hierarchy_node_from_tags(
             "branch_A",
             subspace_tags=["x2"],
             activity_condition_tags={"y1": 1},
             subspaces=subspaces,
-            indicator_tags=["y1"],
         ),
         hierarchy_node_from_tags(
             "branch_B",
             subspace_tags=["x3"],
             activity_condition_tags={"y1": 2},
             subspaces=subspaces,
-            indicator_tags=["y1"],
         ),
     ]
-    return HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"])
+    return HierarchicalSearchSpace(subspaces, hierarchy)
 
 
 def test_categorical_hss_enumerate_tasks_three_configs() -> None:
@@ -642,17 +557,15 @@ def _make_second_hss(**kwargs) -> HierarchicalSearchSpace:
             "z_shared",
             subspace_tags=["z1"],
             subspaces=subspaces,
-            indicator_tags=["w1"],
         ),
         hierarchy_node_from_tags(
             "z_branch",
             subspace_tags=["z2"],
             activity_condition_tags={"w1": 1},
             subspaces=subspaces,
-            indicator_tags=["w1"],
         ),
     ]
-    return HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["w1"], **kwargs)
+    return HierarchicalSearchSpace(subspaces, hierarchy, **kwargs)
 
 
 def test_hss_product_combines_tags_dimension_and_indicators() -> None:
@@ -722,7 +635,7 @@ def test_hss_raises_if_activity_condition_key_negative() -> None:
         activity_condition=condition,
     )
     with pytest.raises(ValueError, match="not an indicator column"):
-        HierarchicalSearchSpace(subspaces, [bad_node], indicator_tags=["y1"])
+        HierarchicalSearchSpace(subspaces, [bad_node])
 
 
 def test_hss_raises_if_non_indicator_subspace_has_no_bounds() -> None:
@@ -737,10 +650,10 @@ def test_hss_raises_if_non_indicator_subspace_has_no_bounds() -> None:
         "n",
         feature_dims=[0],
         feature_bounds=tf.constant([[0.0, 1.0]], dtype=tf.float64),
-        activity_condition=ActivityCondition({0: 1}),
+        activity_condition=ActivityCondition({2: 1}),  # y1 (column 2) is the inferred indicator
     )
     with pytest.raises(ValueError, match="no numerical bounds"):
-        HierarchicalSearchSpace(subspaces, [node], indicator_tags=["y1"])
+        HierarchicalSearchSpace(subspaces, [node])
 
 
 def test_helper_raises_on_duplicate_subspace_tags() -> None:
@@ -751,7 +664,6 @@ def test_helper_raises_on_duplicate_subspace_tags() -> None:
             subspace_tags=["x1", "x1"],
             activity_condition_tags={"y1": 1},
             subspaces=subspaces,
-            indicator_tags=["y1"],
         )
 
 
@@ -773,17 +685,6 @@ def test_helper_rejects_multidimensional_indicator() -> None:
     with pytest.raises(ValueError, match="must be 1-dimensional"):
         hierarchy_node_from_tags(
             "n", subspace_tags=["x1"], activity_condition_tags={"big": 1}, subspaces=subspaces
-        )
-
-
-def test_helper_raises_on_overlapping_subspace_and_indicator_tags() -> None:
-    subspaces = {"x1": Box([0.0], [1.0]), "y1": BooleanSearchSpace()}
-    with pytest.raises(ValueError, match="must be disjoint"):
-        hierarchy_node_from_tags(
-            "n",
-            subspace_tags=["y1"],  # y1 is also declared an indicator below
-            subspaces=subspaces,
-            indicator_tags=["y1"],
         )
 
 
@@ -812,19 +713,6 @@ def test_helper_accepts_discrete_non_indicator_subspace() -> None:
     npt.assert_array_almost_equal(bounds, [[0.0, 1.0], [0.0, 2.0]])
 
 
-def test_hss_raises_on_duplicate_indicator_tags() -> None:
-    subspaces = {"x1": Box([0.0], [1.0]), "y1": BooleanSearchSpace()}
-    node = hierarchy_node_from_tags(
-        "n",
-        subspace_tags=["x1"],
-        activity_condition_tags={"y1": 1},
-        subspaces=subspaces,
-        indicator_tags=["y1"],
-    )
-    with pytest.raises(ValueError, match="duplicate tags"):
-        HierarchicalSearchSpace(subspaces, [node], indicator_tags=["y1", "y1"])
-
-
 # ===== __eq__ / __repr__ =====
 
 
@@ -840,24 +728,21 @@ def test_hss_eq_false_when_hierarchy_differs() -> None:
             "shared_renamed",
             subspace_tags=["x1"],
             subspaces=subspaces,
-            indicator_tags=["y1"],
         ),
         hierarchy_node_from_tags(
             "branch_A",
             subspace_tags=["x2", "x4"],
             activity_condition_tags={"y1": 1},
             subspaces=subspaces,
-            indicator_tags=["y1"],
         ),
         hierarchy_node_from_tags(
             "branch_B",
             subspace_tags=["x3"],
             activity_condition_tags={"y1": 0},
             subspaces=subspaces,
-            indicator_tags=["y1"],
         ),
     ]
-    other = HierarchicalSearchSpace(subspaces, renamed_hierarchy, indicator_tags=["y1"])
+    other = HierarchicalSearchSpace(subspaces, renamed_hierarchy)
     assert _make_worked_example_hss() != other
 
 
@@ -916,7 +801,6 @@ def _make_constrained_hss(constraints, ctol: float = 1e-7) -> HierarchicalSearch
     return HierarchicalSearchSpace(
         subspaces,
         _worked_example_hierarchy(subspaces),
-        indicator_tags=["y1"],
         constraints=constraints,
         ctol=ctol,
     )
@@ -1040,7 +924,6 @@ def _hss_with_conditional(cc: ConditionalConstraint) -> HierarchicalSearchSpace:
     return HierarchicalSearchSpace(
         subspaces,
         _worked_example_hierarchy(subspaces),
-        indicator_tags=["y1"],
         conditional_constraints=[cc],
     )
 
@@ -1091,10 +974,10 @@ def test_conditional_constraint_categorical_indicator_matches_only_target() -> N
         "x2": Box([-1.0], [1.0]),  # column 2
     }
     hierarchy = [
-        hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces, indicator_tags=["y1"]),
+        hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces),
         hierarchy_node_from_tags(
             "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 2},
-            subspaces=subspaces, indicator_tags=["y1"],
+            subspaces=subspaces,
         ),
     ]
     cc = ConditionalConstraint(
@@ -1102,7 +985,7 @@ def test_conditional_constraint_categorical_indicator_matches_only_target() -> N
         indicator_conditions={"y1": 2},
         active_subspace_tags=["x2"],
     )
-    space = HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1"], conditional_constraints=[cc])
+    space = HierarchicalSearchSpace(subspaces, hierarchy, conditional_constraints=[cc])
     pts = tf.constant(
         [
             [0.5, 2.0, -0.8],  # y1=2 active, x2=-0.8 < 0 -> infeasible
@@ -1222,14 +1105,13 @@ def _two_indicator_hierarchy(subspaces: dict[str, SearchSpace]) -> list[Hierarch
     # x2 is active (and both y1, y2 are thereby gated) only when y1 == 0 AND y2 == 1.
     return [
         hierarchy_node_from_tags(
-            "shared", subspace_tags=["x1"], subspaces=subspaces, indicator_tags=["y1", "y2"]
+            "shared", subspace_tags=["x1"], subspaces=subspaces
         ),
         hierarchy_node_from_tags(
             "branch",
             subspace_tags=["x2"],
             activity_condition_tags={"y1": 0, "y2": 1},
             subspaces=subspaces,
-            indicator_tags=["y1", "y2"],
         ),
     ]
 
@@ -1238,7 +1120,7 @@ def test_hss_is_active_multi_indicator_node() -> None:
     # A node gated on two indicators is active only when BOTH conditions hold (logical AND).
     subspaces = _two_indicator_subspaces()
     space = HierarchicalSearchSpace(
-        subspaces, _two_indicator_hierarchy(subspaces), indicator_tags=["y1", "y2"]
+        subspaces, _two_indicator_hierarchy(subspaces)
     )
     assert space.is_active("x2", {"y1": 0, "y2": 1})
     assert not space.is_active("x2", {"y1": 0, "y2": 0})
@@ -1258,7 +1140,6 @@ def test_conditional_constraint_multiple_indicator_conditions() -> None:
     space = HierarchicalSearchSpace(
         subspaces,
         _two_indicator_hierarchy(subspaces),
-        indicator_tags=["y1", "y2"],
         conditional_constraints=[cc],
     )
     # columns: [x1=0, y1=1, y2=2, x2=3]; x2 < 0 violates 0 <= x2 <= 1 only when active.
@@ -1296,14 +1177,14 @@ def _two_indicator_hss(**kwargs) -> HierarchicalSearchSpace:
     }
     hierarchy = [
         hierarchy_node_from_tags(
-            "shared", subspace_tags=["x1"], subspaces=subspaces, indicator_tags=["y1", "y2"]
+            "shared", subspace_tags=["x1"], subspaces=subspaces
         ),
         hierarchy_node_from_tags(
             "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1, "y2": 1},
-            subspaces=subspaces, indicator_tags=["y1", "y2"],
+            subspaces=subspaces,
         ),
     ]
-    return HierarchicalSearchSpace(subspaces, hierarchy, indicator_tags=["y1", "y2"], **kwargs)
+    return HierarchicalSearchSpace(subspaces, hierarchy, **kwargs)
 
 
 def test_logical_proposition_filters_violating_points() -> None:

--- a/tests/unit/test_hierarchical_search_space.py
+++ b/tests/unit/test_hierarchical_search_space.py
@@ -21,7 +21,6 @@ import tensorflow as tf
 
 from trieste.space import (
     INACTIVE_CONSTRAINT_RESIDUAL,
-    ActivityCondition,
     BooleanSearchSpace,
     Box,
     CategoricalSearchSpace,
@@ -33,7 +32,6 @@ from trieste.space import (
     LogicalProposition,
     NonlinearConstraint,
     SearchSpace,
-    hierarchy_node_from_tags,
 )
 
 # ===== Worked-example fixture =====
@@ -56,22 +54,19 @@ def _worked_example_subspaces() -> dict[str, SearchSpace]:
 
 def _worked_example_hierarchy(subspaces: dict[str, SearchSpace]) -> list[HierarchyNode]:
     return [
-        hierarchy_node_from_tags(
+        HierarchyNode(
             "shared",
             subspace_tags=["x1"],
-            subspaces=subspaces,
         ),
-        hierarchy_node_from_tags(
+        HierarchyNode(
             "branch_A",
             subspace_tags=["x2", "x4"],
             activity_condition_tags={"y1": 1},
-            subspaces=subspaces,
         ),
-        hierarchy_node_from_tags(
+        HierarchyNode(
             "branch_B",
             subspace_tags=["x3"],
             activity_condition_tags={"y1": 0},
-            subspaces=subspaces,
         ),
     ]
 
@@ -84,110 +79,116 @@ def _make_worked_example_hss() -> HierarchicalSearchSpace:
     )
 
 
-# ===== hierarchy_node_from_tags =====
+# ===== tag resolution (via to_gpflow_hierarchy) =====
 
 
-def test_helper_resolves_subspace_tags_to_columns() -> None:
+def test_resolves_subspace_tags_to_columns() -> None:
     subspaces = _worked_example_subspaces()
-    node = hierarchy_node_from_tags(
-        "branch_A",
-        subspace_tags=["x2", "x4"],
-        activity_condition_tags={"y1": 1},
-        subspaces=subspaces,
+    space = HierarchicalSearchSpace(
+        subspaces,
+        [
+            HierarchyNode("shared", subspace_tags=["x1"]),
+            HierarchyNode(
+                "branch_A",
+                subspace_tags=["x2", "x4"],
+                activity_condition_tags={"y1": 1},
+            ),
+            HierarchyNode(
+                "branch_B",
+                subspace_tags=["x3"],
+                activity_condition_tags={"y1": 0},
+            ),
+        ],
     )
+    by_name = {n.name: n for n in space.to_gpflow_hierarchy()}
     # x1=col0, y1=col1, x2=col2, x4=col3, x3=col4
-    assert list(node.feature_dims) == [2, 3]
+    assert list(by_name["branch_A"].feature_dims) == [2, 3]
 
 
-def test_helper_translates_activity_condition_tags_to_global_columns() -> None:
+def test_translates_activity_condition_tags_to_global_columns() -> None:
     subspaces = _worked_example_subspaces()
-    node = hierarchy_node_from_tags(
-        "branch_A",
-        subspace_tags=["x2"],
-        activity_condition_tags={"y1": 1},
-        subspaces=subspaces,
-    )
+    space = _make_worked_example_hss()
+    by_name = {n.name: n for n in space.to_gpflow_hierarchy()}
     # y1 is at flat-vector column 1 (x1=0, y1=1, ...), and that column is the key.
-    assert node.activity_condition.requirements == {1: 1}
+    assert by_name["branch_A"].activity_condition.requirements == {1: 1}
 
 
-def test_helper_preserves_categorical_int_value() -> None:
+def test_preserves_categorical_int_value() -> None:
     subspaces = {
         "x1": Box([0.0], [1.0]),
         "y1": CategoricalSearchSpace(3),
         "x2": Box([0.0], [5.0]),
     }
-    node = hierarchy_node_from_tags(
-        "branch",
-        subspace_tags=["x2"],
-        activity_condition_tags={"y1": 2},
-        subspaces=subspaces,
+    space = HierarchicalSearchSpace(
+        subspaces,
+        [
+            HierarchyNode("shared", subspace_tags=["x1"]),
+            HierarchyNode(
+                "branch",
+                subspace_tags=["x2"],
+                activity_condition_tags={"y1": 2},
+            ),
+        ],
     )
+    by_name = {n.name: n for n in space.to_gpflow_hierarchy()}
     # Value 2 must survive as int (not bool-coerced to True). y1 is at column 1.
-    req = node.activity_condition.requirements
+    req = by_name["branch"].activity_condition.requirements
     assert req[1] == 2
     assert not isinstance(req[1], bool)
 
 
-def test_helper_stacks_feature_bounds() -> None:
-    subspaces = _worked_example_subspaces()
-    node = hierarchy_node_from_tags(
-        "branch_A",
-        subspace_tags=["x2", "x4"],
-        activity_condition_tags={"y1": 1},
-        subspaces=subspaces,
-    )
-    bounds = tf.convert_to_tensor(node.feature_bounds, dtype=tf.float64).numpy()
+def test_stacks_feature_bounds() -> None:
+    space = _make_worked_example_hss()
+    by_name = {n.name: n for n in space.to_gpflow_hierarchy()}
+    bounds = tf.convert_to_tensor(by_name["branch_A"].feature_bounds, dtype=tf.float64).numpy()
     npt.assert_array_almost_equal(bounds, [[0.0, 5.0], [-2.0, 2.0]])
 
 
-def test_helper_default_activity_condition_is_empty() -> None:
-    subspaces = _worked_example_subspaces()
-    node = hierarchy_node_from_tags(
-        "shared",
-        subspace_tags=["x1"],
-        subspaces=subspaces,
-    )
-    assert node.activity_condition.requirements == {}
+def test_default_activity_condition_is_empty() -> None:
+    space = _make_worked_example_hss()
+    by_name = {n.name: n for n in space.to_gpflow_hierarchy()}
+    assert by_name["shared"].activity_condition.requirements == {}
 
 
-def test_helper_expands_multidimensional_subspace_to_one_col_per_dim() -> None:
+def test_expands_multidimensional_subspace_to_one_col_per_dim() -> None:
     """A non-indicator subspace of dimension d contributes d consecutive columns."""
     subspaces = {
         "x1": Box([0.0, 0.0], [1.0, 1.0]),  # 2-D
         "y1": BooleanSearchSpace(),
         "x2": Box([0.0], [1.0]),
     }
-    node = hierarchy_node_from_tags(
-        "shared",
-        subspace_tags=["x1"],
-        subspaces=subspaces,
+    space = HierarchicalSearchSpace(
+        subspaces,
+        [
+            HierarchyNode("shared", subspace_tags=["x1"]),
+            HierarchyNode(
+                "branch",
+                subspace_tags=["x2"],
+                activity_condition_tags={"y1": 1},
+            ),
+        ],
     )
-    assert list(node.feature_dims) == [0, 1]
+    by_name = {n.name: n for n in space.to_gpflow_hierarchy()}
+    assert list(by_name["shared"].feature_dims) == [0, 1]
 
 
-def test_helper_infers_indicator_when_indicator_tags_omitted() -> None:
-    # Omitting indicator_tags: the activity_condition_tags key self-identifies as an indicator
-    # and is resolved to its global column (y1 -> column 1) from subspaces alone.
+def test_infers_indicator_when_indicator_tags_omitted() -> None:
+    # The activity_condition_tags key self-identifies as an indicator and is resolved to its
+    # global column (y1 -> column 1) from subspaces alone.
+    space = _make_worked_example_hss()
+    by_name = {n.name: n for n in space.to_gpflow_hierarchy()}
+    assert by_name["branch_A"].activity_condition.requirements == {1: 1}
+
+
+def test_rejects_activity_condition_key_not_a_subspace() -> None:
     subspaces = _worked_example_subspaces()
-    node = hierarchy_node_from_tags(
+    node = HierarchyNode(
         "branch_A",
         subspace_tags=["x2"],
-        activity_condition_tags={"y1": 1},
-        subspaces=subspaces,
+        activity_condition_tags={"nope": 1},
     )
-    assert node.activity_condition.requirements == {1: 1}
-
-
-def test_helper_rejects_activity_condition_key_not_a_subspace() -> None:
-    subspaces = _worked_example_subspaces()
-    with pytest.raises(ValueError, match="not a key of"):
-        hierarchy_node_from_tags(
-            "branch_A",
-            subspace_tags=["x2"],
-            activity_condition_tags={"nope": 1},
-            subspaces=subspaces,
-        )
+    with pytest.raises(ValueError, match="is not a key of"):
+        HierarchicalSearchSpace(subspaces, [node])
 
 
 # ===== HierarchicalSearchSpace: basic shape and properties =====
@@ -215,14 +216,11 @@ def test_hss_multi_indicator_construction() -> None:
         "x2": Box([0.0], [1.0]),
     }
     hierarchy = [
-        hierarchy_node_from_tags(
-            "shared", subspace_tags=["x1"], subspaces=subspaces
-        ),
-        hierarchy_node_from_tags(
+        HierarchyNode("shared", subspace_tags=["x1"]),
+        HierarchyNode(
             "branch",
             subspace_tags=["x2"],
             activity_condition_tags={"y1": 1, "y2": 0},
-            subspaces=subspaces,
         ),
     ]
     space = HierarchicalSearchSpace(subspaces, hierarchy)
@@ -250,10 +248,8 @@ def test_hss_non_gated_boolean_inferred_as_feature() -> None:
         "x2": Box([0.0], [1.0]),
     }
     hierarchy = [
-        hierarchy_node_from_tags("shared", subspace_tags=["x1", "b"], subspaces=subspaces),
-        hierarchy_node_from_tags(
-            "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1}, subspaces=subspaces
-        ),
+        HierarchyNode("shared", subspace_tags=["x1", "b"]),
+        HierarchyNode("branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1}),
     ]
     space = HierarchicalSearchSpace(subspaces, hierarchy)  # indicator_tags inferred
     assert space.indicator_tags == ("y1",)
@@ -265,9 +261,7 @@ def test_hss_inferred_box_indicator_rejected_by_type_check() -> None:
     # rejects it (indicators must be Boolean / 1-D categorical).
     subspaces = {"x1": Box([0.0], [1.0]), "x2": Box([0.0], [1.0])}
     hierarchy = [
-        hierarchy_node_from_tags(
-            "n", subspace_tags=["x1"], activity_condition_tags={"x2": 1}, subspaces=subspaces
-        )
+        HierarchyNode("n", subspace_tags=["x1"], activity_condition_tags={"x2": 1})
     ]
     with pytest.raises(ValueError, match="BooleanSearchSpace or a"):
         HierarchicalSearchSpace(subspaces, hierarchy)
@@ -344,7 +338,7 @@ def test_hss_enumerate_tasks_boolean() -> None:
 def test_hss_enumerate_tasks_no_indicators() -> None:
     # A space with no indicators has a single (empty) task.
     subspaces = {"x1": Box([0.0], [1.0])}
-    hierarchy = [hierarchy_node_from_tags("only", subspace_tags=["x1"], subspaces=subspaces)]
+    hierarchy = [HierarchyNode("only", subspace_tags=["x1"])]
     space = HierarchicalSearchSpace(subspaces, hierarchy)
     assert space.enumerate_tasks() == [{}]
 
@@ -358,23 +352,9 @@ def test_hss_enumerate_tasks_two_indicators() -> None:
         "x3": Box([0.0], [1.0]),
     }
     hierarchy = [
-        hierarchy_node_from_tags(
-            "shared",
-            subspace_tags=["x1"],
-            subspaces=subspaces,
-        ),
-        hierarchy_node_from_tags(
-            "a",
-            subspace_tags=["x2"],
-            activity_condition_tags={"y1": 1},
-            subspaces=subspaces,
-        ),
-        hierarchy_node_from_tags(
-            "b",
-            subspace_tags=["x3"],
-            activity_condition_tags={"y2": 1},
-            subspaces=subspaces,
-        ),
+        HierarchyNode("shared", subspace_tags=["x1"]),
+        HierarchyNode("a", subspace_tags=["x2"], activity_condition_tags={"y1": 1}),
+        HierarchyNode("b", subspace_tags=["x3"], activity_condition_tags={"y2": 1}),
     ]
     space = HierarchicalSearchSpace(subspaces, hierarchy)
     assert len(space.enumerate_tasks()) == 4
@@ -416,63 +396,32 @@ def test_hss_node_for_subspace_shared_branch() -> None:
 
 
 def test_hss_raises_if_indicator_tag_refs_non_indicator_subspace() -> None:
+    # A node gating on a DiscreteSearchSpace makes it an inferred indicator, but a discrete
+    # space is neither Boolean nor a 1-D categorical, so construction must fail.
     subspaces = {
         "x1": Box([0.0], [1.0]),
         "y1": DiscreteSearchSpace(tf.constant([[0], [1], [2]])),
     }
-    # Using a "y1": 1 activity condition just to make hierarchy non-trivial; the
-    # construction must fail because y1 isn't Boolean / 1-D Categorical.
     hierarchy = [
-        gpflow.kernels.HierarchyNode(
-            "n",
-            feature_dims=[0],
-            feature_bounds=tf.constant([[0.0, 1.0]], dtype=tf.float64),
-            activity_condition=ActivityCondition({0: 1}),
-        )
+        HierarchyNode("n", subspace_tags=["x1"], activity_condition_tags={"y1": 1})
     ]
     with pytest.raises(ValueError, match="BooleanSearchSpace"):
         HierarchicalSearchSpace(subspaces, hierarchy)
 
 
-@pytest.mark.parametrize(
-    "feature_dims, feature_bounds, requirements, match",
-    [
-        # feature_dims points at y1, which is an indicator column.
-        pytest.param([1], [[0.0, 1.0]], {1: 1}, "indicator column", id="feature_dim_is_indicator"),
-        pytest.param([42], [[0.0, 1.0]], {1: 1}, "out of range", id="feature_dim_out_of_range"),
-        # x1 lives in [0, 1] but the node claims [-99, 99].
-        pytest.param([0], [[-99.0, 99.0]], {1: 1}, "feature_bounds", id="bounds_disagree"),
-        # The only indicator (y1) is at column 1, but the node references column 7.
-        pytest.param([0], [[0.0, 1.0]], {7: 1}, "not an indicator column", id="key_not_indicator"),
-    ],
-)
-def test_hss_construction_rejects_invalid_nodes(
-    feature_dims: list[int],
-    feature_bounds: list[list[float]],
-    requirements: dict[int, int],
-    match: str,
-) -> None:
-    subspaces = {"x1": Box([0.0], [1.0]), "y1": BooleanSearchSpace()}
-    bad_node = gpflow.kernels.HierarchyNode(
-        "n",
-        feature_dims=feature_dims,
-        feature_bounds=tf.constant(feature_bounds, dtype=tf.float64),
-        activity_condition=ActivityCondition(requirements),
-    )
-    with pytest.raises(ValueError, match=match):
-        HierarchicalSearchSpace(subspaces, [bad_node])
-
-
 def test_hss_raises_if_required_value_not_in_permitted_set() -> None:
-    subspaces = {"x1": Box([0.0], [1.0]), "y1": CategoricalSearchSpace(3)}
-    bad_node = gpflow.kernels.HierarchyNode(
-        "n",
-        feature_dims=[0],
-        feature_bounds=tf.constant([[0.0, 1.0]], dtype=tf.float64),
-        activity_condition=ActivityCondition({1: 5}),  # y1 at column 1; K=3, so 5 invalid
-    )
+    # y1 is a 3-ary categorical (permitted {0, 1, 2}); requiring value 5 is out of range.
+    subspaces = {
+        "x1": Box([0.0], [1.0]),
+        "y1": CategoricalSearchSpace(3),
+        "x2": Box([0.0], [1.0]),
+    }
+    hierarchy = [
+        HierarchyNode("shared", subspace_tags=["x1"]),
+        HierarchyNode("branch", subspace_tags=["x2"], activity_condition_tags={"y1": 5}),
+    ]
     with pytest.raises(ValueError, match="permitted set"):
-        HierarchicalSearchSpace(subspaces, [bad_node])
+        HierarchicalSearchSpace(subspaces, hierarchy)
 
 
 def test_hss_raises_if_orphan_non_indicator_column() -> None:
@@ -481,14 +430,9 @@ def test_hss_raises_if_orphan_non_indicator_column() -> None:
         "x2": Box([0.0], [1.0]),
         "y1": BooleanSearchSpace(),
     }
-    # x2 (column 1) is never referenced by any node's feature_dims.
+    # x2 is never referenced by any node's subspace_tags.
     hierarchy = [
-        hierarchy_node_from_tags(
-            "n",
-            subspace_tags=["x1"],
-            activity_condition_tags={"y1": 1},
-            subspaces=subspaces,
-        )
+        HierarchyNode("n", subspace_tags=["x1"], activity_condition_tags={"y1": 1})
     ]
     with pytest.raises(ValueError, match="orphan"):
         HierarchicalSearchSpace(subspaces, hierarchy)
@@ -505,23 +449,9 @@ def _make_categorical_hss() -> HierarchicalSearchSpace:
         "x3": Box([-1.0], [1.0]),
     }
     hierarchy = [
-        hierarchy_node_from_tags(
-            "shared",
-            subspace_tags=["x1"],
-            subspaces=subspaces,
-        ),
-        hierarchy_node_from_tags(
-            "branch_A",
-            subspace_tags=["x2"],
-            activity_condition_tags={"y1": 1},
-            subspaces=subspaces,
-        ),
-        hierarchy_node_from_tags(
-            "branch_B",
-            subspace_tags=["x3"],
-            activity_condition_tags={"y1": 2},
-            subspaces=subspaces,
-        ),
+        HierarchyNode("shared", subspace_tags=["x1"]),
+        HierarchyNode("branch_A", subspace_tags=["x2"], activity_condition_tags={"y1": 1}),
+        HierarchyNode("branch_B", subspace_tags=["x3"], activity_condition_tags={"y1": 2}),
     ]
     return HierarchicalSearchSpace(subspaces, hierarchy)
 
@@ -553,17 +483,8 @@ def _make_second_hss(**kwargs) -> HierarchicalSearchSpace:
         "z2": Box([0.0], [2.0]),
     }
     hierarchy = [
-        hierarchy_node_from_tags(
-            "z_shared",
-            subspace_tags=["z1"],
-            subspaces=subspaces,
-        ),
-        hierarchy_node_from_tags(
-            "z_branch",
-            subspace_tags=["z2"],
-            activity_condition_tags={"w1": 1},
-            subspaces=subspaces,
-        ),
+        HierarchyNode("z_shared", subspace_tags=["z1"]),
+        HierarchyNode("z_branch", subspace_tags=["z2"], activity_condition_tags={"w1": 1}),
     ]
     return HierarchicalSearchSpace(subspaces, hierarchy, **kwargs)
 
@@ -591,7 +512,7 @@ def test_hss_product_shifts_other_feature_dims_and_requirements() -> None:
     # ``other``'s node feature_dims and activity_condition requirement columns are
     # both shifted by self.dimension (5): z2 -> column 7, and w1 (other column 1)
     # -> combined column 6.
-    z_branch = next(node for node in combined.hierarchy if node.name == "z_branch")
+    z_branch = next(node for node in combined.to_gpflow_hierarchy() if node.name == "z_branch")
     assert list(z_branch.feature_dims) == [7]
     assert dict(z_branch.activity_condition.requirements) == {6: 1}
     # feature_bounds describe values, not columns, so they are carried over unshifted.
@@ -621,95 +542,91 @@ def test_hss_product_raises_on_overlapping_tags() -> None:
 # ===== additional validation =====
 
 
-def test_hss_raises_if_activity_condition_key_negative() -> None:
-    subspaces = {"x1": Box([0.0], [1.0]), "y1": BooleanSearchSpace()}
-    # ActivityCondition validates non-negative keys on construction, so bypass it
-    # to exercise the HierarchicalSearchSpace defence: a negative column is not an
-    # indicator column and must be rejected.
-    condition = ActivityCondition({1: 1})
-    object.__setattr__(condition, "requirements", {-1: 1})
-    bad_node = gpflow.kernels.HierarchyNode(
-        "n",
-        feature_dims=[0],
-        feature_bounds=tf.constant([[0.0, 1.0]], dtype=tf.float64),
-        activity_condition=condition,
-    )
-    with pytest.raises(ValueError, match="not an indicator column"):
-        HierarchicalSearchSpace(subspaces, [bad_node])
-
-
 def test_hss_raises_if_non_indicator_subspace_has_no_bounds() -> None:
-    # c1 is a non-indicator categorical subspace: it has no numerical bounds, so
-    # it cannot be encoded as a (lower, upper) feature_bounds row.
+    # c1 is a non-indicator categorical subspace owned by a node: it has no numerical bounds,
+    # so it cannot be encoded as a (lower, upper) feature_bounds row.
     subspaces = {
         "x1": Box([0.0], [1.0]),
         "c1": CategoricalSearchSpace(3),
         "y1": BooleanSearchSpace(),
     }
-    node = gpflow.kernels.HierarchyNode(
-        "n",
-        feature_dims=[0],
-        feature_bounds=tf.constant([[0.0, 1.0]], dtype=tf.float64),
-        activity_condition=ActivityCondition({2: 1}),  # y1 (column 2) is the inferred indicator
+    hierarchy = [
+        HierarchyNode(
+            "n", subspace_tags=["x1", "c1"], activity_condition_tags={"y1": 1}
+        )
+    ]
+    with pytest.raises(ValueError, match="without numerical"):
+        HierarchicalSearchSpace(subspaces, hierarchy)
+
+
+def test_raises_on_duplicate_subspace_tags() -> None:
+    subspaces = {"x1": Box([0.0], [1.0]), "y1": BooleanSearchSpace()}
+    node = HierarchyNode(
+        "n", subspace_tags=["x1", "x1"], activity_condition_tags={"y1": 1}
     )
-    with pytest.raises(ValueError, match="no numerical bounds"):
+    with pytest.raises(ValueError, match="duplicate tags"):
         HierarchicalSearchSpace(subspaces, [node])
 
 
-def test_helper_raises_on_duplicate_subspace_tags() -> None:
+def test_rejects_empty_subspace_tags() -> None:
     subspaces = {"x1": Box([0.0], [1.0]), "y1": BooleanSearchSpace()}
-    with pytest.raises(ValueError, match="duplicate tags"):
-        hierarchy_node_from_tags(
-            "n",
-            subspace_tags=["x1", "x1"],
-            activity_condition_tags={"y1": 1},
-            subspaces=subspaces,
-        )
-
-
-def test_helper_rejects_empty_subspace_tags() -> None:
-    subspaces = {"x1": Box([0.0], [1.0]), "y1": BooleanSearchSpace()}
+    node = HierarchyNode("n", subspace_tags=[])
     with pytest.raises(ValueError, match="must be non-empty"):
-        hierarchy_node_from_tags("n", subspace_tags=[], subspaces=subspaces)
+        HierarchicalSearchSpace(subspaces, [node])
 
 
-def test_helper_rejects_subspace_tag_not_a_subspace() -> None:
+def test_rejects_subspace_tag_not_a_subspace() -> None:
     subspaces = {"x1": Box([0.0], [1.0]), "y1": BooleanSearchSpace()}
-    with pytest.raises(ValueError, match="not a key of"):
-        hierarchy_node_from_tags("n", subspace_tags=["missing"], subspaces=subspaces)
+    node = HierarchyNode("n", subspace_tags=["missing"])
+    with pytest.raises(ValueError, match="is not a key of"):
+        HierarchicalSearchSpace(subspaces, [node])
 
 
-def test_helper_rejects_multidimensional_indicator() -> None:
+def test_rejects_multidimensional_indicator() -> None:
     # An activity-condition key resolving to more than one column is not a valid indicator.
     subspaces = {"x1": Box([0.0], [1.0]), "big": Box([0.0, 0.0], [1.0, 1.0])}
+    node = HierarchyNode(
+        "n", subspace_tags=["x1"], activity_condition_tags={"big": 1}
+    )
     with pytest.raises(ValueError, match="must be 1-dimensional"):
-        hierarchy_node_from_tags(
-            "n", subspace_tags=["x1"], activity_condition_tags={"big": 1}, subspaces=subspaces
-        )
+        HierarchicalSearchSpace(subspaces, [node])
 
 
-def test_helper_rejects_non_indicator_subspace_without_bounds() -> None:
+def test_rejects_non_indicator_subspace_without_bounds() -> None:
     # A categorical (no numerical bounds) cannot be a non-indicator feature.
     subspaces = {
         "x1": Box([0.0], [1.0]),
         "c": CategoricalSearchSpace(3),
         "y1": BooleanSearchSpace(),
     }
+    node = HierarchyNode(
+        "n", subspace_tags=["c"], activity_condition_tags={"y1": 1}
+    )
     with pytest.raises(ValueError, match="without numerical"):
-        hierarchy_node_from_tags("n", subspace_tags=["c"], subspaces=subspaces)
+        HierarchicalSearchSpace(subspaces, [node])
 
 
-def test_helper_accepts_discrete_non_indicator_subspace() -> None:
+def test_accepts_discrete_non_indicator_subspace() -> None:
     # A discrete (bounded) subspace is allowed as a non-indicator feature.
     subspaces = {
         "x1": Box([0.0], [1.0]),
         "d": DiscreteSearchSpace(tf.constant([[0.0], [1.0], [2.0]], dtype=tf.float64)),
         "y1": BooleanSearchSpace(),
+        "x2": Box([0.0], [1.0]),
     }
-    node = hierarchy_node_from_tags("shared", subspace_tags=["x1", "d"], subspaces=subspaces)
+    space = HierarchicalSearchSpace(
+        subspaces,
+        [
+            HierarchyNode("shared", subspace_tags=["x1", "d"]),
+            HierarchyNode(
+                "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1}
+            ),
+        ],
+    )
+    by_name = {n.name: n for n in space.to_gpflow_hierarchy()}
     # x1 -> col 0, d -> col 1; bounds reflect each subspace.
-    assert list(node.feature_dims) == [0, 1]
-    bounds = tf.convert_to_tensor(node.feature_bounds, dtype=tf.float64).numpy()
+    assert list(by_name["shared"].feature_dims) == [0, 1]
+    bounds = tf.convert_to_tensor(by_name["shared"].feature_bounds, dtype=tf.float64).numpy()
     npt.assert_array_almost_equal(bounds, [[0.0, 1.0], [0.0, 2.0]])
 
 
@@ -724,22 +641,16 @@ def test_hss_eq_false_when_hierarchy_differs() -> None:
     # Same subspaces, but a hierarchy whose node names differ.
     subspaces = _worked_example_subspaces()
     renamed_hierarchy = [
-        hierarchy_node_from_tags(
-            "shared_renamed",
-            subspace_tags=["x1"],
-            subspaces=subspaces,
-        ),
-        hierarchy_node_from_tags(
+        HierarchyNode("shared_renamed", subspace_tags=["x1"]),
+        HierarchyNode(
             "branch_A",
             subspace_tags=["x2", "x4"],
             activity_condition_tags={"y1": 1},
-            subspaces=subspaces,
         ),
-        hierarchy_node_from_tags(
+        HierarchyNode(
             "branch_B",
             subspace_tags=["x3"],
             activity_condition_tags={"y1": 0},
-            subspaces=subspaces,
         ),
     ]
     other = HierarchicalSearchSpace(subspaces, renamed_hierarchy)
@@ -767,19 +678,19 @@ def test_hss_hierarchy_requirements_use_global_columns() -> None:
     # Columns: [x1, y1, x2, x4, x3]; the single indicator y1 is at flat column 1,
     # and requirements are keyed by that global column (gpflow's convention).
     assert space.indicator_dims == [1]
-    by_name = {n.name: n for n in space.hierarchy}
+    by_name = {n.name: n for n in space.to_gpflow_hierarchy()}
     assert dict(by_name["shared"].activity_condition.requirements) == {}
     assert dict(by_name["branch_A"].activity_condition.requirements) == {1: 1}
     assert dict(by_name["branch_B"].activity_condition.requirements) == {1: 0}
 
 
 def test_hss_hierarchy_is_directly_consumable_by_arc_hierarchical() -> None:
-    # No adapter needed: space.hierarchy already uses gpflow's column convention,
+    # No adapter needed: to_gpflow_hierarchy() uses gpflow's column convention,
     # so feature columns and indicator columns tile active_dims contiguously.
     space = _make_worked_example_hss()
     active_dims = list(range(int(space.dimension)))
     kernel = gpflow.kernels.ArcHierarchical(
-        list(space.hierarchy), active_dims=active_dims
+        space.to_gpflow_hierarchy(), active_dims=active_dims
     )
     # Two points differing only in the indicator are placed apart by the kernel.
     x = tf.constant(
@@ -974,11 +885,8 @@ def test_conditional_constraint_categorical_indicator_matches_only_target() -> N
         "x2": Box([-1.0], [1.0]),  # column 2
     }
     hierarchy = [
-        hierarchy_node_from_tags("shared", subspace_tags=["x1"], subspaces=subspaces),
-        hierarchy_node_from_tags(
-            "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 2},
-            subspaces=subspaces,
-        ),
+        HierarchyNode("shared", subspace_tags=["x1"]),
+        HierarchyNode("branch", subspace_tags=["x2"], activity_condition_tags={"y1": 2}),
     ]
     cc = ConditionalConstraint(
         constraint=LinearConstraint(A=tf.constant([[1.0]], dtype=tf.float64), lb=[0.0], ub=[1.0]),
@@ -1104,14 +1012,11 @@ def _two_indicator_subspaces() -> dict[str, SearchSpace]:
 def _two_indicator_hierarchy(subspaces: dict[str, SearchSpace]) -> list[HierarchyNode]:
     # x2 is active (and both y1, y2 are thereby gated) only when y1 == 0 AND y2 == 1.
     return [
-        hierarchy_node_from_tags(
-            "shared", subspace_tags=["x1"], subspaces=subspaces
-        ),
-        hierarchy_node_from_tags(
+        HierarchyNode("shared", subspace_tags=["x1"]),
+        HierarchyNode(
             "branch",
             subspace_tags=["x2"],
             activity_condition_tags={"y1": 0, "y2": 1},
-            subspaces=subspaces,
         ),
     ]
 
@@ -1176,12 +1081,9 @@ def _two_indicator_hss(**kwargs) -> HierarchicalSearchSpace:
         "x2": Box([0.0], [1.0]),
     }
     hierarchy = [
-        hierarchy_node_from_tags(
-            "shared", subspace_tags=["x1"], subspaces=subspaces
-        ),
-        hierarchy_node_from_tags(
-            "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1, "y2": 1},
-            subspaces=subspaces,
+        HierarchyNode("shared", subspace_tags=["x1"]),
+        HierarchyNode(
+            "branch", subspace_tags=["x2"], activity_condition_tags={"y1": 1, "y2": 1}
         ),
     ]
     return HierarchicalSearchSpace(subspaces, hierarchy, **kwargs)

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -1541,7 +1541,6 @@ def hierarchy_node_from_tags(
     subspace_tags: Sequence[str],
     activity_condition_tags: Mapping[str, int] | None = None,
     subspaces: Mapping[str, SearchSpace],
-    indicator_tags: set[str] | None = None,
 ) -> HierarchyNode:
     """Construct a :class:`gpflow.kernels.HierarchyNode` from tag-based inputs.
 
@@ -1566,16 +1565,11 @@ def hierarchy_node_from_tags(
         means the node is unconditionally active.
     :param subspaces: Tag-keyed mapping of subspaces; its iteration order
         defines the flat-vector column layout.
-    :param indicator_tags: Optional cross-check: when given, every
-        ``activity_condition_tags`` key must appear here (catches typos). May be
-        omitted, in which case any valid ``subspaces`` tag is accepted as an
-        indicator.
     :return: An assembled :class:`gpflow.kernels.HierarchyNode`. GPflow
         performs node-local validation (uniqueness of ``feature_dims``,
         non-negativity of required values, ...).
     """
     activity_condition_tags = activity_condition_tags or {}
-    indicator_tags = set(indicator_tags or ())
 
     if not subspace_tags:
         raise ValueError(
@@ -1584,17 +1578,8 @@ def hierarchy_node_from_tags(
         )
 
     # Reject duplicate ``subspace_tags``: they would yield duplicate ``feature_dims``
-    # (rejected by GPflow downstream, but with an opaque message). ``indicator_tags`` is a
-    # set, so it cannot contain duplicates.
+    # (rejected by GPflow downstream, but with an opaque message).
     _reject_duplicate_tags("subspace_tags", subspace_tags)
-
-    # A tag cannot be both an owned (feature) subspace and an indicator.
-    tag_overlap = set(subspace_tags) & set(indicator_tags)
-    if tag_overlap:
-        raise ValueError(
-            f"`subspace_tags` and `indicator_tags` must be disjoint; overlapping tags: "
-            f"{sorted(tag_overlap)}."
-        )
 
     # Build a tag -> [columns] map from the subspaces mapping (insertion order).
     tag_to_columns = _build_tag_to_columns_map(
@@ -1632,18 +1617,11 @@ def hierarchy_node_from_tags(
     requirements: dict[int, int] = {}
     for ind_tag, required in activity_condition_tags.items():
         # An activity-condition key is an indicator by definition; resolve its column from
-        # ``subspaces``. ``indicator_tags`` is an optional cross-check: when supplied, the key
-        # must be one of the declared indicators (catches typos); when omitted, any valid
-        # subspace tag is accepted.
+        # ``subspaces``.
         if ind_tag not in tag_to_columns:
             raise ValueError(
                 f"activity_condition_tags key '{ind_tag}' is not a key of `subspaces` "
                 f"{list(tag_to_columns)}."
-            )
-        if indicator_tags and ind_tag not in indicator_tags:
-            raise ValueError(
-                f"activity_condition_tags key '{ind_tag}' is not in "
-                f"indicator_tags {sorted(indicator_tags)}."
             )
         if len(tag_to_columns[ind_tag]) != 1:
             raise ValueError(
@@ -1745,7 +1723,8 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
     :class:`gpflow.kernels.ActivityCondition`). Variables fall into three roles:
 
     - **Indicators** (:class:`BooleanSearchSpace` or dimension-1
-      :class:`CategoricalSearchSpace`), declared via ``indicator_tags``.
+      :class:`CategoricalSearchSpace`), inferred by role as the subspaces referenced
+      as ``activity_condition`` keys in the hierarchy.
       Boolean indicators take values in :math:`\{0, 1\}`, ``K``-ary categorical
       indicators in :math:`\{0, \ldots, K-1\}`. Indicators are always
       unconditional; their flat-vector columns must not appear in any
@@ -1785,29 +1764,24 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         }
         hierarchy = [
             hierarchy_node_from_tags(
-                "shared", subspace_tags=["x1"],
-                subspaces=subspaces, indicator_tags=["y1"],
+                "shared", subspace_tags=["x1"], subspaces=subspaces,
             ),
             hierarchy_node_from_tags(
                 "branch_A", subspace_tags=["x2", "x4"],
-                activity_condition_tags={"y1": 1},
-                subspaces=subspaces, indicator_tags=["y1"],
+                activity_condition_tags={"y1": 1}, subspaces=subspaces,
             ),
             hierarchy_node_from_tags(
                 "branch_B", subspace_tags=["x3"],
-                activity_condition_tags={"y1": 0},
-                subspaces=subspaces, indicator_tags=["y1"],
+                activity_condition_tags={"y1": 0}, subspaces=subspaces,
             ),
         ]
-        space = HierarchicalSearchSpace(
-            subspaces, hierarchy, indicator_tags=["y1"])
+        space = HierarchicalSearchSpace(subspaces, hierarchy)
     """
 
     def __init__(
         self,
         subspaces: Mapping[str, SearchSpace],
         hierarchy: Sequence[HierarchyNode],
-        indicator_tags: Optional[Sequence[str]] = None,
         constraints: Optional[Sequence[Constraint]] = None,
         conditional_constraints: Sequence[ConditionalConstraint] = (),
         logical_propositions: Sequence[LogicalProposition] = (),
@@ -1819,15 +1793,10 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         :param hierarchy: A sequence of :class:`gpflow.kernels.HierarchyNode`
             objects defining the conditional structure. Every non-indicator
             flat-vector column must appear in at least one node's
-            ``feature_dims``.
-        :param indicator_tags: Tags corresponding to indicator subspaces; each
-            tag must be a key of ``subspaces`` and the corresponding subspace
-            must be either a :class:`BooleanSearchSpace` or a dimension-1
-            :class:`CategoricalSearchSpace`. **Optional**: if omitted, the
-            indicators are inferred as the subspaces whose columns appear as
-            ``activity_condition`` keys in ``hierarchy`` (in subspace order).
-            Pass it explicitly to disambiguate a Boolean intended as a plain
-            feature, or to have an ungated indicator flagged as an error.
+            ``feature_dims``. Indicators are inferred by role: a subspace whose
+            column is referenced as an ``activity_condition`` key is an indicator
+            and must be a :class:`BooleanSearchSpace` or a dimension-1
+            :class:`CategoricalSearchSpace`.
         :param constraints: Optional explicit (global) constraints enforced on the
             full flat-vector representation, following the same ``constraints``
             contract as :class:`Box`. Consumed by :meth:`constraints_residuals`
@@ -1872,22 +1841,17 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         }
         self._total_columns = sum(len(cols) for cols in self._tag_to_columns.values())
 
-        # Resolve the indicator tags. When not given explicitly, infer them by role: an
-        # indicator is a subspace whose column is referenced as an ``activity_condition`` key
-        # somewhere in the hierarchy (kept in subspace order for determinism). An explicit
-        # value is used as-is so callers can mark a Boolean as a plain feature or have an
-        # ungated indicator rejected by ``_validate``.
-        if indicator_tags is None:
-            referenced_columns = {
-                col for node in self._hierarchy for col in node.activity_condition.requirements
-            }
-            self._indicator_tags = tuple(
-                tag
-                for tag in self._tags
-                if any(col in referenced_columns for col in self._tag_to_columns[tag])
-            )
-        else:
-            self._indicator_tags = tuple(indicator_tags)
+        # Infer the indicator tags by role: an indicator is a subspace whose column is
+        # referenced as an ``activity_condition`` key somewhere in the hierarchy (kept in
+        # subspace order for determinism).
+        referenced_columns = {
+            col for node in self._hierarchy for col in node.activity_condition.requirements
+        }
+        self._indicator_tags = tuple(
+            tag
+            for tag in self._tags
+            if any(col in referenced_columns for col in self._tag_to_columns[tag])
+        )
 
         self._validate()
 
@@ -2433,7 +2397,6 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
                 )
             )
         hierarchy = list(self.hierarchy) + shifted_other_hierarchy
-        indicator_tags = list(self.indicator_tags) + list(other.indicator_tags)
         conditional_constraints = list(self._conditional_constraints) + list(
             other._conditional_constraints
         )
@@ -2443,7 +2406,6 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         return HierarchicalSearchSpace(
             combined_subspaces,
             hierarchy,
-            indicator_tags,
             constraints=constraints,
             conditional_constraints=conditional_constraints,
             logical_propositions=logical_propositions,

--- a/trieste/space.py
+++ b/trieste/space.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import operator
 from abc import ABC, abstractmethod
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import reduce
 from itertools import chain
 from itertools import product as itertools_product
@@ -39,7 +39,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from check_shapes import check_shapes
 from gpflow.keras import tf_keras
-from gpflow.kernels import ActivityCondition, HierarchyNode
+from gpflow.kernels import ActivityCondition
 from typing_extensions import Protocol, runtime_checkable
 
 from .types import TensorType
@@ -1535,69 +1535,60 @@ def _build_tag_to_columns_map(tag_sizes: Sequence[tuple[str, int]]) -> dict[str,
     return tag_to_columns
 
 
-def hierarchy_node_from_tags(
-    name: str,
-    *,
-    subspace_tags: Sequence[str],
-    activity_condition_tags: Mapping[str, int] | None = None,
+@dataclass(frozen=True)
+class HierarchyNode:
+    """Tag-based specification of one node in a :class:`HierarchicalSearchSpace` hierarchy.
+
+    A node owns a set of non-indicator (feature) subspaces, referenced by tag, and is active
+    only when its gating indicators take the required values (also by tag). References are by
+    tag; the owning :class:`HierarchicalSearchSpace` resolves them to the flat-vector column
+    layout (and to a :class:`gpflow.kernels.HierarchyNode`) internally, so ``subspaces`` is
+    supplied once -- to the space -- rather than to every node.
+
+    :param name: Human-readable label for the node (also the kernel-association identifier).
+    :param subspace_tags: Tags of the non-indicator subspaces owned by this node. Each must be a
+        key of the space's ``subspaces`` and define numerical bounds (e.g. a :class:`Box`). Must
+        be non-empty and contain no duplicates.
+    :param activity_condition_tags: ``{indicator_tag: required_value}`` gating this node; empty
+        (the default) means the node is unconditionally active.
+    """
+
+    name: str
+    subspace_tags: Sequence[str]
+    activity_condition_tags: Mapping[str, int] = field(default_factory=dict)
+
+
+def _resolve_node(
+    node: HierarchyNode,
     subspaces: Mapping[str, SearchSpace],
-) -> HierarchyNode:
-    """Construct a :class:`gpflow.kernels.HierarchyNode` from tag-based inputs.
+    tag_to_columns: Mapping[str, Sequence[int]],
+) -> gpflow.kernels.HierarchyNode:
+    """Resolve a tag-based :class:`HierarchyNode` to the gpflow column-based node.
 
     The GPflow type is keyed on integer column indices (``feature_dims``) and an
-    :class:`ActivityCondition` whose keys are also flat-vector column indices --
-    the global column of the gating indicator, in the same coordinate system as
-    ``feature_dims``. This helper accepts the user-facing tag form and resolves it
-    against a ``subspaces`` mapping whose iteration order defines the flat-vector
-    layout (one column per dimension of each subspace, in insertion order).
-
-    :param name: Human-readable label for the node (also the kernel-association
-        identifier downstream).
-    :param subspace_tags: Tags of non-indicator subspaces owned by this node. Each
-        tag must be a key of ``subspaces`` and must define numerical bounds (e.g.
-        :class:`Box`); categorical non-indicator subspaces are not supported. Each
-        subspace contributes one column per dimension, in the order it appears in
-        ``subspaces``. Must not contain duplicates.
-    :param activity_condition_tags: ``{indicator_tag: required_value}`` for the
-        indicators that gate this node. Each key must be a key of ``subspaces``; it
-        is resolved to that indicator's global flat-vector column, which is the key
-        stored in :class:`gpflow.kernels.ActivityCondition`. The default of ``None``
-        means the node is unconditionally active.
-    :param subspaces: Tag-keyed mapping of subspaces; its iteration order
-        defines the flat-vector column layout.
-    :return: An assembled :class:`gpflow.kernels.HierarchyNode`. GPflow
-        performs node-local validation (uniqueness of ``feature_dims``,
-        non-negativity of required values, ...).
+    :class:`ActivityCondition` whose keys are also flat-vector columns, in the layout given by
+    ``tag_to_columns`` (one column per dimension of each subspace, in ``subspaces`` order).
+    Values are coerced to ``int`` so K-ary categorical category indices survive without
+    bool-coercion. GPflow performs node-local validation downstream.
     """
-    activity_condition_tags = activity_condition_tags or {}
-
-    if not subspace_tags:
+    if not node.subspace_tags:
         raise ValueError(
-            "`subspace_tags` must be non-empty; every node must own at least one "
-            "(feature) subspace."
+            f"node '{node.name}': `subspace_tags` must be non-empty; every node must own at "
+            f"least one (feature) subspace."
         )
-
-    # Reject duplicate ``subspace_tags``: they would yield duplicate ``feature_dims``
-    # (rejected by GPflow downstream, but with an opaque message).
-    _reject_duplicate_tags("subspace_tags", subspace_tags)
-
-    # Build a tag -> [columns] map from the subspaces mapping (insertion order).
-    tag_to_columns = _build_tag_to_columns_map(
-        [(tag, int(sub.dimension)) for tag, sub in subspaces.items()]
-    )
+    _reject_duplicate_tags(f"node '{node.name}' subspace_tags", node.subspace_tags)
 
     feature_dims: list[int] = []
     bounds_rows: list[tuple[float, float]] = []
-    for stag in subspace_tags:
+    for stag in node.subspace_tags:
         if stag not in tag_to_columns:
             raise ValueError(
-                f"subspace_tag '{stag}' is not a key of `subspaces` " f"{list(tag_to_columns)}."
+                f"subspace_tag '{stag}' is not a key of `subspaces` {list(tag_to_columns)}."
             )
         sub = subspaces[stag]
         # Non-indicator subspaces are encoded as (lower, upper) feature bounds, so they must
         # expose numerical bounds. Box and the discrete spaces qualify; categorical subspaces
-        # (``has_bounds`` is False) are rejected here with a clear message rather than letting
-        # ``sub.lower`` raise an opaque AttributeError downstream.
+        # (``has_bounds`` is False) are rejected here with a clear message.
         if not sub.has_bounds:
             raise ValueError(
                 f"subspace_tag '{stag}' refers to a {type(sub).__name__} without numerical "
@@ -1610,14 +1601,8 @@ def hierarchy_node_from_tags(
             feature_dims.append(col)
             bounds_rows.append((float(lo), float(hi)))
 
-    # Translate indicator-tag keys to global flat-vector columns (the same
-    # coordinate system as ``feature_dims``, matching gpflow's convention) and
-    # coerce values to int so K-ary categorical category indices survive without
-    # bool-coercion.
     requirements: dict[int, int] = {}
-    for ind_tag, required in activity_condition_tags.items():
-        # An activity-condition key is an indicator by definition; resolve its column from
-        # ``subspaces``.
+    for ind_tag, required in node.activity_condition_tags.items():
         if ind_tag not in tag_to_columns:
             raise ValueError(
                 f"activity_condition_tags key '{ind_tag}' is not a key of `subspaces` "
@@ -1630,8 +1615,8 @@ def hierarchy_node_from_tags(
             )
         requirements[tag_to_columns[ind_tag][0]] = int(required)
 
-    return HierarchyNode(
-        name=name,
+    return gpflow.kernels.HierarchyNode(
+        name=node.name,
         feature_dims=feature_dims,
         feature_bounds=tf.constant(bounds_rows, dtype=tf.float64),
         activity_condition=ActivityCondition(requirements=requirements),
@@ -1718,21 +1703,21 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
     A :class:`SearchSpace` that extends :class:`CollectionSearchSpace` with a hierarchy
     specification describing conditional activation of subspaces.
 
-    The hierarchy is described by a sequence of :class:`gpflow.kernels.HierarchyNode`
-    objects (each carrying integer ``feature_dims`` and a
-    :class:`gpflow.kernels.ActivityCondition`). Variables fall into three roles:
+    The hierarchy is described by a sequence of tag-based :class:`HierarchyNode`
+    objects (each owning ``subspace_tags`` and gated by ``activity_condition_tags``); the
+    space resolves them to gpflow's column-based representation internally (see
+    :meth:`to_gpflow_hierarchy`). Variables fall into three roles:
 
     - **Indicators** (:class:`BooleanSearchSpace` or dimension-1
       :class:`CategoricalSearchSpace`), inferred by role as the subspaces referenced
-      as ``activity_condition`` keys in the hierarchy.
+      as ``activity_condition_tags`` keys in the hierarchy.
       Boolean indicators take values in :math:`\{0, 1\}`, ``K``-ary categorical
       indicators in :math:`\{0, \ldots, K-1\}`. Indicators are always
-      unconditional; their flat-vector columns must not appear in any
-      ``HierarchyNode.feature_dims``.
-    - **Unconditional variables** owned by a node with the default (empty)
-      ``activity_condition``. Always active.
+      unconditional; they must not appear in any node's ``subspace_tags``.
+    - **Unconditional variables** owned by a node with empty
+      ``activity_condition_tags``. Always active.
     - **Conditional variables** owned by a node with non-empty
-      ``activity_condition.requirements``. Active only when the referenced
+      ``activity_condition_tags``. Active only when the referenced
       indicators take the required values.
 
     Points are represented as flat vectors concatenated in the iteration order
@@ -1763,17 +1748,11 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
             "x3": Box([-1.0], [1.0]),
         }
         hierarchy = [
-            hierarchy_node_from_tags(
-                "shared", subspace_tags=["x1"], subspaces=subspaces,
-            ),
-            hierarchy_node_from_tags(
-                "branch_A", subspace_tags=["x2", "x4"],
-                activity_condition_tags={"y1": 1}, subspaces=subspaces,
-            ),
-            hierarchy_node_from_tags(
-                "branch_B", subspace_tags=["x3"],
-                activity_condition_tags={"y1": 0}, subspaces=subspaces,
-            ),
+            HierarchyNode("shared", subspace_tags=["x1"]),
+            HierarchyNode("branch_A", subspace_tags=["x2", "x4"],
+                          activity_condition_tags={"y1": 1}),
+            HierarchyNode("branch_B", subspace_tags=["x3"],
+                          activity_condition_tags={"y1": 0}),
         ]
         space = HierarchicalSearchSpace(subspaces, hierarchy)
     """
@@ -1790,13 +1769,12 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         """
         :param subspaces: Tag-keyed mapping of subspaces; iteration order
             defines the flat-vector layout.
-        :param hierarchy: A sequence of :class:`gpflow.kernels.HierarchyNode`
-            objects defining the conditional structure. Every non-indicator
-            flat-vector column must appear in at least one node's
-            ``feature_dims``. Indicators are inferred by role: a subspace whose
-            column is referenced as an ``activity_condition`` key is an indicator
-            and must be a :class:`BooleanSearchSpace` or a dimension-1
-            :class:`CategoricalSearchSpace`.
+        :param hierarchy: A sequence of tag-based :class:`HierarchyNode` objects
+            defining the conditional structure. Every non-indicator subspace tag
+            must appear in at least one node's ``subspace_tags``. Indicators are
+            inferred by role: a subspace referenced as an ``activity_condition_tags``
+            key is an indicator and must be a :class:`BooleanSearchSpace` or a
+            dimension-1 :class:`CategoricalSearchSpace`.
         :param constraints: Optional explicit (global) constraints enforced on the
             full flat-vector representation, following the same ``constraints``
             contract as :class:`Box`. Consumed by :meth:`constraints_residuals`
@@ -1831,8 +1809,8 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         self._dimension = tf.cast(tf.reduce_sum(subspace_sizes), dtype=tf.int32)
 
         # Pre-compute a flat tag -> [column indices] map and its inverse
-        # (column index -> owning tag) so feature_dims can be translated back
-        # to subspace tags by the activity/query methods.
+        # (column index -> owning tag) for resolving tag-based nodes and for the
+        # activity/query methods.
         self._tag_to_columns = _build_tag_to_columns_map(
             [(tag, int(self._subspace_sizes_by_tag[tag])) for tag in self._tags]
         )
@@ -1841,34 +1819,30 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         }
         self._total_columns = sum(len(cols) for cols in self._tag_to_columns.values())
 
-        # Infer the indicator tags by role: an indicator is a subspace whose column is
-        # referenced as an ``activity_condition`` key somewhere in the hierarchy (kept in
-        # subspace order for determinism).
-        referenced_columns = {
-            col for node in self._hierarchy for col in node.activity_condition.requirements
-        }
-        self._indicator_tags = tuple(
-            tag
-            for tag in self._tags
-            if any(col in referenced_columns for col in self._tag_to_columns[tag])
+        # Resolve the tag-based nodes to gpflow's column-based representation, used by the
+        # kernel (:meth:`to_gpflow_hierarchy`) and by column-level validation. ``subspaces``
+        # is needed only here.
+        self._gpflow_hierarchy: tuple[gpflow.kernels.HierarchyNode, ...] = tuple(
+            _resolve_node(node, subspaces, self._tag_to_columns) for node in self._hierarchy
         )
+
+        # Infer the indicator tags by role: an indicator is a subspace referenced as an
+        # ``activity_condition`` key somewhere in the hierarchy (kept in subspace order).
+        referenced_tags = {tag for node in self._hierarchy for tag in node.activity_condition_tags}
+        self._indicator_tags = tuple(tag for tag in self._tags if tag in referenced_tags)
 
         self._validate()
 
     def _validate(self) -> None:
-        all_tags = set(self.subspace_tags)
+        # Node-shape and tag-existence checks already ran during resolution to the gpflow
+        # representation (see ``_resolve_node``): every ``subspace_tags`` / ``activity_condition``
+        # key exists, is bounded where required, and indicators are single-column. This method
+        # adds the space-level semantics. Indicators are inferred (by role) from the unique
+        # subspace tags, so they cannot be duplicated or unknown.
 
-        # indicator_tags must not contain duplicates; a repeated tag would corrupt
-        # the indicator column lookup used by ActivityCondition.
-        _reject_duplicate_tags("indicator_tags", self._indicator_tags)
-
-        # indicator_tags must exist and reference a BooleanSearchSpace or a 1-D
-        # CategoricalSearchSpace; record each indicator's permitted value set.
+        # Indicators must reference a BooleanSearchSpace or a 1-D CategoricalSearchSpace;
+        # record each indicator's permitted value set.
         for itag in self._indicator_tags:
-            if itag not in all_tags:
-                raise ValueError(
-                    f"Indicator tag '{itag}' is not a key of `subspaces` {sorted(all_tags)}."
-                )
             sub = self.get_subspace(itag)
             if isinstance(sub, BooleanSearchSpace):
                 self._indicator_value_sets[itag] = (0, 1)
@@ -1901,102 +1875,36 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
                     f"Non-indicator subspaces must define numerical bounds (e.g. Box)."
                 )
 
-        # Set of flat-vector columns occupied by indicators (forbidden in
-        # feature_dims) and by non-indicator subspaces (must each be covered).
-        indicator_columns: set[int] = set()
-        for itag in self._indicator_tags:
-            indicator_columns.update(self._tag_to_columns[itag])
-        non_indicator_columns: set[int] = set(range(self._total_columns)) - indicator_columns
-
-        covered_non_indicator_columns: set[int] = set()
-        used_indicator_columns: set[int] = set()
-
+        all_tags = set(self.subspace_tags)
+        indicator_set = set(self._indicator_tags)
         for node in self._hierarchy:
-            node_feature_dims = list(node.feature_dims)
-            node_bounds = tf.convert_to_tensor(node.feature_bounds, dtype=tf.float64)
-
-            # feature_dims must be in range and not point at indicator columns
-            for col in node_feature_dims:
-                if col < 0 or col >= self._total_columns:
-                    raise ValueError(
-                        f"HierarchyNode '{node.name}' has feature_dims column {col} "
-                        f"out of range [0, {self._total_columns - 1}]."
-                    )
-                if col in indicator_columns:
-                    raise ValueError(
-                        f"HierarchyNode '{node.name}' feature_dims column {col} points "
-                        f"at an indicator column."
-                    )
-                covered_non_indicator_columns.add(col)
-
-            # feature_bounds rows must match the underlying subspace bounds
-            for row_index, col in enumerate(node_feature_dims):
-                owning_tag = self._column_to_tag[col]
-                owning_sub = self.get_subspace(owning_tag)
-                col_within_sub = self._tag_to_columns[owning_tag].index(col)
-                expected_lower = float(
-                    tf.cast(owning_sub.lower, tf.float64).numpy()[col_within_sub]
+            # A tag cannot be both an owned feature and an indicator.
+            owned_indicators = [t for t in node.subspace_tags if t in indicator_set]
+            if owned_indicators:
+                raise ValueError(
+                    f"HierarchyNode '{node.name}' lists indicator tag(s) {owned_indicators} in "
+                    f"`subspace_tags`; an indicator cannot be owned as a feature."
                 )
-                expected_upper = float(
-                    tf.cast(owning_sub.upper, tf.float64).numpy()[col_within_sub]
-                )
-                actual_lower = float(node_bounds[row_index, 0].numpy())
-                actual_upper = float(node_bounds[row_index, 1].numpy())
-                if not (
-                    np.isclose(expected_lower, actual_lower)
-                    and np.isclose(expected_upper, actual_upper)
-                ):
-                    raise ValueError(
-                        f"HierarchyNode '{node.name}' feature_bounds row {row_index} "
-                        f"= ({actual_lower}, {actual_upper}) disagrees with the "
-                        f"underlying subspace bounds ({expected_lower}, "
-                        f"{expected_upper}) at column {col} (tag '{owning_tag}')."
-                    )
-
-            # ActivityCondition requirements keys are the global flat-vector
-            # columns of the gating indicators (gpflow's convention, the same
-            # coordinate system as feature_dims). Each must be an indicator column
-            # and its required value must be in that indicator's permitted set.
-            for indicator_col, required in node.activity_condition.requirements.items():
-                if indicator_col not in indicator_columns:
-                    raise ValueError(
-                        f"HierarchyNode '{node.name}' activity_condition references "
-                        f"column {indicator_col}, which is not an indicator column "
-                        f"(indicators are at columns {sorted(indicator_columns)})."
-                    )
-                ind_tag = self._column_to_tag[indicator_col]
+            # Each required value must be in the gating indicator's permitted set.
+            for ind_tag, required in node.activity_condition_tags.items():
                 permitted = self._indicator_value_sets[ind_tag]
                 if int(required) not in permitted:
                     raise ValueError(
-                        f"HierarchyNode '{node.name}' activity_condition required value "
-                        f"{required!r} for indicator '{ind_tag}' (column "
-                        f"{indicator_col}) is not in the indicator's permitted set "
-                        f"{list(permitted)}."
+                        f"HierarchyNode '{node.name}' requires value {required!r} for indicator "
+                        f"'{ind_tag}', which is not in its permitted set {list(permitted)}."
                     )
-                used_indicator_columns.add(indicator_col)
 
-        # Every non-indicator column must be covered by some node.feature_dims
-        orphan_columns = non_indicator_columns - covered_non_indicator_columns
-        if orphan_columns:
-            orphan_tags = sorted({self._column_to_tag[c] for c in orphan_columns})
+        # Every non-indicator subspace must be owned by some node.
+        covered = {tag for node in self._hierarchy for tag in node.subspace_tags}
+        orphans = sorted(set(self.non_indicator_tags) - covered)
+        if orphans:
             raise ValueError(
-                f"Non-indicator subspace tags {orphan_tags} have orphan columns "
-                f"{sorted(orphan_columns)} that do not appear in any "
-                f"HierarchyNode.feature_dims."
-            )
-
-        # Every indicator column must appear as an activity_condition key somewhere
-        unused = indicator_columns - used_indicator_columns
-        if unused:
-            unused_tags = sorted({self._column_to_tag[c] for c in unused})
-            raise ValueError(
-                f"Indicator tags {unused_tags} are unused: they do not appear as a key "
-                f"in any HierarchyNode.activity_condition.requirements."
+                f"Non-indicator subspace tags {orphans} are orphaned: they do not appear in "
+                f"any HierarchyNode.subspace_tags."
             )
 
         # Conditional constraints: indicator conditions must reference declared indicators
         # with permitted values, and active_subspace_tags must be existing non-indicators.
-        indicator_set = set(self._indicator_tags)
         for i, cc in enumerate(self._conditional_constraints):
             for ind_tag, required in cc.indicator_conditions.items():
                 if ind_tag not in indicator_set:
@@ -2022,28 +1930,6 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
                         f"indicator; constraints operate on the non-indicator slice only."
                     )
 
-    @staticmethod
-    def _nodes_equal(left: Sequence[HierarchyNode], right: Sequence[HierarchyNode]) -> bool:
-        """Compare two hierarchies by value. ``HierarchyNode`` is a frozen dataclass,
-        but its ``feature_bounds`` is a tensor, so the auto-generated ``__eq__`` would
-        compare tensors elementwise (and fail ``bool()``); compare field by field
-        instead, using ``np.array_equal`` for the bounds."""
-        if len(left) != len(right):
-            return False
-        for a, b in zip(left, right):
-            if a.name != b.name:
-                return False
-            if list(a.feature_dims) != list(b.feature_dims):
-                return False
-            if dict(a.activity_condition.requirements) != dict(b.activity_condition.requirements):
-                return False
-            if not np.array_equal(
-                tf.convert_to_tensor(a.feature_bounds, dtype=tf.float64).numpy(),
-                tf.convert_to_tensor(b.feature_bounds, dtype=tf.float64).numpy(),
-            ):
-                return False
-        return True
-
     def __eq__(self, other: object) -> bool:
         """
         :param other: A search space.
@@ -2060,7 +1946,7 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
             and self._constraints == other._constraints
             and self._conditional_constraints == other._conditional_constraints
             and self._logical_propositions == other._logical_propositions
-            and self._nodes_equal(self._hierarchy, other._hierarchy)
+            and self._hierarchy == other._hierarchy
         )
 
     def __repr__(self) -> str:
@@ -2076,8 +1962,14 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
 
     @property
     def hierarchy(self) -> tuple[HierarchyNode, ...]:
-        """The hierarchy specification."""
+        """The tag-based hierarchy specification (the :class:`HierarchyNode`\\ s as supplied)."""
         return self._hierarchy
+
+    def to_gpflow_hierarchy(self) -> list[gpflow.kernels.HierarchyNode]:
+        """The hierarchy resolved to gpflow's column-based
+        :class:`gpflow.kernels.HierarchyNode`\\ s, ready to build a hierarchical kernel, e.g.
+        ``ArcHierarchical(space.to_gpflow_hierarchy(), active_dims=...)``."""
+        return list(self._gpflow_hierarchy)
 
     @property
     def indicator_tags(self) -> tuple[str, ...]:
@@ -2241,12 +2133,10 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         return values[..., start:end]
 
     def _node_subspace_tags(self, node: HierarchyNode) -> list[str]:
-        """Translate a node's ``feature_dims`` to the (unique, ordered) list of
-        non-indicator subspace tags it owns."""
+        """The (unique, ordered) non-indicator subspace tags a node owns."""
         seen: list[str] = []
-        for col in node.feature_dims:
-            tag = self._column_to_tag.get(int(col))
-            if tag is not None and tag not in seen:
+        for tag in node.subspace_tags:
+            if tag not in seen:
                 seen.append(tag)
         return seen
 
@@ -2326,8 +2216,7 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
 
     def node_for_subspace(self, tag: str) -> list[HierarchyNode]:
         """
-        Return the :class:`HierarchyNode` objects whose ``feature_dims`` include any column
-        belonging to the given subspace tag.
+        Return the :class:`HierarchyNode` objects that own the given subspace tag.
 
         :param tag: A non-indicator subspace tag.
         :return: List of nodes containing this tag.
@@ -2348,17 +2237,14 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
     def product(self, other: HierarchicalSearchSpace) -> HierarchicalSearchSpace:
         """
         Return a new :class:`HierarchicalSearchSpace` that is the combination of this space and
-        ``other``. Tags in the two spaces must be disjoint. The hierarchy nodes are
-        concatenated; both the node ``feature_dims`` and the ``activity_condition``
-        requirement columns in ``other`` are shifted by ``self.dimension`` so they index the
-        combined flat-vector layout.
-
-        Conditional constraints reference subspaces and indicators by tag, so they compose
-        across the disjoint-tag product unchanged and are concatenated. Global (positional)
-        constraints are remapped into the combined layout via :func:`_embed_constraint`:
-        ``self``'s constraints keep columns ``[0, D_self)`` and ``other``'s are shifted to
-        ``[D_self, D_self + D_other)``. The combined space takes the tighter (minimum) of the
-        two operands' constraint tolerances.
+        ``other``. Tags in the two spaces must be disjoint. The (tag-based) hierarchy nodes,
+        conditional constraints and logical propositions reference subspaces and indicators by
+        tag, so they compose across the disjoint-tag product unchanged and are simply
+        concatenated; the combined space re-resolves the nodes against the merged column layout.
+        Global (positional) constraints are remapped via :func:`_embed_constraint`: ``self``'s
+        keep columns ``[0, D_self)`` and ``other``'s shift to ``[D_self, D_self + D_other)``.
+        The combined space takes the tighter (minimum) of the two operands' constraint
+        tolerances.
 
         :param other: Another :class:`HierarchicalSearchSpace`.
         :return: The combined hierarchical space.
@@ -2379,24 +2265,9 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
             _embed_constraint(c, offset, int(other.dimension), combined_dim)
             for c in other._constraints
         ]
-        shifted_other_hierarchy: list[HierarchyNode] = []
-        for node in other.hierarchy:
-            shifted_other_hierarchy.append(
-                HierarchyNode(
-                    name=node.name,
-                    feature_dims=[int(c) + offset for c in node.feature_dims],
-                    feature_bounds=node.feature_bounds,
-                    activity_condition=ActivityCondition(
-                        # requirement keys are global indicator columns; shift them
-                        # into the combined layout by the same offset as feature_dims.
-                        requirements={
-                            k + offset: v
-                            for k, v in node.activity_condition.requirements.items()
-                        }
-                    ),
-                )
-            )
-        hierarchy = list(self.hierarchy) + shifted_other_hierarchy
+        # Tag-based nodes compose unchanged across disjoint tags; the new space re-resolves
+        # them to the merged column layout.
+        hierarchy = list(self.hierarchy) + list(other.hierarchy)
         conditional_constraints = list(self._conditional_constraints) + list(
             other._conditional_constraints
         )
@@ -2413,13 +2284,12 @@ class HierarchicalSearchSpace(CollectionSearchSpace):
         )
 
     def _node_is_active(self, node: HierarchyNode, indicator_config: Mapping[str, int]) -> bool:
-        """Check whether a node's activity_condition.requirements (keyed by indicator global
-        column) are all satisfied by ``indicator_config`` (keyed by indicator tag). Uses
-        integer equality so that K-ary categorical indicators are compared exactly rather
-        than via Boolean truthiness. Assumes a complete config (see
-        :meth:`_require_complete_config`, enforced by the public callers)."""
-        for indicator_col, required in node.activity_condition.requirements.items():
-            ind_tag = self._column_to_tag[indicator_col]
+        """Check whether a node's ``activity_condition_tags`` are all satisfied by
+        ``indicator_config`` (both keyed by indicator tag). Uses integer equality so that
+        K-ary categorical indicators are compared exactly rather than via Boolean truthiness.
+        Assumes a complete config (see :meth:`_require_complete_config`, enforced by the public
+        callers)."""
+        for ind_tag, required in node.activity_condition_tags.items():
             if int(indicator_config[ind_tag]) != int(required):
                 return False
         return True


### PR DESCRIPTION
…dicator_tags

Indicators are now inferred by role (a subspace tag referenced as an activity_condition key); removes the indicator_tags parameter from hierarchy_node_from_tags and HierarchicalSearchSpace. Addresses @pakhaykwok's review on #934/#935.

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

...

<!-- A clear and concise description of the contents of this pull request. -->

**Fully backwards compatible:** yes 

<!-- if not, include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [X] The quality checks are all passing
- [X] The bug case / new feature is covered by tests
- [X] Any new features are well-documented (in docstrings or notebooks)
